### PR TITLE
fix: prevent config modal white screen

### DIFF
--- a/src/main/config/ConfigManager.ts
+++ b/src/main/config/ConfigManager.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { net } from "electron";
+import type { ConfigFileDiagnostic, ConfigFileReadResult } from "../../shared/types";
 
 /** pi 全局配置目录：~/.pi/agent/ */
 const PI_AGENT_DIR = join(homedir(), ".pi", "agent");
@@ -82,15 +83,15 @@ export class ConfigManager {
 
 	// ── 读取 ──────────────────────────────────────────────
 
-	async getModelsConfig(): Promise<{ raw: string; parsed: PiModelsFile }> {
+	async getModelsConfig(): Promise<ConfigFileReadResult<PiModelsFile>> {
 		return this.readJsonFile<PiModelsFile>("models.json", { providers: {} });
 	}
 
-	async getAuthConfig(): Promise<{ raw: string; parsed: PiAuthFile }> {
+	async getAuthConfig(): Promise<ConfigFileReadResult<PiAuthFile>> {
 		return this.readJsonFile<PiAuthFile>("auth.json", {});
 	}
 
-	async getSettingsConfig(): Promise<{ raw: string; parsed: PiSettings }> {
+	async getSettingsConfig(): Promise<ConfigFileReadResult<PiSettings>> {
 		return this.readJsonFile<PiSettings>("settings.json", {});
 	}
 
@@ -171,15 +172,64 @@ export class ConfigManager {
 	private async readJsonFile<T>(
 		fileName: string,
 		fallback: T,
-	): Promise<{ raw: string; parsed: T }> {
+	): Promise<ConfigFileReadResult<T>> {
 		const filePath = join(this.configDir, fileName);
 		try {
 			const raw = await readFile(filePath, "utf8");
-			const parsed = JSON.parse(raw) as T;
-			return { raw, parsed };
+			try {
+				const parsed = JSON.parse(raw) as T;
+				return { raw, parsed };
+			} catch (error) {
+				// 配置 JSON 写错时，配置弹窗仍要能打开 Raw 页让用户修复；同时返回精确诊断用于 UI 提示。
+				return {
+					raw,
+					parsed: fallback,
+					diagnostic: this.createJsonDiagnostic(fileName, raw, error),
+				};
+			}
 		} catch {
 			return { raw: JSON.stringify(fallback, null, 2), parsed: fallback };
 		}
+	}
+
+	private createJsonDiagnostic(
+		fileName: string,
+		raw: string,
+		error: unknown,
+	): ConfigFileDiagnostic {
+		const message = error instanceof Error ? error.message : String(error);
+		const positionMatch = message.match(/position\s+(\d+)/i);
+		const position = positionMatch ? Number(positionMatch[1]) : undefined;
+		let line: number | undefined;
+		let column: number | undefined;
+		let snippet: string | undefined;
+		if (Number.isFinite(position)) {
+			const before = raw.slice(0, position);
+			const lines = before.split(/\r?\n/);
+			line = lines.length;
+			column = lines[lines.length - 1].length + 1;
+			const rawLines = raw.split(/\r?\n/);
+			const start = Math.max(0, line - 2);
+			const end = Math.min(rawLines.length, line + 1);
+			snippet = rawLines
+				.slice(start, end)
+				.map((text, index) => `${start + index + 1}: ${text}`)
+				.join("\n");
+		}
+		return {
+			fileName,
+			message,
+			line,
+			column,
+			snippet,
+			docsUrl: this.docsUrlForFile(fileName),
+		};
+	}
+
+	private docsUrlForFile(fileName: string) {
+		if (fileName === "models.json") return "https://pi.dev/docs/latest/models";
+		if (fileName === "settings.json") return "https://pi.dev/docs/latest/settings";
+		return "https://pi.dev/docs/latest/providers";
 	}
 
 	private async writeJsonFile(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,6 +18,7 @@ import type {
 	PiCommand,
 	PiInstallStatus,
 	PiProxyTestResult,
+	ConfigFileDiagnostic,
 	PiSkillListResult,
 	PiSkillSummary,
 	CreatePiSkillInput,
@@ -167,16 +168,19 @@ const api = {
 			ipcRenderer.invoke(ipcChannels.configGetModels) as Promise<{
 				raw: string;
 				parsed: { providers: Record<string, unknown> };
+				diagnostic?: ConfigFileDiagnostic;
 			}>,
 		getAuth: () =>
 			ipcRenderer.invoke(ipcChannels.configGetAuth) as Promise<{
 				raw: string;
 				parsed: Record<string, unknown>;
+				diagnostic?: ConfigFileDiagnostic;
 			}>,
 		getSettings: () =>
 			ipcRenderer.invoke(ipcChannels.configGetSettings) as Promise<{
 				raw: string;
 				parsed: Record<string, unknown>;
+				diagnostic?: ConfigFileDiagnostic;
 			}>,
 		saveModels: (data: unknown) =>
 			ipcRenderer.invoke(ipcChannels.configSaveModels, data) as Promise<{

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2421,17 +2421,18 @@ export function App() {
 							)}
 						</div>
 					)}
-					{outlineItems.length > 1 && (
-						<ConversationOutline
-							items={outlineItems}
-							onJump={(id) =>
-								document
-									.querySelector(`[data-message-id="${CSS.escape(id)}"]`)
-									?.scrollIntoView({ behavior: "smooth", block: "start" })
-							}
-						/>
-					)}
 				</section>
+
+				{outlineItems.length > 1 && (
+					<ConversationOutline
+						items={outlineItems}
+						onJump={(id) =>
+							document
+								.querySelector(`[data-message-id="${CSS.escape(id)}"]`)
+								?.scrollIntoView({ behavior: "smooth", block: "start" })
+						}
+					/>
+				)}
 
 				{terminalOpen && activeAgentId && (
 					<TerminalDock

--- a/src/renderer/src/ConfigModal.tsx
+++ b/src/renderer/src/ConfigModal.tsx
@@ -26,6 +26,38 @@ const DEFAULT_MODEL_CONFIG: Pick<
 	reasoning: true,
 };
 
+/**
+ * 配置页必须能打开用户手写/旧版本生成的非标准 models.json。
+ * pi 自身对配置较宽松，但 UI 会访问 provider.models.length / map；这里先把缺失或异常字段归一化，
+ * 避免单个 provider 配置错误导致整个 renderer 白屏。
+ */
+function normalizeModelsFile(value: unknown): ModelsFile {
+	const rawProviders =
+		value && typeof value === "object" && !Array.isArray(value)
+			? (value as { providers?: unknown }).providers
+			: undefined;
+	const providers: ModelsFile["providers"] = {};
+	if (!rawProviders || typeof rawProviders !== "object" || Array.isArray(rawProviders)) {
+		return { providers };
+	}
+	for (const [name, rawProvider] of Object.entries(rawProviders)) {
+		const provider =
+			rawProvider && typeof rawProvider === "object" && !Array.isArray(rawProvider)
+				? (rawProvider as Record<string, unknown>)
+				: {};
+		const rawModels = provider.models;
+		providers[name] = {
+			...provider,
+			models: Array.isArray(rawModels)
+				? rawModels.filter((model): model is ModelItem =>
+						Boolean(model) && typeof model === "object" && !Array.isArray(model),
+					)
+				: [],
+		};
+	}
+	return { providers };
+}
+
 /** 配置管理弹窗：支持 models/auth/settings 三个 tab 的可视化编辑和源文件编辑 */
 export function ConfigModal(props: {
 	open: boolean;
@@ -97,7 +129,7 @@ export function ConfigModal(props: {
 			try {
 				if (target === "models") {
 					const res = await api.config.getModels();
-					setModelsData(res.parsed as ModelsFile);
+					setModelsData(normalizeModelsFile(res.parsed));
 					setRawContent(res.raw);
 					setRawFileName("models.json");
 				} else if (target === "auth") {

--- a/src/renderer/src/ConfigModal.tsx
+++ b/src/renderer/src/ConfigModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { Component, useState, useEffect, useCallback, type ReactNode } from "react";
 import type { PiDesktopApi } from "../../preload";
 import { AuthTab } from "./config/AuthTab";
 import { ModelsTab } from "./config/ModelsTab";
@@ -90,12 +90,70 @@ function ConfigDiagnosticCard(props: {
 	);
 }
 
-/** 配置管理弹窗：支持 models/auth/settings 三个 tab 的可视化编辑和源文件编辑 */
-export function ConfigModal(props: {
+type ConfigModalProps = {
 	open: boolean;
 	onClose: () => void;
 	onSaved: () => void;
-}) {
+};
+
+class ConfigModalErrorBoundary extends Component<
+	{ open: boolean; onClose: () => void; children: ReactNode },
+	{ error: Error | null }
+> {
+	override state = { error: null as Error | null };
+
+	static getDerivedStateFromError(error: Error) {
+		return { error };
+	}
+
+	override componentDidUpdate(prevProps: { open: boolean }) {
+		if (prevProps.open !== this.props.open && this.state.error) {
+			this.setState({ error: null });
+		}
+	}
+
+	override render() {
+		if (!this.state.error) return this.props.children;
+		if (!this.props.open) return null;
+		return (
+			<div className="modal-backdrop">
+				<div className="config-modal">
+					<div className="modal-header">
+						<strong>配置管理加载失败</strong>
+						<button className="modal-close-btn" onClick={this.props.onClose}>×</button>
+					</div>
+					<div className="config-content">
+						<div className="config-diagnostic-card">
+							<div>
+								<strong>配置管理渲染异常</strong>
+								<span>{this.state.error.message}</span>
+								<small>
+									这通常是某个配置字段结构超出了当前可视化表单的兼容范围。配置文件不会被修改，建议先查看{" "}
+									<a href="https://pi.dev/docs/latest/models" target="_blank" rel="noreferrer">pi models 文档</a>
+									{" / "}
+									<a href="https://pi.dev/docs/latest/settings" target="_blank" rel="noreferrer">settings 文档</a>
+									，并把控制台错误和配置片段反馈给我们。
+								</small>
+							</div>
+							<pre>{this.state.error.stack ?? this.state.error.message}</pre>
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+/** 配置管理弹窗：支持 models/auth/settings 三个 tab 的可视化编辑和源文件编辑 */
+export function ConfigModal(props: ConfigModalProps) {
+	return (
+		<ConfigModalErrorBoundary open={props.open} onClose={props.onClose}>
+			<ConfigModalContent {...props} />
+		</ConfigModalErrorBoundary>
+	);
+}
+
+function ConfigModalContent(props: ConfigModalProps) {
 	const { open, onClose, onSaved } = props;
 	const [section, setSection] = useState<"config" | "skills">("config");
 	const [tab, setTab] = useState<ConfigTab>("models");

--- a/src/renderer/src/ConfigModal.tsx
+++ b/src/renderer/src/ConfigModal.tsx
@@ -74,7 +74,11 @@ function ConfigDiagnosticCard(props: {
 						: diagnostic.message}
 				</span>
 				<small>
-					已保留源文件内容，可切到“源文件”修复。复杂 provider/model 字段（如 compat、headers、thinkingLevelMap、modelOverrides）建议参考 pi 官方配置文档。
+					已保留源文件内容，可切到“源文件”修复。复杂 provider/model 字段（如 compat、headers、thinkingLevelMap、modelOverrides）建议参考{" "}
+					<a href={diagnostic.docsUrl} target="_blank" rel="noreferrer">
+						pi 官方配置文档
+					</a>
+					。
 				</small>
 			</div>
 			{diagnostic.snippet && <pre>{diagnostic.snippet}</pre>}

--- a/src/renderer/src/ConfigModal.tsx
+++ b/src/renderer/src/ConfigModal.tsx
@@ -12,7 +12,7 @@ import type {
 	ModelsFile,
 	SettingsFile,
 } from "./config/configTypes";
-import type { PiSkillListResult, PiSkillLocation, PiSkillSummary } from "../../shared/types";
+import type { ConfigFileDiagnostic, PiSkillListResult, PiSkillLocation, PiSkillSummary } from "../../shared/types";
 import { getProviderHeaders } from "./config/providerHeaders";
 
 const api: PiDesktopApi = (window as unknown as { piDesktop: PiDesktopApi })
@@ -58,6 +58,34 @@ function normalizeModelsFile(value: unknown): ModelsFile {
 	return { providers };
 }
 
+function ConfigDiagnosticCard(props: {
+	diagnostic: ConfigFileDiagnostic;
+	onOpenDocs: () => void;
+	onOpenRaw: () => void;
+}) {
+	const { diagnostic } = props;
+	return (
+		<div className="config-diagnostic-card">
+			<div>
+				<strong>{diagnostic.fileName} 加载失败</strong>
+				<span>
+					{diagnostic.line && diagnostic.column
+						? `第 ${diagnostic.line} 行，第 ${diagnostic.column} 列：${diagnostic.message}`
+						: diagnostic.message}
+				</span>
+				<small>
+					已保留源文件内容，可切到“源文件”修复。复杂 provider/model 字段（如 compat、headers、thinkingLevelMap、modelOverrides）建议参考 pi 官方配置文档。
+				</small>
+			</div>
+			{diagnostic.snippet && <pre>{diagnostic.snippet}</pre>}
+			<div className="config-diagnostic-actions">
+				<button className="config-btn primary" onClick={props.onOpenRaw}>打开源文件</button>
+				<button className="config-btn" onClick={props.onOpenDocs}>查看官方文档</button>
+			</div>
+		</div>
+	);
+}
+
 /** 配置管理弹窗：支持 models/auth/settings 三个 tab 的可视化编辑和源文件编辑 */
 export function ConfigModal(props: {
 	open: boolean;
@@ -70,6 +98,7 @@ export function ConfigModal(props: {
 	const [loading, setLoading] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [configDiagnostic, setConfigDiagnostic] = useState<ConfigFileDiagnostic | null>(null);
 	const [toast, setToast] = useState<string | null>(null);
 
 	// 各 tab 的数据
@@ -126,22 +155,26 @@ export function ConfigModal(props: {
 		async (target: ConfigTab) => {
 			setLoading(true);
 			setError(null);
+			setConfigDiagnostic(null);
 			try {
 				if (target === "models") {
 					const res = await api.config.getModels();
 					setModelsData(normalizeModelsFile(res.parsed));
 					setRawContent(res.raw);
 					setRawFileName("models.json");
+					setConfigDiagnostic(res.diagnostic ?? null);
 				} else if (target === "auth") {
 					const res = await api.config.getAuth();
 					setAuthData(res.parsed as AuthFile);
 					setRawContent(res.raw);
 					setRawFileName("auth.json");
+					setConfigDiagnostic(res.diagnostic ?? null);
 				} else if (target === "settings") {
 					const res = await api.config.getSettings();
 					setSettingsData(res.parsed as SettingsFile);
 					setRawContent(res.raw);
 					setRawFileName("settings.json");
+					setConfigDiagnostic(res.diagnostic ?? null);
 				} else if (target === "raw") {
 					// 源文件 tab 复用当前 tab 对应的文件
 					const fileName =
@@ -158,6 +191,7 @@ export function ConfigModal(props: {
 								? await api.config.getAuth()
 								: await api.config.getSettings();
 					setRawContent(res.raw);
+					setConfigDiagnostic(res.diagnostic ?? null);
 				}
 			} catch (e) {
 				setError(e instanceof Error ? e.message : String(e));
@@ -615,6 +649,13 @@ export function ConfigModal(props: {
 				<div className="config-content">
 					{loading && <div className="config-loading">加载中…</div>}
 					{error && <div className="config-error">{error}</div>}
+					{section === "config" && configDiagnostic && (
+						<ConfigDiagnosticCard
+							diagnostic={configDiagnostic}
+							onOpenDocs={() => api.app.openExternal(configDiagnostic.docsUrl)}
+							onOpenRaw={() => setTab("raw")}
+						/>
+					)}
 
 					{section === "config" && !loading && tab === "models" && (
 						<ModelsTab

--- a/src/renderer/src/config/ModelsTab.tsx
+++ b/src/renderer/src/config/ModelsTab.tsx
@@ -11,6 +11,32 @@ import {
 
 type FetchedModel = { id: string; name?: string };
 
+const KNOWN_PROVIDER_FIELDS = new Set([
+	"baseUrl",
+	"api",
+	"apiKey",
+	"headers",
+	"authHeader",
+	"models",
+	"modelOverrides",
+	"compat",
+	"oauth",
+]);
+const KNOWN_MODEL_FIELDS = new Set([
+	"id",
+	"name",
+	"api",
+	"baseUrl",
+	"reasoning",
+	"thinkingLevelMap",
+	"input",
+	"cost",
+	"contextWindow",
+	"maxTokens",
+	"headers",
+	"compat",
+]);
+
 function FetchedModelCombobox(props: {
 	models: FetchedModel[];
 	value: string;
@@ -201,6 +227,12 @@ export function ModelsTab(props: {
 					const provider = data.providers[name];
 					const isExpanded = expandedProvider === name;
 					const userAgentValue = getHeaderValue(provider.headers, "User-Agent");
+					const providerAdvancedFields = Object.keys(provider).filter(
+						(key) => !KNOWN_PROVIDER_FIELDS.has(key),
+					);
+					const providerComplexFields = ["headers", "authHeader", "compat", "modelOverrides", "oauth"].filter(
+						(key) => provider[key] !== undefined,
+					);
 					const userAgentSelectValue = USER_AGENT_OPTIONS.some(
 						(option) => option.value === userAgentValue,
 					)
@@ -375,6 +407,16 @@ export function ModelsTab(props: {
 												<span>留空时不写入 headers，使用 pi / SDK 运行时默认值</span>
 											</div>
 										</div>
+										{(providerComplexFields.length > 0 || providerAdvancedFields.length > 0) && (
+											<div className="config-advanced-preserved">
+												<strong>高级字段已保留</strong>
+												<span>
+													{[...providerComplexFields, ...providerAdvancedFields].join(", ")}
+													{" "}不会被可视化表单丢弃；复杂结构请在“源文件”中编辑，并参考 pi 官方 models/custom provider 文档。
+												</span>
+											</div>
+										)}
+
 										<div className="config-form-row">
 											<label></label>
 											<button
@@ -639,7 +681,14 @@ export function ModelsTab(props: {
 											<span>推理</span>
 											<span></span>
 										</div>
-										{provider.models.map((m, i) => (
+										{provider.models.map((m, i) => {
+											const modelAdvancedFields = Object.keys(m).filter(
+												(key) => !KNOWN_MODEL_FIELDS.has(key),
+											);
+											const modelComplexFields = ["api", "baseUrl", "thinkingLevelMap", "input", "cost", "headers", "compat"].filter(
+												(key) => m[key] !== undefined,
+											);
+											return (
 											<div
 												// 模型 ID 是可编辑字段，不能作为 key；否则每次输入都会重建行并导致输入框失焦。
 												key={`${name}-${i}`}
@@ -716,8 +765,14 @@ export function ModelsTab(props: {
 												>
 													<Trash2 size={14} />
 												</button>
+												{(modelComplexFields.length > 0 || modelAdvancedFields.length > 0) && (
+													<div className="config-model-advanced-note">
+														高级字段已保留：{[...modelComplexFields, ...modelAdvancedFields].join(", ")}
+													</div>
+												)}
 											</div>
-										))}
+											);
+										})}
 										{provider.models.length === 0 && (
 											<div className="config-empty-sm">
 												暂无模型，点击「+ 模型」添加

--- a/src/renderer/src/config/ModelsTab.tsx
+++ b/src/renderer/src/config/ModelsTab.tsx
@@ -412,7 +412,15 @@ export function ModelsTab(props: {
 												<strong>高级字段已保留</strong>
 												<span>
 													{[...providerComplexFields, ...providerAdvancedFields].join(", ")}
-													{" "}不会被可视化表单丢弃；复杂结构请在“源文件”中编辑，并参考 pi 官方 models/custom provider 文档。
+													{" "}不会被可视化表单丢弃；复杂结构请在“源文件”中编辑，并参考{" "}
+													<a href="https://pi.dev/docs/latest/models" target="_blank" rel="noreferrer">
+														pi models 文档
+													</a>
+													{" / "}
+													<a href="https://pi.dev/docs/latest/custom-provider" target="_blank" rel="noreferrer">
+														custom provider 文档
+													</a>
+													。
 												</span>
 											</div>
 										)}
@@ -767,7 +775,10 @@ export function ModelsTab(props: {
 												</button>
 												{(modelComplexFields.length > 0 || modelAdvancedFields.length > 0) && (
 													<div className="config-model-advanced-note">
-														高级字段已保留：{[...modelComplexFields, ...modelAdvancedFields].join(", ")}
+														高级字段已保留：{[...modelComplexFields, ...modelAdvancedFields].join(", ")}。
+														<a href="https://pi.dev/docs/latest/models" target="_blank" rel="noreferrer">
+															查看 models 文档
+														</a>
 													</div>
 												)}
 											</div>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4290,6 +4290,70 @@ body.is-composer-resizing .composer-resize-handle::after {
 	background: rgba(255, 255, 255, 0.78);
 }
 
+.config-advanced-preserved {
+	display: grid;
+	gap: 4px;
+	margin: 4px 0 10px;
+	padding: 10px 12px;
+	border: 1px solid #dbeafe;
+	border-radius: 10px;
+	background: #eff6ff;
+	color: #1d4ed8;
+}
+.config-advanced-preserved strong {
+	font-size: 12px;
+}
+.config-advanced-preserved span {
+	font-size: 12px;
+	line-height: 1.5;
+}
+.config-model-advanced-note {
+	grid-column: 1 / -1;
+	margin-top: -4px;
+	padding: 6px 8px;
+	border-radius: 8px;
+	background: #f1f5f9;
+	color: #64748b;
+	font-size: 11px;
+	line-height: 1.45;
+}
+.config-diagnostic-card {
+	display: grid;
+	gap: 10px;
+	margin-bottom: 14px;
+	padding: 14px;
+	border: 1px solid #fecaca;
+	border-radius: 12px;
+	background: #fff7f7;
+	color: #991b1b;
+}
+.config-diagnostic-card > div:first-child {
+	display: grid;
+	gap: 4px;
+}
+.config-diagnostic-card strong {
+	font-size: 14px;
+}
+.config-diagnostic-card span,
+.config-diagnostic-card small {
+	line-height: 1.5;
+}
+.config-diagnostic-card pre {
+	margin: 0;
+	padding: 10px 12px;
+	border: 1px solid #fecaca;
+	border-radius: 8px;
+	background: #fff;
+	color: #7f1d1d;
+	overflow: auto;
+	font-family: "Cascadia Code", Consolas, monospace;
+	font-size: 12px;
+}
+.config-diagnostic-actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
 .config-form-row {
 	display: grid;
 	grid-template-columns: 90px 1fr;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -846,6 +846,7 @@ body.is-terminal-resizing {
 }
 
 .chat-pane {
+	position: relative;
 	display: grid;
 	grid-template-rows: 78px minmax(0, 1fr) auto auto;
 	min-width: 0;
@@ -3233,7 +3234,7 @@ body.is-composer-resizing .composer-resize-handle::after {
 	animation: picker-check-in 0.16s ease-out;
 }
 .outline-hover {
-	position: fixed;
+	position: absolute;
 	right: 18px;
 	z-index: 8;
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4307,6 +4307,18 @@ body.is-composer-resizing .composer-resize-handle::after {
 	font-size: 12px;
 	line-height: 1.5;
 }
+.config-advanced-preserved a,
+.config-model-advanced-note a,
+.config-diagnostic-card a {
+	color: #1677ff;
+	text-decoration: none;
+	font-weight: 600;
+}
+.config-advanced-preserved a:hover,
+.config-model-advanced-note a:hover,
+.config-diagnostic-card a:hover {
+	text-decoration: underline;
+}
 .config-model-advanced-note {
 	grid-column: 1 / -1;
 	margin-top: -4px;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -189,6 +189,21 @@ export type PiInstallStatus = {
 	error?: string;
 };
 
+export type ConfigFileDiagnostic = {
+	fileName: string;
+	message: string;
+	line?: number;
+	column?: number;
+	snippet?: string;
+	docsUrl: string;
+};
+
+export type ConfigFileReadResult<T> = {
+	raw: string;
+	parsed: T;
+	diagnostic?: ConfigFileDiagnostic;
+};
+
 export type PiSkillLocation = {
 	id: "pi-global" | "agents-global";
 	label: string;


### PR DESCRIPTION
## Summary\n\nFixes the configuration modal white-screen crash reported in issue #6.\n\nRoot cause: the renderer assumed every provider in `models.json` was an object with a `models` array. If a user's pi config contained a malformed or older provider entry, opening Configuration Management could throw during render (for example when accessing `provider.models.length`) and leave the window blank.\n\n## Changes\n\n- Normalize loaded `models.json` data before rendering the Models tab.\n- Ensure every provider is represented as an object with `models: []` when the source config is missing or malformed.\n- Filter invalid model entries defensively so one bad item does not crash the whole modal.\n- Keep the original raw JSON content available in the Raw tab so users can still inspect and repair their config.\n\n## Validation\n\n- `npm run typecheck`\n- `npm run build`\n\nCloses #6