### PR TITLE
[codex] fix pi shim Node runtime alignment

### DIFF
--- a/src/main/extensions/ExtensionManager.ts
+++ b/src/main/extensions/ExtensionManager.ts
@@ -39,7 +39,7 @@ export class ExtensionManager {
 				invocation.args,
 				{
 					env: {
-						...this.locator.createProcessEnv(this.getSettings()),
+						...this.locator.createProcessEnv(this.getSettings(), invocation.pathPrefix),
 						PI_OFFLINE: "1",
 					},
 					shell: invocation.shell,

--- a/src/main/pi/PiLocator.ts
+++ b/src/main/pi/PiLocator.ts
@@ -1,6 +1,6 @@
 import { execFile, execFileSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
-import { delimiter, extname, join } from "node:path";
+import { delimiter, dirname, extname, join } from "node:path";
 import { app } from "electron";
 import type { AppSettings, PiInstallStatus } from "../../shared/types";
 
@@ -13,6 +13,7 @@ export type PiCommandInvocation = {
   command: string;
   args: string[];
   shell: boolean;
+  pathPrefix?: string;
   /**
    * Windows 下通过 cmd.exe /c 启动 .cmd shim 时，命令行里已经手动完成引号包装。
    * 必须禁止 Node 再次转义参数，否则路径中含空格会被 cmd 误解析为不存在的路径。
@@ -64,17 +65,22 @@ export class PiLocator {
     return [...new Set(dirs.filter(Boolean))];
   }
 
-  createProcessEnv(settings?: PiProxySettings) {
+  createProcessEnv(settings?: PiProxySettings, pathPrefix?: string) {
+    const searchDirs = pathPrefix
+      ? [pathPrefix, ...this.getSearchDirs().filter(dir => dir !== pathPrefix)]
+      : this.getSearchDirs();
     const env = {
       ...process.env,
-      PATH: this.getSearchDirs().join(delimiter),
+      PATH: searchDirs.join(delimiter),
     };
 
     return this.applyPiProxyEnv(env, settings);
   }
 
   createInvocation(command: string, args: string[]): PiCommandInvocation {
-    if (process.platform !== "win32") return { command, args, shell: false };
+    if (process.platform !== "win32") {
+      return { command, args, shell: false, pathPrefix: this.getCommandBinDir(command) };
+    }
 
     // Windows 仅支持 .cmd/.exe/裸命令，不再走 PowerShell .ps1。
     // npm/yarn/pnpm 生成的 pi.ps1 与 pi.cmd 指向同一个包入口，但 PowerShell 的执行策略、编码和引号规则更复杂；
@@ -90,6 +96,7 @@ export class PiLocator {
       command: process.env.ComSpec || "cmd.exe",
       args: ["/d", "/s", "/c", commandLine],
       shell: false,
+      pathPrefix: this.getCommandBinDir(command),
       // 关键：cmd /c 的最后一个参数是完整命令行，里面的引号由 quoteCmdArgument/control 逻辑维护。
       // 若让 Node 再转义一次，`D:\\foo bar\\pi.cmd` 会变成 cmd 无法识别的路径。
       windowsVerbatimArguments: true,
@@ -209,7 +216,7 @@ export class PiLocator {
     return new Promise(resolve => {
       const invocation = this.createInvocation(command, ["--version"]);
       execFile(invocation.command, invocation.args, {
-        env: this.createProcessEnv(),
+        env: this.createProcessEnv(undefined, invocation.pathPrefix),
         shell: invocation.shell,
         windowsHide: true,
         timeout: 8_000,
@@ -270,6 +277,16 @@ export class PiLocator {
 
   private needsCmdQuote(value: string) {
     return /[\s&()\[\]{}^=;!'+,`~|<>]/.test(value);
+  }
+
+  private getCommandBinDir(command: string) {
+    if (!/[\\/]/.test(command) || !existsSync(command)) return undefined;
+    const binDir = dirname(command);
+    // npm/nvm/asdf/mise shims resolve Node through env/PATH. Prepending the shim's own
+    // bin directory keeps that lookup on the Node version that installed pi, instead
+    // of a different Node inherited from Finder/Explorer/Electron.
+    const nodeName = process.platform === "win32" ? "node.exe" : "node";
+    return existsSync(join(binDir, nodeName)) ? binDir : undefined;
   }
 
   private getCandidates() {

--- a/src/main/pi/PiProcess.ts
+++ b/src/main/pi/PiProcess.ts
@@ -36,7 +36,7 @@ export class PiProcess extends EventEmitter {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
       shell: invocation.shell,
-      env: locator.createProcessEnv(this.settings),
+      env: locator.createProcessEnv(this.settings, invocation.pathPrefix),
       windowsVerbatimArguments: invocation.windowsVerbatimArguments,
     });
 

--- a/src/renderer/src/agentListDisplay.ts
+++ b/src/renderer/src/agentListDisplay.ts
@@ -1,0 +1,29 @@
+import type { AgentTab } from "../../shared/types";
+
+const DEFAULT_VISIBLE_AGENT_LIMIT = 3;
+
+export type AgentListDisplay = {
+	visibleAgents: AgentTab[];
+	hasHiddenAgents: boolean;
+	hiddenCount: number;
+};
+
+export function getVisibleAgentsForProject(
+	agents: AgentTab[],
+	isExpanded: boolean,
+	visibleLimit = DEFAULT_VISIBLE_AGENT_LIMIT,
+): AgentListDisplay {
+	if (isExpanded || agents.length <= visibleLimit) {
+		return {
+			visibleAgents: agents,
+			hasHiddenAgents: false,
+			hiddenCount: 0,
+		};
+	}
+
+	return {
+		visibleAgents: agents.slice(0, visibleLimit),
+		hasHiddenAgents: true,
+		hiddenCount: agents.length - visibleLimit,
+	};
+}

--- a/tests/piLocator.test.mjs
+++ b/tests/piLocator.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import ts from "typescript";
+import vm from "node:vm";
+
+const require = createRequire(import.meta.url);
+
+function loadPiLocatorModule(platform = process.platform) {
+	const source = readFileSync("src/main/pi/PiLocator.ts", "utf8");
+	const { outputText } = ts.transpileModule(source, {
+		compilerOptions: {
+			module: ts.ModuleKind.CommonJS,
+			target: ts.ScriptTarget.ES2022,
+		},
+	});
+	const sandbox = {
+		Buffer,
+		TextDecoder,
+		exports: {},
+		process: {
+			...process,
+			env: { ...process.env },
+			platform,
+		},
+		require: (id) => {
+			if (id === "electron") {
+				return { app: { getPath: () => tmpdir() } };
+			}
+			return require(id);
+		},
+	};
+	sandbox.global = sandbox;
+	vm.runInNewContext(outputText, sandbox, {
+		filename: "PiLocator.ts",
+	});
+	return sandbox.exports;
+}
+
+test("uses the pi shim bin directory as PATH prefix on macOS when node is beside the shim", () => {
+	const root = join(tmpdir(), `pi-desktop-locator-${process.pid}-${Date.now()}`);
+	const binDir = join(root, ".nvm", "versions", "node", "v22.22.1", "bin");
+	mkdirSync(binDir, { recursive: true });
+	const piPath = join(binDir, "pi");
+	writeFileSync(piPath, "#!/usr/bin/env node\n", "utf8");
+	writeFileSync(join(binDir, "node"), "", "utf8");
+
+	try {
+		const { PiLocator } = loadPiLocatorModule("darwin");
+		const invocation = new PiLocator().createInvocation(piPath, ["--version"]);
+
+		assert.equal(invocation.command, piPath);
+		assert.deepEqual(invocation.args, ["--version"]);
+		assert.equal(invocation.shell, false);
+		assert.equal(invocation.pathPrefix, binDir);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("uses the pi cmd shim bin directory as PATH prefix on Windows when node.exe is beside the shim", () => {
+	const root = join(tmpdir(), `pi-desktop-locator-win-${process.pid}-${Date.now()}`);
+	const binDir = join(root, "nvm", "v22.22.1");
+	mkdirSync(binDir, { recursive: true });
+	const piPath = join(binDir, "pi.cmd");
+	writeFileSync(piPath, "@echo off\r\nnode \"%~dp0\\node_modules\\pi\\bin.js\" %*\r\n", "utf8");
+	writeFileSync(join(binDir, "node.exe"), "", "utf8");
+
+	try {
+		const { PiLocator } = loadPiLocatorModule("win32");
+		const invocation = new PiLocator().createInvocation(piPath, ["--version"]);
+
+		assert.match(invocation.command.toLowerCase(), /cmd\.exe$/);
+		assert.equal(JSON.stringify(invocation.args.slice(0, 3)), JSON.stringify(["/d", "/s", "/c"]));
+		assert.equal(invocation.shell, false);
+		assert.equal(invocation.pathPrefix, binDir);
+		assert.equal(invocation.windowsVerbatimArguments, true);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

Fixes the pi CLI launch path for users whose `pi` shim is installed under a Node version manager directory, such as macOS Intel users with nvm. The reported crash showed `pi` installed under Node 22 but executed by Node 20, which caused `undici` to load with an incompatible runtime and fail before the RPC agent could start.

This also restores the missing renderer helper used by the project agent list, which was causing the production build to fail before packaging.

## Root Cause

`pi` shims installed by npm/nvm/asdf/mise commonly resolve Node through `/usr/bin/env node` or through `node` on PATH. The desktop app already scans version-manager directories to locate `pi`, but when launching from Finder/Explorer/Electron, the inherited PATH can still point `node` at a different runtime than the one that installed the global pi package.

In the issue report, `pi` lived at:

```text
/Users/weilai/.nvm/versions/node/v22.22.1/bin/pi
```

but the process was executed by:

```text
Node.js v20.1.0
```

That version mismatch caused `undici` to call an API missing from the older runtime.

## Fix

- Adds an optional `pathPrefix` to `PiCommandInvocation`.
- When the resolved `pi` command is an explicit path and its directory contains `node` or `node.exe`, prepends that directory to the child process PATH.
- Applies the same invocation PATH prefix to:
  - pi install checks and manual path validation
  - agent RPC process startup
  - extension management commands
- Covers Windows as well as macOS/Linux, so `pi.cmd` beside `node.exe` also gets the same runtime alignment.
- Adds the missing `agentListDisplay` renderer module used by `App.tsx`.

## Validation

```text
node --test tests\piLocator.test.mjs
npm run build
```

The new regression test covers both:

- macOS-style `pi` shim beside `node`
- Windows-style `pi.cmd` shim beside `node.exe`

Closes #9
