### PR TITLE
feat: 飞书/Lark 远程控制集成 — 双向对话 + 流式卡片 + 自动拉群

### DIFF
--- a/docs/飞书远程控制-维护手册.md
+++ b/docs/飞书远程控制-维护手册.md
@@ -1,0 +1,1092 @@
+# 飞书远程控制 — 维护手册
+
+> 项目目录：`/Users/1900th/Downloads/同步空间/Pi Agent/飞书远程控制/`  
+> 版本：v4（流式活动轨迹 + 闪电确认 + 并行启动）  
+> 最后更新：2026-06-18
+
+---
+
+## 目录
+
+- [1. 项目概述](#1-项目概述)
+- [2. 系统架构](#2-系统架构)
+- [3. 双项目结构详解](#3-双项目结构详解)
+- [4. 核心功能实现原理](#4-核心功能实现原理)
+- [5. 数据流与生命周期](#5-数据流与生命周期)
+- [6. 文件与配置](#6-文件与配置)
+- [7. 注入点详解（8 个关键点）](#7-注入点详解8-个关键点)
+- [8. 日常维护操作](#8-日常维护操作)
+- [9. 常见问题排查](#9-常见问题排查)
+- [10. 编译与启动](#10-编译与启动)
+- [11. 附录](#11-附录)
+
+---
+
+## 1. 项目概述
+
+### 1.1 它能做什么？
+
+将飞书 / Lark 聊天与 Pi Agent（AI 编码助手）连接起来，实现：
+
+| 功能 | 说明 |
+|------|------|
+| 📱 飞书 ↔ Pi 双向对话 | 在飞书给 Bot 发消息，Agent 自动回复 |
+| 🤖 自动拉群 | Pi 中新建会话 → 飞书自动创建 Bot+你的私人群 |
+| 📊 流式卡片 | Agent 处理过程（工具调用、思考、输出）在飞书卡片中实时可见 |
+| 🔁 消息同步 | Pi 界面中的 Agent 回复同步推送到飞书 |
+| 💬 飞书内命令 | `/stop` 停止、`/new` 新会话、`/whoami` 查看 open_id 等 |
+| ⚡ 闪电确认 | 收到消息后 ~200ms 快速响应 "⚡ 已收到" |
+
+### 1.2 两个子项目
+
+| 项目 | 路径 | 角色 |
+|------|------|------|
+| **pi-feishu-lark** | `pi-feishu-lark/` | Pi CLI 的原生扩展（npm 包），参考实现 |
+| **PiDeck** | `pi-desktop/` | 实际运行的 Electron 桌面应用，飞书功能集成在 `src/main/feishu/` |
+
+> **实际运行的是 PiDeck（pi-desktop）**，pi-feishu-lark 是早期安装的 npm 包，我们的飞书功能已完全重写集成在 PiDeck 内部。
+
+---
+
+## 2. 系统架构
+
+### 2.1 整体架构图
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        Electron 主进程                            │
+│                                                                   │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │                     FeishuBridge                             │ │
+│  │  飞书桥接主类 (~1200 行)                                     │ │
+│  │                                                              │ │
+│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  │ │
+│  │  │ Lark WSClient │  │ CardStream   │  │ Session Mirror   │  │ │
+│  │  │ (长连接)      │  │ (流式卡片)   │  │ (自动拉群)       │  │ │
+│  │  └──────┬───────┘  └──────┬───────┘  └────────┬─────────┘  │ │
+│  │         │                 │                    │             │ │
+│  │  ┌──────▼─────────────────▼────────────────────▼─────────┐  │ │
+│  │  │              消息处理管线                              │  │ │
+│  │  │  去重 → 解析 → 命令路由 → Agent 调度 → 流式卡片 → 回复│  │ │
+│  │  └────────────────────────┬───────────────────────────────┘  │ │
+│  └───────────────────────────┼──────────────────────────────────┘ │
+│                              │                                     │
+│  ┌───────────────────────────▼──────────────────────────────────┐ │
+│  │                      AgentManager                            │ │
+│  │  管理多个 Pi RPC 子进程                                       │ │
+│  │  create() / sendPrompt() / stop() / list()                   │ │
+│  └───────────────────────────┬──────────────────────────────────┘ │
+│                              │                                     │
+│  ┌───────────────────────────▼──────────────────────────────────┐ │
+│  │       Pi RPC 子进程 (pi --mode rpc) × N                      │ │
+│  │  每个 Agent Tab = 一个独立 pi 进程                           │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────┘
+                                  │
+                          IPC 通道 (agents:event, agents:state...)
+                                  │
+┌─────────────────────────────────▼────────────────────────────────┐
+│                     Electron 渲染进程                             │
+│  ┌──────────────────────┐  ┌──────────────────────────────────┐ │
+│  │ FeishuPanel.tsx      │  │ FeishuConnectDialog.tsx          │ │
+│  │ (侧边栏状态面板)     │  │ (Bot 配置弹窗)                   │ │
+│  └──────────────────────┘  └──────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 技术栈
+
+| 层 | 技术 |
+|------|------|
+| 桌面框架 | Electron 38 + electron-vite |
+| 前端 | React 19 + TypeScript |
+| 飞书 SDK | `@larksuiteoapi/node-sdk` v1.67（WSClient + EventDispatcher）|
+| Agent 运行时 | `pi --mode rpc` 子进程 |
+| IPC 通信 | Electron contextBridge + ipcMain/ipcRenderer |
+| 持久化 | JSON 文件（`~/.pi-desktop/feishu*.json`） |
+| 状态管理 | zustand (Renderer) + 内存 Map (Main) |
+
+---
+
+## 3. 双项目结构详解
+
+### 3.1 pi-feishu-lark（参考实现）
+
+```
+pi-feishu-lark/
+├── package.json                         # npm 包描述，依赖 @larksuiteoapi/node-sdk
+├── README.md                            # 使用文档
+├── tsconfig.json                        # TypeScript 配置
+├── node_modules/                        # 依赖
+└── .pi/extensions/feishu/               # 扩展核心代码 (19 个文件)
+    ├── index.ts                         # 🔑 入口：命令注册、生命周期、自动启动
+    ├── types.ts                         # 类型定义 (FeishuConfig, FeishuMessage, ...)
+    ├── config.ts                        # 配置读写、路径常量、环境变量支持
+    ├── transport.ts                     # 🔑 WebSocket 连接 + 飞书 API 封装 (~330 行)
+    ├── conversation-manager.ts          # 🔑 会话管理：创建、prompt、恢复、模型切换 (~360 行)
+    ├── message-handler.ts               # 🔑 消息解析、命令路由、图片/文件处理 (~210 行)
+    ├── task-status-card.ts              # 流式任务状态卡片 + Pi 事件描述 (~245 行)
+    ├── bridge-runtime.ts                # 桥接运行态：定时任务转发
+    ├── bridge-store.ts                  # 路由/任务持久化
+    ├── delivery.ts                      # 消息投递器
+    ├── dedupe-store.ts                  # 持久化消息去重 (24h TTL)
+    ├── gateway-lock.ts                  # 多进程互斥锁 + 心跳 (~270 行)
+    ├── rich-text.ts                     # 🔑 Markdown→飞书消息卡片/Post 渲染 (~380 行)
+    ├── attachments.ts                   # 图片/文件附件检测与解码
+    ├── messages.ts                      # 消息解析工具函数
+    ├── card-action-webhook.ts           # Webhook 服务器接收卡片按钮回调
+    ├── card-actions.ts                  # 卡片按钮 action 值解析
+    ├── card-dispatcher.ts               # 卡片动作分发器
+    ├── cards.ts                         # 飞书卡片构建（模型选择、会话恢复）
+    ├── commands.ts                      # /feishu 管理命令处理
+    ├── copy-source-store.ts             # Markdown 原文复制源存储
+    ├── debug.ts                         # 调试日志
+    ├── format.ts                        # 格式化工具
+    ├── model-selector.ts                # 模型选择器
+    ├── process-reaper.ts                # 守护进程清理
+    ├── setup.ts                         # 🔑 终端交互式配置向导
+    ├── status.ts                        # 连接状态管理
+    └── utils.ts                         # 通用工具函数
+```
+
+### 3.2 PiDeck 飞书模块（实际运行）
+
+```
+pi-desktop/
+├── package.json                         # Electron 应用配置
+├── src/
+│   ├── main/
+│   │   ├── index.ts                     # 🔑 Electron 主入口，注册飞书 IPC 处理器
+│   │   ├── feishu/
+│   │   │   ├── FeishuBridge.ts          # 🔑🔑🔑 核心：飞书桥接主类 (~1200 行) — 整个飞书集成的中枢
+│   │   │   ├── FeishuConfig.ts          # 🔑 多 Bot 配置 CRUD + Secret base64 编码 + 绑定持久化
+│   │   │   ├── types.ts                 # 内部类型（LarkSDK, LarkClient, FeishuMessageContext...）
+│   │   │   ├── rich-text.ts             # 🔑 智能消息模式 + Markdown→飞书卡片/Post 构建
+│   │   │   ├── CardStream.ts            # 🔑 流式卡片协议（im.v1.message.patch + 200ms 节流）
+│   │   │   ├── CardRunState.ts          # 🔑 状态机 + 活动轨迹（纯函数 reduce）
+│   │   │   └── CardRenderer.ts          # 🔑 RunState → 飞书卡片 JSON 渲染器
+│   │   ├── pi/
+│   │   │   └── AgentManager.ts          # Pi RPC 进程管理（create/sendPrompt/stop/list）
+│   │   └── ...
+│   ├── renderer/src/
+│   │   ├── components/feishu/
+│   │   │   ├── FeishuPanel.tsx          # 侧边栏飞书状态面板
+│   │   │   └── FeishuConnectDialog.tsx  # Bot 配置弹窗
+│   │   ├── hooks/
+│   │   │   └── useFeishuBridge.ts       # 飞书状态 Hook
+│   │   └── config/
+│   │       └── ImTab.tsx                # 设置 > IM 连接 Tab
+│   └── shared/
+│       ├── ipc.ts                       # IPC 通道名称定义
+│       └── types.ts                     # 共享类型 (FeishuBotConfig, FeishuBridgeStatus...)
+└── out/                                 # 构建产物
+    └── main/index.js                    # 编译后的主进程入口
+```
+
+---
+
+## 4. 核心功能实现原理
+
+### 4.1 WebSocket 长连接（消息接收）
+
+**实现位置：** `FeishuBridge.ts` → `start()` 方法
+
+**流程：**
+
+```
+1. 创建 Lark Client (App ID + App Secret)
+2. 调用 bot/v3/info API 获取 Bot 自身的 open_id
+3. 创建 EventDispatcher，注册事件处理器：
+   - im.message.receive_v1 → handleRawMessage()
+   - card.action.trigger → handleCardAction()
+4. 创建 WSClient，传入 EventDispatcher
+5. wsClient.start() 建立 WebSocket 长连接
+6. 飞书平台通过 WebSocket 推送消息事件到本地
+```
+
+**关键代码段（start 方法核心）：**
+
+```typescript
+const lark = await import("@larksuiteoapi/node-sdk");
+this.client = new lark.Client({ appId, appSecret, ... });
+
+// 探测 Bot Open ID
+const botInfoResp = await this.client.request({
+  method: "GET", url: "https://open.feishu.cn/open-apis/bot/v3/info/"
+});
+this.botOpenId = botInfoResp?.bot?.open_id ?? null;
+
+// 注册事件
+const dispatcher = new lark.EventDispatcher(...).register({
+  "im.message.receive_v1": async (data) => this.handleRawMessage(data),
+  "card.action.trigger": async (data) => this.handleCardAction(data),
+});
+
+// 启动 WebSocket
+const ws = new lark.WSClient({ appId, appSecret, ... });
+ws.start({ eventDispatcher: dispatcher });
+```
+
+### 4.2 消息去重（三重保障）
+
+**实现位置：** `FeishuBridge.ts` → `handleMessage()` 方法
+
+| 去重层 | 数据结构 | TTL / 上限 | 键 |
+|--------|----------|------------|-----|
+| event_id | `Set<string>` | 200 条 | 飞书事件 ID |
+| message_id | `Set<string>` | 200 条 | 飞书消息 ID |
+| 内容去重 | `Map<string, number>` | 5 秒 TTL | chatId + userId + text + 附件（图片/文件 key） |
+
+**内容去重键的生成逻辑：**
+
+```typescript
+const dedupParts = [chatId, userId, text];
+if (imageAttachments.length > 0)
+  dedupParts.push("img", ...imageAttachments.map(a => a.imageKey));
+if (fileAttachments.length > 0)
+  dedupParts.push("file", ...fileAttachments.map(f => f.fileKey));
+const contentKey = dedupParts.join("\u0000");
+```
+
+> ⚠️ 超过 2000 条内容去重记录时自动清理最早的。
+
+### 4.3 智能消息模式选择
+
+**实现位置：** `rich-text.ts` → `chooseMessageMode()` 函数
+
+**根据文本特征自动选择消息类型：**
+
+```
+输入文本
+  │
+  ├─ 短文本、无格式 → text（纯文本，飞书原生支持）
+  │
+  ├─ 含表格 ≥2 行 + 分隔符
+  │   代码块 ≥1 个
+  │   标题 ≥3 个
+  │   列表项 ≥8 个
+  │   链接 ≥5 个
+  │   文本长度 ≥1200 字符  → interactive（飞书卡片，markdown 渲染）
+  │
+  └─ 多行 + 感知 Markdown
+       或 长度 ≥250 字符 → post（飞书富文本，原生表格）
+```
+
+**三种模式对比：**
+
+| 模式 | 优点 | 缺点 | 适用场景 |
+|------|------|------|----------|
+| text | 零开销，最快 | 无格式渲染 | "你好"、"收到" 等简短回复 |
+| post | 原生表格渲染好 | 不支持代码高亮 | 中等复杂度回复 |
+| interactive | Markdown 渲染 + 代码高亮 + 按钮 | 29KB 限制，需分片 | 长回复、代码、复杂格式 |
+
+**interactive 卡片分片逻辑：** (`rich-text.ts` → `splitMarkdownToFit()`)
+
+```
+1. 按 ## 标题拆分 → 按 ### 标题拆分 → 按空行拆分
+2. 将每个块依次尝试放入当前卡片：
+   - 能放下（< 29KB）→ 追加
+   - 放不下 → 开新卡片
+3. 如果单个块超过 29KB → 按行二分查找切割
+4. 每张卡片自动附加 "返回MD原文" 按钮（copySourceId）
+```
+
+### 4.4 流式卡片系统（CardStream + CardRunState + CardRenderer）
+
+这是 v4 的核心升级，由三个模块协作完成。
+
+#### 4.4.1 CardStream（通信层）
+
+**实现位置：** `CardStream.ts`
+
+**核心协议：**
+```
+1. im.message.reply(initialCard) → 发送初始骨架卡 → 获得 messageId
+2. im.v1.message.patch(messageId, newCard) → 原子替换卡片内容
+3. 每次 patch 飞书立即重新渲染 → 用户看到"实时更新"
+```
+
+**节流策略：**
+- 200ms 合并间隔：相邻的 update() 调用合并为一次 patch
+- 终态（done/error/interrupted）强制立即 flush，不等待节流
+- 最大重试 2 次，重试间隔递增（200ms → 400ms）
+
+**降级兜底：**
+- 如果 `lastPatchFailed = true`，终态卡片 patch 失败后
+- 改用 `sendSmartMessage()` 发送文本消息作为最终结果
+
+#### 4.4.2 CardRunState（状态机）
+
+**实现位置：** `CardRunState.ts`
+
+**RunState 结构：**
+
+```typescript
+interface RunState {
+  blocks: Block[];          // 回答块列表（文本 / 工具调用）
+  reasoning: { content: string; active: boolean };  // 思考内容
+  footer: FooterStatus;     // thinking / tool_running / streaming / null
+  terminal: Terminal;       // running / done / interrupted / error
+  errorMsg?: string;
+  startedAt: number;
+  meta: { durationMs?: number; model?: string; };
+  trail: TrailEntry[];      // 🔥 v4 新增：活动轨迹
+  outputText: string;       // 🔥 v4 新增：累积输出文本
+}
+
+interface TrailEntry {
+  id: string;
+  timestamp: number;
+  type: "agent" | "tool" | "compaction" | "retry" | "error" | "info";
+  text: string;             // 显示文本
+  detail?: string;          // 附加详情（如工具参数摘要）
+  status: "running" | "done" | "error";
+}
+```
+
+**事件 → 状态转换表（`reduceFromPiEvent`）：**
+
+| AgentManager 事件 | 状态变化 |
+|---|---|
+| `agent_start` | trail + "agent 启动" done |
+| `turn_start` | trail + "第 N 轮对话" running |
+| `message_start` (assistant) | 初始化文本块 |
+| `message_update.text_delta` | outputText 追加 + trail "开始输出" |
+| `message_update.thinking_delta` | reasoning.content 追加 + trail "开始思考" |
+| `message_update.toolcall_start` | blocks + tool running + trail "工具调用: xxx" |
+| `message_update.toolcall_end` | tool 标记 done/error + trail 更新状态 |
+| `tool_execution_start` | 同上（另一种事件来源） |
+| `tool_execution_end` | 同上 |
+| `compaction_start` | trail "上下文压缩" |
+| `auto_retry_start` | trail "自动重试: 1/3" |
+| `auto_retry_end` | trail 更新成功/失败 |
+| `agent_end` | terminal = done/error，finalizeAllTrail |
+
+**纯函数设计：** 所有 reduce 函数是纯函数（`(state, event) → newState`），便于测试和调试。
+
+#### 4.4.3 CardRenderer（渲染层）
+
+**实现位置：** `CardRenderer.ts`
+
+**将 RunState 渲染为飞书卡片 JSON：**
+
+```json
+{
+  "config": { "wide_screen_mode": true, "update_multi": true },
+  "header": {
+    "title": { "tag": "plain_text", "content": "群名 · Agent 处理中" },
+    "template": "blue"  // 运行中=blue, 完成=green, 失败=red
+  },
+  "elements": [
+    // 活动轨迹区域：每个 TrailEntry 一行
+    { "tag": "div", "text": { "tag": "lark_md", "content": "🟢 12:34:56 agent 启动" } },
+    { "tag": "div", "text": { "tag": "lark_md", "content": "🔵 12:34:58 工具调用: bash" } },
+    { "tag": "hr" },
+
+    // 输出区域：累积的 assistant 文本
+    { "tag": "markdown", "content": "这是 Agent 的输出内容..." },
+
+    // 停止按钮（运行中时显示）
+    { "tag": "action", "actions": [{ "tag": "button", "text": "停止任务", "type": "danger" }] },
+
+    // 底部状态（思考中 / 工具调用中 / 输出中）
+    { "tag": "note", "elements": [{ "tag": "plain_text", "content": "🤔 思考中..." }] }
+  ]
+}
+```
+
+### 4.5 并行启动 + 事件缓存重放
+
+**v4 核心优化：CardStream 创建和 Agent 推理并行执行**
+
+```
+用户发消息
+  │
+  ├─→ CardStream.open()  (并行)        ├─→ AgentManager.sendPrompt()  (并行)
+  │   创建卡片，获得 messageId            │   Agent 开始推理
+  │                                     │   事件暂存到 pendingCardEvents[]
+  │   ← 卡片创建完成 ←                  │   ← Agent 推理中...
+  │                                     │
+  ├─→ replayBufferedEvents()            │
+  │   将缓存的事件批量应用到卡片          │
+  │                                     │
+  └─→ 后续事件直接更新卡片 ←────────────┘
+```
+
+**关键代码：**
+
+```typescript
+// 并行化：CardStream + Agent 互不阻塞
+const cardPromise = CardStream.open(client, chatId, initialCard, ...);
+// 不 await！直接启动 Agent
+await this.agentManager.sendPrompt({ agentId, message, images });
+
+// 再等待卡片创建完成
+const cardStream = await cardPromise;
+// 回放缓存事件
+this.replayBufferedEvents(sessionId, cardStream, headerTitle);
+```
+
+### 4.6 闪电确认（⚡ 已收到）
+
+**目的：** 让用户在飞书中立即感知 Bot 已收到消息，避免 1-3 秒的"空白等待"。
+
+**实现：**
+
+```typescript
+// fire-and-forget，不等待结果
+void this.sendLightningConfirm(chatId, replyToMsgId).catch(() => {});
+
+// 这个调用在 runAgent() 之前执行，先发 "⚡ 已收到"，
+// 然后才开始创建卡片和启动 Agent。
+```
+
+### 4.7 Session Mirror — 自动拉群
+
+**实现位置：** `FeishuBridge.ts` → `ensureSessionMirror()` 方法
+
+**触发时机：**
+
+1. PiDeck 中创建新 Agent 会话（`index.ts` 中的 `agentsCreate` IPC handler → `feishu.ensureSessionMirror()`）
+2. 飞书中发送消息时绑定失效，检测到后复用/重建
+
+**完整流程：**
+
+```
+PiDeck 创建新会话
+  │
+  ├─ 1. 按 sessionId 查已有绑定
+  │     ├─ 找到 → 返回 chatId
+  │     └─ 未找到 ↓
+  │
+  ├─ 2. 按 sessionPath 查已有绑定（重启后 sessionId 会变，但 sessionPath 不变）
+  │     ├─ 找到 → 更新 sessionId 映射，返回 chatId
+  │     └─ 未找到 ↓
+  │
+  ├─ 3. 按孤立 session-mirror 群匹配（agent 不存在的旧绑定可复用）
+  │     ├─ 找到 → 复用群聊，返回 chatId
+  │     └─ 未找到 ↓
+  │
+  └─ 4. 调用 im.chat.create 创建新群聊
+       name: "Pi Agent - {标题前50字符}"
+       chat_mode: "group", chat_type: "private"
+       user_id_list: [用户open_id, Bot_open_id]  // 如果 open_id 已知
+       创建绑定 → 发欢迎消息
+```
+
+**用户 open_id 获取优先级：**
+
+1. 配置中的 `defaultUserOpenId`（用户在 PiDeck UI 中填入）
+2. 自动记住的 `userOpenId`（首次飞书消息时自动保存）
+3. 如果都没有 → 群聊里只有 Bot（后续可通过 `/whoami` 获取并补填）
+
+**安全检查：** 如果填入的 open_id 恰好是 Bot 自己的 open_id，会在日志中警告并忽略。
+
+### 4.8 绑定失效恢复
+
+**场景：** 应用重启后，旧的 `sessionId` 对应的 Agent 进程不再存在。
+
+**恢复策略（`resumeOrCreateAgent`）：**
+
+```
+1. 尝试用 sessionPath 恢复（sessionPath 是持久化的 .jsonl 文件路径）
+   ├─ sessionPath 文件存在 → AgentManager.create({sessionPath}) → 新 sessionId，旧绑定更新
+   └─ sessionPath 不存在 ↓
+
+2. 创建全新的 Agent 会话 → 复用已有 chatId 绑定（不新建群）
+   给用户发 "🔄 会话已恢复，新 ID: xxx"
+```
+
+### 4.9 命令系统
+
+**实现位置：** `FeishuBridge.ts` → `handleCommand()` 方法
+
+| 命令 | 实现 | 说明 |
+|------|------|------|
+| `/help` 或 `/h` | `sendHelpCard()` | 发送帮助卡片 |
+| `/new` 或 `/n` | `createNewSession()` | 为该聊天创建新 Agent 会话 |
+| `/stop` 或 `/s` | `handleStopCommand()` | 流式卡片 markInterrupted + agentManager.abort() |
+| `/status` | `handleStatusCommand()` | 发送当前连接状态卡片 |
+| `/whoami` | `sendSmartMessage()` | 回复用户的 open_id |
+| `/refresh` 或 `/r` | `reloadBindings()` | 重新从磁盘加载绑定 |
+
+### 4.10 自动重连
+
+**实现位置：** `FeishuBridge.ts` → `scheduleReconnect()` 方法
+
+- 连接断开后指数退避重连
+- 初始间隔 5 秒，每次 ×1.5，最大 60 秒，最多 10 次
+- 重连成功后重置计数
+
+---
+
+## 5. 数据流与生命周期
+
+### 5.1 一条飞书消息的完整旅程
+
+```
+1. 用户 → 飞书 App 发消息
+   ↓
+2. 飞书平台 → WSClient WebSocket → EventDispatcher
+   ↓
+3. handleRawMessage(data)
+   ├─ 过滤 bot 自己的消息
+   ├─ event_id 去重
+   └─ → handleMessage()
+   ↓
+4. handleMessage(event)
+   ├─ message_id 去重
+   ├─ chatType 检查 (group + requireMention → 检查 @Bot)
+   ├─ 解析消息类型 (text/post/image/file)
+   ├─ 下载附件（图片/文件）→ Buffer → base64
+   ├─ 内容去重 (5s TTL)
+   ├─ 检查是否为命令 (以 / 开头) → handleCommand()
+   └─ → runAgent()
+   ↓
+5. runAgent(msgCtx, text, images, files)
+   ├─ 查找/创建绑定 (chatId ↔ sessionId)
+   ├─ ⚡ sendLightningConfirm()  (fire-and-forget)
+   ├─ 初始化 RunState + pendingCardEvents
+   ├─ 🔥 并行启动：
+   │   ├─ CardStream.open()  (创建卡片)
+   │   └─ AgentManager.sendPrompt()  (启动 Agent)
+   ├─ 等待 CardStream 创建完成
+   ├─ 回放缓存事件到卡片
+   ├─ 等待 Agent 完成 (agent_end 事件 or 超时 300s)
+   ├─ 等待终态卡片 flush
+   └─ 清理状态
+   ↓
+6. 期间 handleAgentEvent() 持续处理
+   ├─ reduceFromPiEvent(state, event) → newState
+   ├─ CardStream.update(newCard)  (200ms 节流)
+   └─ agent_end → CardStream.flush(finalCard) + close
+```
+
+### 5.2 AgentManager 事件流
+
+```
+Pi RPC 子进程
+  │
+  ├─ PiProcess (stdin/stdout JSON-RPC)
+  │
+  ↓ IPC
+AgentManager
+  │
+  ├─ emit("agents:event", {agentId, event})     ← 结构化的 Agent 事件
+  ├─ emit("agents:state", {list()})              ← Agent 列表状态
+  ├─ emit("agents:thinking", {agentId, text})   ← 思考内容流
+  ├─ emit("agents:log", {agentId, line})         ← 日志行
+  └─ emit("agents:message", {agentId, message})  ← 消息
+```
+
+**FeishuBridge 监听到的事件（`handleAgentEvent`）：**
+
+| 事件类型 | 用途 |
+|----------|------|
+| `agent_start` | 流式状态 → trail |
+| `turn_start` | 流式状态 → trail |
+| `message_start` | 流式状态 → 初始化文本块 |
+| `message_update.text_delta` | 流式状态 → outputText 追加 |
+| `message_update.thinking_delta` | 流式状态 → reasoning 追加 |
+| `message_update.toolcall_start` | 流式状态 → tool block |
+| `message_update.toolcall_end` | 流式状态 → tool done |
+| `tool_execution_start` | 流式状态 → tool block |
+| `tool_execution_end` | 流式状态 → tool done |
+| `compaction_start` | 流式状态 → trail |
+| `auto_retry_start` | 流式状态 → trail |
+| `auto_retry_end` | 流式状态 → trail update |
+| `agent_end` | 流式状态 → terminal done |
+
+### 5.3 生命周期管理
+
+```
+PiDeck 启动
+  │
+  ├─ new FeishuBridge(config, agentManager, getWindow, getProjects)
+  │   (构造函数：只保存引用，不连接)
+  │
+  ├─ bridge.start()
+  │   ├─ Lark Client 初始化
+  │   ├─ Bot Open ID 探测
+  │   ├─ WSClient 启动 + EventDispatcher
+  │   ├─ 注册 AgentManager 本地事件监听
+  │   ├─ loadPersistedBindings() → 恢复聊天绑定
+  │   └─ status → "connected"
+  │
+  ├─ 运行中：处理飞书消息 + Agent 事件
+  │
+  ├─ bridge.stop()
+  │   ├─ 取消事件监听
+  │   ├─ 关闭所有流式卡片 (CardStream.close())
+  │   ├─ WSClient.stop()
+  │   ├─ 清理绑定、去重缓存、状态
+  │   └─ status → "disconnected"
+  │
+  └─ PiDeck 关闭
+      └─ app.on("before-quit") → bridge.stop()
+```
+
+---
+
+## 6. 文件与配置
+
+### 6.1 PiDeck 飞书配置持久化
+
+| 文件 | 路径 | 内容 |
+|------|------|------|
+| 多 Bot 配置 | `~/.pi-desktop/feishu.json` | 所有 Bot 的 App ID、加密 Secret、名称、设置 |
+| 绑定数据 | `~/.pi-desktop/feishu-bindings-{botId}.json` | 飞书聊天 ↔ Pi 会话的映射关系 |
+
+**feishu.json 结构：**
+
+```json
+{
+  "version": 2,
+  "bots": [
+    {
+      "id": "uuid",
+      "name": "Pi Agent 助手",
+      "enabled": true,
+      "appId": "cli_xxxxxxxxxxxx",
+      "appSecret": "base64_encoded_secret",
+      "defaultWorkspaceId": "",
+      "defaultUserOpenId": "ou_xxxxxxxxxxxxx",
+      "requireMention": true
+    }
+  ]
+}
+```
+
+**feishu-bindings-{botId}.json 结构：**
+
+```json
+[
+  {
+    "chatId": "oc_xxxxxxxxxxxx",
+    "botId": "uuid",
+    "userId": "ou_xxxxxxxxxxxxx",
+    "sessionId": "agent-uuid",
+    "sessionPath": "/path/to/session.jsonl",
+    "workspaceId": "",
+    "source": "feishu" | "session-mirror",
+    "chatType": "p2p" | "group",
+    "groupName": "Pi Agent - xxx",
+    "createdAt": 1718697600000
+  }
+]
+```
+
+### 6.2 pi-feishu-lark 配置持久化（参考）
+
+| 文件 | 路径 | 内容 |
+|------|------|------|
+| 配置 | `~/.pi/agent/feishu/config.json` | App ID、Secret、domain、groupPolicy |
+| 状态 | `~/.pi/agent/feishu/state.json` | 飞书会话 ↔ Pi 会话映射 + 模型选择 |
+| 桥接路由 | `~/.pi/agent/feishu/bridge.json` | 定时任务路由信息 |
+| 调试日志 | `~/.pi/agent/feishu/debug.log` | 最近调试日志 |
+| 守护进程日志 | `~/.pi/agent/feishu/daemon.log` | 后台守护进程日志 |
+| 去重数据 | `~/.pi/agent/feishu/dedupe.json` | 消息去重持久化 |
+| 网关锁 | `~/.pi/agent/locks.json` | 多进程互斥锁 |
+
+### 6.3 App Secret 加密
+
+**当前方案（base64）：** 简单的 base64 编码，不提供真正的安全性。
+
+```typescript
+function encryptSecret(plain: string): string {
+  return Buffer.from(plain, "utf-8").toString("base64");
+}
+function decryptSecret(encrypted: string): string {
+  return Buffer.from(encrypted, "base64").toString("utf-8");
+}
+```
+
+> ⚠️ 待升级：计划使用 `electron.safeStorage` 实现系统级加密存储。
+
+### 6.4 环境变量
+
+| 变量 | 用途 | 默认值 |
+|------|------|--------|
+| `FEISHU_APP_ID` | 飞书应用 ID | 从 config.json 读取 |
+| `FEISHU_APP_SECRET` | 飞书应用密钥 | 从 config.json 读取 |
+| `FEISHU_DOMAIN` | `feishu` 或 `lark` | `feishu` |
+| `FEISHU_GROUP_POLICY` | `open` 或 `mention` | `open` |
+| `FEISHU_CARD_ACTION_MODE` | `webhook` 或 `ws` | `webhook` |
+| `FEISHU_AUTO_START` | `1` 或 `0` | `1` |
+| `PI_BIN` | pi 可执行文件路径 | `pi` |
+| `PI_FEISHU_DAEMON` | 守护进程模式标识 | 未设置 |
+| `FEISHU_EXT_DEV` | 开发模式，状态栏显示 [DEV] | 未设置 |
+
+---
+
+## 7. 注入点详解（8 个关键点）
+
+### 注入点 1：消息入口 — `handleRawMessage`
+
+**位置：** `FeishuBridge.ts` 第 ~570 行
+
+**功能：** 从 WebSocket 事件中提取消息，过滤 bot 自己的消息，调用 `handleMessage`。
+
+**维护注意：**
+- 这里用 `data?.event ?? data` 兼容两种 SDK 响应格式
+- event_id 去重在此处完成
+- 如果消息收不到，先检查这里是否有 event_id
+
+### 注入点 2：消息处理 — `handleMessage`
+
+**位置：** `FeishuBridge.ts` 第 ~590 行
+
+**功能：** 消息去重、类型解析、图片下载、命令识别、内容去重、Agent 调度。
+
+**维护注意：**
+- 内容去重键使用 `\u0000` 分隔，支持图片/文件附件去重
+- 图片/文件下载失败时自动生成错误提示文本
+- processingChats 防止重入（同一 chatId 同时只能处理一条消息）
+
+### 注入点 3：Agent 调度 — `runAgent`
+
+**位置：** `FeishuBridge.ts` 第 ~700 行
+
+**功能：** 绑定管理、闪电确认、并行启动、事件缓存重放、等待完成、结果发送。
+
+**维护注意：**
+- 绑定失效恢复（`resumeOrCreateAgent`）在此触发
+- 并行启动：CardStream.open 和 AgentManager.sendPrompt 同时执行
+- 超时 300 秒（5 分钟）
+- 降级兜底：CardStream patch 失败后改用 sendSmartMessage 发送文本结果
+
+### 注入点 4：Agent 事件处理 — `handleAgentEvent`
+
+**位置：** `FeishuBridge.ts` 第 ~850 行
+
+**功能：** 从 AgentManager 监听事件，驱动流式卡片状态机，触发 Pi→飞书同步。
+
+**维护注意：**
+- 事件先更新 RunState，再更新 CardStream（如果卡片已创建）
+- 如果卡片尚未创建（并行模式），事件暂存到 pendingCardEvents
+- agent_end 事件触发终态 flush + close，同时触发 Session Mirror 同步
+- feishuSessions 集合标记哪些会话是飞书发起的（不需要 mirror）
+
+### 注入点 5：流式卡片通信 — `CardStream`
+
+**位置：** `CardStream.ts`
+
+**功能：** im.message.reply/create 发送初始卡片，im.v1.message.patch 原子更新。
+
+**维护注意：**
+- 节流间隔 THROTTLE_MS = 200ms
+- 最大重试 MAX_UPDATE_RETRIES = 2
+- lastPatchFailed 标记用于上层降级
+- im.v1.message.patch 需要 Lark SDK >= v1.40
+
+### 注入点 6：状态机 — `CardRunState.reduceFromPiEvent`
+
+**位置：** `CardRunState.ts`
+
+**功能：** 纯函数，将 AgentManager 事件转换为结构化的 RunState。
+
+**维护注意：**
+- 所有函数是纯函数（输入 state + event → 输出 newState），不修改原对象
+- trail 条目自动生成唯一 ID（trail_时间戳_递增序号）
+- outputText 是累积的，不是增量的
+- toolInputSummary 根据工具名提取有意义的参数摘要（read→文件路径, bash→命令, write→路径）
+
+### 注入点 7：Session Mirror — `ensureSessionMirror`
+
+**位置：** `FeishuBridge.ts` 第 ~1000 行
+
+**功能：** Pi 侧创建会话时自动创建飞书群聊。
+
+**维护注意：**
+- 四级匹配策略：sessionId → sessionPath → 孤立群 → 新建群
+- 用户 open_id 安全检查：防止误填 Bot 自己的 open_id
+- 需要 im:chat 权限
+- 欢迎消息 "🤖 Pi Agent 会话已创建\n会话 ID: xxx\n\n直接发消息即可与 Agent 对话。"
+
+### 注入点 8：绑定持久化 — `FeishuConfig`
+
+**位置：** `FeishuConfig.ts`
+
+**功能：** 多 Bot CRUD、Secret 加密、绑定 JSON 文件读写。
+
+**维护注意：**
+- App Secret 使用 base64 编码（非安全加密，待升级）
+- 绑定按 botId 分文件存储
+- 向后兼容 v1 格式（单 Bot JSON 自动迁移为 v2）
+- isBase64 检测用于区分明文和已加密的 Secret
+
+---
+
+## 8. 日常维护操作
+
+### 8.1 启动项目
+
+```bash
+cd "/Users/1900th/Downloads/同步空间/Pi Agent/飞书远程控制/pi-desktop"
+npm run build && npx electron-vite preview
+```
+
+### 8.2 编译检查
+
+```bash
+cd pi-desktop
+npx tsc --noEmit
+```
+
+### 8.3 查看运行日志
+
+```bash
+# PiDeck 主进程日志（终端输出）
+# 关键标签：
+#   [飞书 Bridge]     — 桥接主逻辑
+#   [飞书 CardStream] — 流式卡片
+#   [飞书 Session Mirror] — 自动拉群
+
+# 日志级别过滤建议：
+#   正常流程：只看 [飞书 Bridge] 的 log
+#   排查问题：关注 warn 和 error
+```
+
+### 8.4 清理与重置
+
+```bash
+# 完全清理飞书配置
+rm -f ~/.pi-desktop/feishu.json
+rm -f ~/.pi-desktop/feishu-bindings-*.json
+
+# 清理 pi-feishu-lark 残留（如果安装了）
+rm -rf ~/.pi/agent/feishu/
+rm -f ~/.pi/agent/locks.json
+```
+
+### 8.5 新增 Bot 绑定流程
+
+1. 飞书开放平台创建应用 → 获取 App ID + Secret
+2. 配置权限（见 [第 9.2 节](#92-需要的飞书权限)）
+3. 发布应用版本
+4. PiDeck → 设置 → IM 连接 → 添加 Bot
+5. 填入 App ID、Secret、名称
+6. 点击「测试连接」→ 确认成功
+7. 点击「连接」
+8. 飞书 App 中搜索 Bot 名称 → 发送 `/whoami` 获取 open_id
+9. 编辑 Bot 配置 → 填入「你的 Open ID」
+
+### 8.6 更新依赖
+
+```bash
+cd pi-desktop
+npm update @larksuiteoapi/node-sdk
+```
+
+---
+
+## 9. 常见问题排查
+
+### 9.1 飞书收不到 Bot 回复
+
+**排查清单：**
+
+| # | 检查项 | 怎么做 |
+|---|--------|--------|
+| 1 | PiDeck 是否运行 | 确认窗口打开，终端无报错 |
+| 2 | 飞书连接状态 | PiDeck 侧边栏状态灯 → 应为绿色 |
+| 3 | 应用是否发布 | 飞书开放平台 → 应用发布 → 版本已发布 |
+| 4 | 权限是否足够 | 飞书开放平台 → 权限管理（见下方） |
+| 5 | 是群聊还是私聊 | 群聊需 @Bot 或开启 im:message:group |
+| 6 | WebSocket 连接 | 查看终端 `[飞书 Bridge] WSClient 已启动` |
+
+### 9.2 需要的飞书权限
+
+| 权限代码 | 名称 | 用途 |
+|----------|------|------|
+| `im:message` | 获取用户发给机器人的单聊消息 | 接收私聊 |
+| `im:message:group_at` | 获取用户在群组中@机器人的消息 | 接收群聊@ |
+| `im:message:group` | 获取群组中的所有消息 | 免@接收群聊 |
+| `im:message:send_as_bot` | 以应用身份发送消息 | Bot 回复 |
+| `im:chat` | 创建群聊 | 自动拉群 |
+| `im:chat:readonly` | 获取群信息 | 读取群名等 |
+| `im:resource` | 获取与上传图片/文件资源 | 接收图片/文件 |
+
+### 9.3 流式卡片不更新
+
+**可能原因：**
+
+1. **im.v1.message.patch API 不支持** → 检查 Lark SDK 版本 ≥ 1.40
+2. **卡片 messageId 为空** → 查看 `CardStream.open` 返回值
+3. **patch 重试耗尽** → 查看 `lastPatchFailed` 和 `lastPatchError`
+4. **事件不匹配** → 查看终端日志中 `handleAgentEvent` 输出
+
+**调试方法：**
+
+```bash
+# 查看 CardStream 相关日志
+grep "CardStream" 终端输出
+
+# 查看 patch 错误详情
+grep "patch 失败" 终端输出
+```
+
+### 9.4 自动拉群不工作
+
+**排查：**
+
+1. 确认 `im:chat` 权限已开通
+2. 确认应用已重新发布
+3. 查看终端日志 `[飞书 Session Mirror]`
+4. 常见错误码：
+   - `230001` → 缺少 im:chat 权限
+   - `permission denied` → 权限未开通或未发布
+   - `invalid user_id` → open_id 格式错误
+
+### 9.5 图片无法识别
+
+**可能原因：**
+
+1. `im:resource` 权限未开 → 去开放平台开通
+2. 当前模型不支持 vision → 检查模型配置
+3. 图片下载超时（15 秒）→ 网络问题
+4. 飞书 SDK streamToBuffer 失败 → 查看终端日志
+
+### 9.6 连接频繁断开
+
+**检查：**
+
+1. 网络稳定性
+2. WebSocket 心跳（飞书 SDK 内置）
+3. 查看重连日志 `reconnectAttempts`
+4. App Secret 是否过期 → 去开放平台重置
+
+### 9.7 App Secret 找回
+
+飞书开放平台 → 应用详情页 → 点击 App Secret 旁的「重置」按钮。
+重置后旧 Secret 立即失效，需要更新 PiDeck 配置。
+
+---
+
+## 10. 编译与启动
+
+### 10.1 环境要求
+
+- Node.js 20+
+- npm
+- 系统 PATH 中可访问 `pi` 命令
+- 已完成 pi 的 Provider / API Key 配置
+
+### 10.2 从源码编译
+
+```bash
+cd "/Users/1900th/Downloads/同步空间/Pi Agent/飞书远程控制/pi-desktop"
+npm install
+npm run make-icon    # 生成图标资源
+npm run dev          # 开发模式启动
+```
+
+### 10.3 构建发布包
+
+```bash
+npm run dist        # 当前平台
+npm run dist:mac    # macOS (DMG + zip)
+npm run dist:win    # Windows (NSIS + portable + zip)
+npm run dist:linux  # Linux (AppImage + deb + tar.gz)
+```
+
+### 10.4 类型检查
+
+```bash
+cd pi-desktop
+npx tsc --noEmit
+# 应输出 0 errors
+
+cd pi-feishu-lark
+npx tsc --noEmit
+# 参考项目类型检查
+```
+
+### 10.5 浏览器预览模式
+
+打开 `http://localhost:5173/` 进行 UI 调试。
+Renderer 在 `window.piDesktop` 不可用时自动降级为 mock 数据。
+但飞书相关功能必须在 Electron 中验证。
+
+---
+
+## 11. 附录
+
+### 11.1 关键 URL
+
+| 名称 | URL |
+|------|-----|
+| 飞书开放平台 | https://open.feishu.cn/ |
+| 飞书 API 文档 | https://open.feishu.cn/document/server-docs/im-v1/ |
+| PiDeck 源码 | https://github.com/1900EasonJin/pi-desktop |
+| pi-feishu-lark 参考 | https://github.com/AX1202/pi-feishu-lark |
+| Lark Node SDK | https://www.npmjs.com/package/@larksuiteoapi/node-sdk |
+
+### 11.2 相关文档文件索引
+
+| 文档 | 路径 | 内容 |
+|------|------|------|
+| 本维护手册 | `飞书远程控制-维护手册.md` | 完整维护指南（你正在读的这个） |
+| pi-feishu-lark 分析 | `4.pi-feishu-lark分析.md` | 参考项目源码分析 |
+| 开发进度 | `3.开发进度.md` | 功能开发状态 |
+| 编译与启动 | `编译与启动指南.md` | 基础启动指南 |
+| 机器人绑定教程 | `7.飞书机器人绑定完整教程.md` | 用户侧绑定教程 |
+| PiDeck 集成方案 | `2.PiDeck集成飞书远程控制-完整方案.md` | 集成架构设计 |
+| 桥接修复说明 | `8.飞书桥接修复说明.md` | 桥接修复记录 |
+| 流式卡片优化 | `6.飞书流式卡片优化方案.md` | 流式卡片设计 |
+| open_id 修复 | `5.自动拉群-open_id修复方案.md` | open_id 原理与修复 |
+| 优化减重计划 | `优化减重计划.md` | 代码精简计划 |
+| HTML 预览 | `预览-PiDeck集成方案.html` | 方案可视化预览 |
+| HTML 预览 | `预览-飞书机器人绑定教程.html` | 教程可视化预览 |
+
+### 11.3 版本历史摘要
+
+| 版本 | 日期 | 主要变更 |
+|------|------|----------|
+| v1 | 2026-06-15 | 基础飞书连接（LarkChannel + 消息回复） |
+| v2 | 2026-06-16 | WSClient + EventDispatcher + 自动重连 + 多 Bot CRUD |
+| v3 | 2026-06-17 | 智能消息模式 + 流式卡片 + 自动拉群 + Pi→飞书同步 |
+| v4 | 2026-06-17 | 活动轨迹 + 闪电确认 + 并行启动 + 输出流式渲染 + 降级兜底 |
+
+### 11.4 关键常量速查
+
+| 常量 | 值 | 模块 | 说明 |
+|------|-----|------|------|
+| `THROTTLE_MS` | 200 | CardStream.ts | 流式卡片更新节流间隔 |
+| `MAX_UPDATE_RETRIES` | 2 | CardStream.ts | 流式卡片 patch 最大重试 |
+| `MAX_CARD_BYTES` | 29KB | rich-text.ts | 单张飞书卡片最大字节数 |
+| `TEXT_CHUNK_MAX_BYTES` | 120KB | transport.ts (参考) | 单条 text 消息最大字节数 |
+| `POST_LENGTH_THRESHOLD` | 250 | rich-text.ts | 超过此长度考虑 post 模式 |
+| `INTERACTIVE_LENGTH_THRESHOLD` | 1200 | rich-text.ts | 超过此长度考虑 interactive 模式 |
+| `CONTENT_DEDUPE_TTL_MS` | 5000 | FeishuBridge.ts | 内容去重窗口 |
+| `DEDUP_MAX` | 200 | FeishuBridge.ts | event_id/message_id 去重上限 |
+| `AGENT_TIMEOUT_MS` | 300000 | FeishuBridge.ts | Agent 最大等待时间 |
+| `GROUP_CACHE_TTL` | 3600000 | FeishuBridge.ts | 群信息缓存时间 |
+
+### 11.5 踩坑记录
+
+1. **飞书 WebSocket 心跳** — Lark SDK 的 WSClient 内置了 WebSocket ping/pong，不需要额外实现心跳。如果连接断开，飞书平台会主动关闭 WebSocket，SDK 触发 onClose 回调。
+
+2. **im.v1.message.patch 兼容性** — 这个 API 需要 Lark Node SDK >= v1.40。确保 `package.json` 中的 `@larksuiteoapi/node-sdk` 版本 ≥ 1.40。
+
+3. **飞书卡片内容大小限制** — 单张卡片 JSON 序列化后不能超过 30KB（我们设为 29KB 安全边界）。超过会返回 `content size exceeds limit` 错误。解决方式是按 ## 标题分片。
+
+4. **open_id 的"鸡生蛋"问题** — 创建群聊（`im.chat.create`）需要用户的 open_id，但 open_id 需要通过用户在飞书发消息才能获取。所以如果用户从未发过消息就创建 Pi 会话，群聊里只有 Bot 一人。解决方案：在 Bot 配置中预设 `defaultUserOpenId`。
+
+5. **EPIPE 错误** — 当父进程管道断开时，`console.log` 可能抛出 EPIPE。解决方案：`safeLog` 函数用 try-catch 包裹所有日志输出。
+
+6. **AgentManager 事件格式** — AgentManager 发出的 `message_update` 事件的字段是 `assistantMessageEvent.delta`（而不是 `text`），需要兼容两种格式。
+
+7. **并行启动竞态** — CardStream.open 和 AgentManager.sendPrompt 并行执行时，Agent 事件可能在卡片创建完成前到达。需要在 `handleAgentEvent` 中检测 `streamingCards.has(agentId)` 来判断是否缓存事件。
+
+8. **绑定失效的问题** — Electron 重启后，旧的 agent sessionId 不再有效。需要通过 sessionPath 来恢复绑定，如果没有 sessionPath 则创建新 agent。
+
+---
+
+> 📌 **维护原则：**
+> 1. 修改 `FeishuBridge.ts` 后务必运行 `npx tsc --noEmit` 检查类型
+> 2. 飞书 SDK 升级前先在独立分支测试
+> 3. 添加新功能时同步更新本文档的对应章节
+> 4. 遇到飞书 API 错误，先查看 `[飞书 Bridge]` 日志中的错误码，再去飞书 API 文档查原因
+> 5. 不要在飞书卡片中放入超过 29KB 的内容（含 JSON 序列化开销）
+> 6. 图片/文件处理要加超时（当前 15 秒），防止卡死整个消息管线

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,21 @@
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/utils": "^4.0.0",
-        "node-pty": "^1.1.0"
+        "@larksuiteoapi/node-sdk": "^1.67.0",
+        "node-pty": "^1.1.0",
+        "qrcode": "^1.5.4"
       },
       "devDependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@fiahfy/icns": "^0.0.7",
         "@types/node": "^24.0.0",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^5.0.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
-        "electron": "^38.0.0",
+        "electron": "^38.8.6",
         "electron-builder": "^26.8.1",
         "electron-vite": "^4.0.0",
         "lucide-react": "^1.17.0",
@@ -198,7 +201,6 @@
       "integrity": "sha512-ngdgVGp05lJzUyA+sUzr0MDZ7AMtANcJpwIzq4ZsfpZL5B3S7A4XYfMcU2sECZc3bx3ysOhYcdbbaTjc3ve0WQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.54.0",
         "@algolia/requester-browser-xhr": "5.54.0",
@@ -327,7 +329,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -664,6 +665,49 @@
         }
       }
     },
+    "node_modules/@docsearch/js/node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/@docsearch/js/node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.23.2.tgz",
@@ -671,6 +715,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -1063,6 +1108,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1084,6 +1130,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1100,6 +1147,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1114,6 +1162,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2175,6 +2224,20 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.67.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@larksuiteoapi/node-sdk/-/node-sdk-1.67.0.tgz",
+      "integrity": "sha512-pr3iZbK+CkwgwIhUzt86mZGP/wLCzBDRmCy+Vt+/UAWx/KjwxwrRpfAKm4eOmd0uUd8AcG2mWC/ZSUMu7lZIqg==",
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -2252,6 +2315,63 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -2909,7 +3029,18 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.15",
@@ -2917,7 +3048,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3312,7 +3442,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3340,7 +3469,6 @@
       "integrity": "sha512-APAX4ajIOgsmYoUlGe++oNZkSTBgmXYM4maHC0OxC+Yo7xkaKQElV0ATZYCZA7jzrSJX1OBiqEs7mk+ZxXgYqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.20.0",
         "@algolia/client-abtesting": "5.54.0",
@@ -3365,7 +3493,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3375,7 +3502,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3610,7 +3736,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -3621,6 +3746,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/bail": {
@@ -3729,7 +3865,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3904,7 +4039,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3912,6 +4046,31 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4089,7 +4248,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4102,14 +4260,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4204,7 +4360,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4266,6 +4423,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decode-named-character-reference": {
@@ -4358,7 +4524,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4404,6 +4569,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
@@ -4453,7 +4624,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -4563,7 +4733,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4592,11 +4761,10 @@
     },
     "node_modules/electron": {
       "version": "38.8.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.8.6.tgz",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/electron/-/electron-38.8.6.tgz",
       "integrity": "sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -4785,6 +4953,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4805,6 +4974,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4833,7 +5003,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex-xs": {
@@ -4885,7 +5054,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4895,7 +5063,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4905,7 +5072,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4918,7 +5084,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5146,22 +5311,53 @@
         "node": ">=10"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/focus-trap": {
       "version": "7.8.0",
       "resolved": "https://registry.npmmirror.com/focus-trap/-/focus-trap-7.8.0.tgz",
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5214,7 +5410,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5234,7 +5429,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5244,7 +5438,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5269,7 +5462,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5399,7 +5591,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5466,7 +5657,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5479,7 +5669,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5495,7 +5684,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5799,7 +5987,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5984,12 +6171,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -6009,6 +6232,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6090,7 +6314,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7002,7 +7225,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7012,7 +7234,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7099,6 +7320,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7306,6 +7528,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -7362,6 +7596,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -7388,6 +7657,15 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -7450,7 +7728,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7554,6 +7831,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -7571,6 +7849,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -7642,6 +7921,35 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -7662,6 +7970,112 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -7680,7 +8094,6 @@
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7850,11 +8263,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resedit": {
       "version": "1.7.2",
@@ -7916,6 +8334,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -8060,6 +8479,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -8156,6 +8581,77 @@
         "@shikijs/types": "2.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -8292,7 +8788,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8322,7 +8817,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8429,6 +8923,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -8602,7 +9097,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8829,7 +9323,6 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9875,7 +10368,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -9936,7 +10428,6 @@
       "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.38",
         "@vue/compiler-sfc": "3.5.38",
@@ -9969,6 +10460,12 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -9992,6 +10489,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
   "dependencies": {
     "@electron-toolkit/utils": "^4.0.0",
     "@larksuiteoapi/node-sdk": "^1.67.0",
-    "node-pty": "^1.1.0",
-    "qrcode": "^1.5.4"
+    "node-pty": "^1.1.0"
   },
   "build": {
     "appId": "com.ayuayue.pi-desktop",
@@ -99,7 +98,6 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@fiahfy/icns": "^0.0.7",
     "@types/node": "^24.0.0",
-    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   },
   "dependencies": {
     "@electron-toolkit/utils": "^4.0.0",
-    "node-pty": "^1.1.0"
+    "@larksuiteoapi/node-sdk": "^1.67.0",
+    "node-pty": "^1.1.0",
+    "qrcode": "^1.5.4"
   },
   "build": {
     "appId": "com.ayuayue.pi-desktop",
@@ -97,12 +99,13 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@fiahfy/icns": "^0.0.7",
     "@types/node": "^24.0.0",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.0.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
-    "electron": "^38.0.0",
+    "electron": "^38.8.6",
     "electron-builder": "^26.8.1",
     "electron-vite": "^4.0.0",
     "lucide-react": "^1.17.0",

--- a/src/main/feishu/CardRenderer.ts
+++ b/src/main/feishu/CardRenderer.ts
@@ -1,244 +1,242 @@
 /**
- * CardRenderer — RunState → CardKit 2.0 卡片 JSON 的纯函数渲染器
+ * CardRenderer v4 — RunState → 飞书 interactive 卡片 JSON
  *
- * 参考 Proma 的 card-renderer-v2.ts：
- * - streaming_mode 标志告诉飞书这是动态卡
- * - 工具调用 >= 3 时合并为摘要面板
- * - 底部 summary 是手机端通知预览的短文本
- * - 可折叠面板展示工具输入输出
+ * v4 设计原则：
+ * - hr 分割线切分每个区域，层级清晰如 MD 标题
+ * - 思考过程用 note 小字，和输出正文区分开
+ * - 轨迹一行一条，紧凑整洁
+ * - 工具调用带参数预览
+ *
+ * 配合 CardStream v2 的 im.v1.message.patch 实现真正流式。
  */
 
-import type { Block, FooterStatus, RunState, ToolEntry } from "./CardRunState";
+import type { Block, RunState, ToolEntry, TrailEntry } from "./CardRunState";
 
-const REASONING_MAX = 1500;
-const TEXT_BLOCK_MAX = 20_000;
-const MIN_TOOLS_TO_COLLAPSE = 3;
-const TOOL_BODY_MAX = 4000;
+const OUTPUT_MAX = 15_000;
+const THINKING_MAX = 2_000;
+const TRAIL_ENTRIES_MAX = 20;
 
 export interface RenderOptions {
 	header?: string;
 	stopHint?: string;
-	showToolCalls?: boolean;
 }
 
-interface ToolGroup { kind: "tools"; tools: ToolEntry[] }
-interface TextGroup { kind: "text"; content: string }
-type Group = ToolGroup | TextGroup;
-
 export function renderRunCard(state: RunState, opts: RenderOptions = {}): object {
-	const showToolCalls = opts.showToolCalls !== false;
 	const elements: object[] = [];
+	const isRunning = state.terminal === "running";
 
-	// 思考过程面板
+	// ── 1. 活动轨迹 ──
+	elements.push(renderTrail(state.trail, isRunning));
+
+	// ── 2. 思考过程（note 小字，和输出区分） ──
 	if (state.reasoning.content) {
-		elements.push(reasoningPanel(state.reasoning.content, state.reasoning.active));
+		if (elements.length > 0) elements.push(hr());
+		elements.push(renderThinking(state.reasoning.content, state.reasoning.active));
 	}
 
-	// 内容块
-	const visibleBlocks = showToolCalls
-		? state.blocks
-		: state.blocks.filter((b) => b.kind !== "tool");
-
-	for (const group of groupBlocks(visibleBlocks)) {
-		if (group.kind === "text") {
-			if (group.content.trim()) {
-				elements.push(markdown(truncate(group.content, TEXT_BLOCK_MAX)));
-			}
-		} else {
-			elements.push(...renderToolGroup(group.tools, state.terminal !== "running"));
+	// ── 3. 当前正在执行的操作 ──
+	const runningTools = state.blocks.filter(
+		(b) => b.kind === "tool" && b.tool.status === "running",
+	);
+	for (const b of runningTools) {
+		if (b.kind === "tool") {
+			if (needsSep(elements)) elements.push(hr());
+			elements.push(renderRunningTool(b.tool));
 		}
 	}
 
-	// 终态标记
-	if (state.terminal === "interrupted") {
-		elements.push(noteMd("_已被中断_"));
-	} else if (state.terminal === "error" && state.errorMsg) {
-		elements.push(noteMd(`❌ Agent 失败：${state.errorMsg}`));
-	} else if (state.terminal === "done" && elements.length === 0) {
-		elements.push(noteMd("_（Agent 未返回内容）_"));
+	// ── 4. 输出正文 ──
+	if (state.outputText.trim()) {
+		if (needsSep(elements)) elements.push(hr());
+		elements.push(renderOutput(state.outputText, isRunning));
 	}
 
-	// 运行中：显示 footer + 停止提示
-	if (state.terminal === "running") {
-		if (state.footer) elements.push(footerStatus(state.footer, state.blocks));
-		if (opts.stopHint) elements.push(noteMd(opts.stopHint));
-	} else {
-		// 完成后：显示耗时等 meta
-		elements.push(metaFooter(state));
+	// ── 5. 已完成的工具 ──
+	const doneTools = state.blocks.filter(
+		(b) => b.kind === "tool" && b.tool.status !== "running",
+	);
+	if (doneTools.length > 0) {
+		if (needsSep(elements)) elements.push(hr());
+		elements.push(renderDoneTools(doneTools));
 	}
+
+	// ── 6. 终态提示 ──
+	if (state.terminal === "interrupted") {
+		elements.push(hr());
+		elements.push(note("⏹ 已被中断"));
+	} else if (state.terminal === "error" && state.errorMsg) {
+		elements.push(hr());
+		elements.push(note(`❌ 失败: ${state.errorMsg}`));
+	}
+
+	// ── 7. 底部状态栏 ──
+	elements.push(hr());
+	elements.push(renderFooter(state, isRunning, opts.stopHint));
 
 	const card: Record<string, unknown> = {
-		schema: "2.0",
-		config: {
-			streaming_mode: state.terminal === "running",
-			summary: { content: summaryText(state) },
-		},
-		body: { elements },
+		config: { wide_screen_mode: true, update_multi: true },
+		elements,
 	};
 
 	if (opts.header) {
 		card.header = {
 			title: { tag: "plain_text", content: opts.header },
-			template: state.terminal === "error" ? "red" : state.terminal === "running" ? "blue" : "default",
+			template: state.terminal === "error" ? "red"
+				: state.terminal === "interrupted" ? "grey"
+				: state.terminal === "done" ? "green"
+				: "blue",
 		};
 	}
 
 	return card;
 }
 
-function* groupBlocks(blocks: Block[]): Generator<Group> {
-	let toolBuf: ToolEntry[] = [];
-	for (const b of blocks) {
-		if (b.kind === "tool") {
-			toolBuf.push(b.tool);
-		} else {
-			if (toolBuf.length > 0) {
-				yield { kind: "tools", tools: toolBuf };
-				toolBuf = [];
-			}
-			yield { kind: "text", content: b.content };
+// ========== 区域渲染 ==========
+
+/** 活动轨迹 — 一行一条，紧凑 */
+function renderTrail(trail: TrailEntry[], isRunning: boolean): object {
+	let entries = trail;
+	let hidden = 0;
+	if (entries.length > TRAIL_ENTRIES_MAX) {
+		hidden = entries.length - TRAIL_ENTRIES_MAX;
+		entries = entries.slice(-TRAIL_ENTRIES_MAX);
+	}
+
+	const lines: string[] = [];
+	lines.push("**📋 活动轨迹**");
+
+	if (entries.length === 0) {
+		lines.push(isRunning ? "_等待 Agent 启动..._" : "_无记录_");
+	} else {
+		if (hidden > 0) lines.push(`_…前面 ${hidden} 条_`);
+		for (const e of entries) {
+			const time = fmt(e.timestamp);
+			const icon = e.status === "running" ? "🔄" : e.status === "error" ? "❌" : "✅";
+			let line = `\`${time}\` ${icon} ${e.text}`;
+			if (e.detail) line += ` — ${e.detail}`;
+			lines.push(line);
 		}
 	}
-	if (toolBuf.length > 0) yield { kind: "tools", tools: toolBuf };
+
+	return md(lines.join("\n"));
 }
 
-function renderToolGroup(tools: ToolEntry[], finalized: boolean): object[] {
-	if (tools.length === 0) return [];
-	if (tools.length < MIN_TOOLS_TO_COLLAPSE) {
-		return tools.map((t) => toolPanel(t));
+/** 思考过程 — notation 小字，和正文区分层级 */
+function renderThinking(content: string, active: boolean): object {
+	const display = content.length > THINKING_MAX
+		? content.slice(0, THINKING_MAX) + "\n\n…（已截断）"
+		: content;
+
+	const title = active ? "**💭 思考中**" : "**💭 思考过程**";
+	return { tag: "markdown", content: `${title}\n${display}`, text_size: "notation" };
+}
+
+/** 正在运行的工具 */
+function renderRunningTool(tool: ToolEntry): object {
+	const preview = toolInputPreview(tool);
+	const lines: string[] = [];
+	lines.push(`**🔧 正在调用 \`${tool.name}\``);
+	if (preview) lines.push(`\`${preview}\``);
+	return md(lines.join("\n"));
+}
+
+/** 输出正文 */
+function renderOutput(text: string, streaming: boolean): object {
+	const display = text.length > OUTPUT_MAX
+		? text.slice(0, OUTPUT_MAX) + "\n\n…（已截断）"
+		: text;
+	const marker = streaming ? " 🔵" : "";
+	return md(`**📤 输出**${marker}\n\n${display}`);
+}
+
+/** 已完成的工具列表 */
+function renderDoneTools(blocks: Block[]): object {
+	const tools = blocks
+		.filter((b) => b.kind === "tool")
+		.map((b) => (b as { kind: "tool"; tool: ToolEntry }).tool);
+
+	const MAX = 8;
+	let hidden = 0;
+	let shown = tools;
+	if (tools.length > MAX) {
+		hidden = tools.length - MAX;
+		shown = tools.slice(0, MAX);
 	}
-	if (finalized) {
-		return [toolSummaryPanel(tools, true)];
+
+	const lines: string[] = ["**🔧 已完成工具**"];
+	for (const t of shown) {
+		const icon = t.status === "error" ? "❌" : "✅";
+		const preview = toolInputPreview(t);
+		const previewPart = preview ? ` — \`${preview}\`` : "";
+		lines.push(`${icon} **${t.name}**${previewPart}`);
 	}
-	// 运行期：已完成的合并成摘要，最新的单独
-	const prior = tools.slice(0, -1);
-	const latest = tools[tools.length - 1];
-	const out: object[] = [];
-	if (prior.length > 0) out.push(toolSummaryPanel(prior, false));
-	if (latest) out.push(toolPanel(latest));
-	return out;
+	if (hidden > 0) lines.push(`_…还有 ${hidden} 个_`);
+
+	return md(lines.join("\n"));
 }
 
-function reasoningPanel(content: string, active: boolean): object {
-	const title = active ? "**🧠 思考中...**" : "**💭 思考完成（点击查看）**";
-	return collapsiblePanel({
-		title,
-		expanded: active,
-		border: "grey",
-		body: truncate(content, REASONING_MAX),
-	});
+/** 底部状态栏 */
+function renderFooter(state: RunState, isRunning: boolean, stopHint?: string): object {
+	const parts: string[] = [];
+
+	if (isRunning) {
+		// 运行中：显示当前阶段
+		if (state.footer === "thinking") {
+			parts.push("🧠 思考中");
+		} else if (state.footer === "tool_running") {
+			const rt = [...state.blocks].reverse().find(
+				(b) => b.kind === "tool" && b.tool.status === "running",
+			);
+			if (rt?.kind === "tool") parts.push(`🔧 调用 \`${rt.tool.name}\``);
+			else parts.push("🔧 调用工具");
+		} else if (state.footer === "streaming") {
+			parts.push("✍️ 输出中");
+		} else {
+			parts.push("⏳ 处理中");
+		}
+
+		if (stopHint) parts.push(stopHint);
+	} else {
+		// 完成：显示耗时
+		if (state.meta.durationMs !== undefined) {
+			parts.push(`⏱ ${(state.meta.durationMs / 1000).toFixed(1)}s`);
+		}
+		parts.push("✅ 完成");
+	}
+
+	return note(parts.join("  |  "));
 }
 
-function toolPanel(tool: ToolEntry): object {
-	return collapsiblePanel({
-		title: toolHeaderText(tool),
-		expanded: false,
-		border: tool.status === "error" ? "red" : "grey",
-		body: toolBodyMd(tool) || "_无输出_",
-	});
-}
+// ========== 工具函数 ==========
 
-function toolSummaryPanel(tools: ToolEntry[], finalized: boolean): object {
-	const suffix = finalized ? "（已结束）" : "";
-	const title = `**${tools.length} 个工具调用${suffix}**`;
-	const headerList = tools.map((t) => `- ${toolHeaderText(t)}`).join("\n");
-	return {
-		tag: "collapsible_panel",
-		expanded: false,
-		header: panelHeader(title),
-		border: { color: "blue", corner_radius: "5px" },
-		vertical_spacing: "8px",
-		padding: "8px 8px 8px 8px",
-		elements: [{ tag: "markdown", content: headerList, text_size: "notation" }],
-	};
-}
-
-function collapsiblePanel(opts: { title: string; expanded: boolean; border: "grey" | "red" | "blue"; body: string }): object {
-	return {
-		tag: "collapsible_panel",
-		expanded: opts.expanded,
-		header: panelHeader(opts.title),
-		border: { color: opts.border, corner_radius: "5px" },
-		vertical_spacing: "8px",
-		padding: "8px 8px 8px 8px",
-		elements: [{ tag: "markdown", content: opts.body, text_size: "notation" }],
-	};
-}
-
-function panelHeader(titleMd: string): object {
-	return {
-		title: { tag: "markdown", content: titleMd },
-		vertical_align: "center",
-		icon: { tag: "standard_icon", token: "down-small-ccm_outlined", size: "16px 16px" },
-		icon_position: "follow_text",
-		icon_expanded_angle: -180,
-	};
-}
-
-function markdown(content: string): object {
+function md(content: string): object {
 	return { tag: "markdown", content };
 }
 
-function noteMd(content: string): object {
-	return { tag: "markdown", content, text_size: "notation" };
+function note(content: string): object {
+	return { tag: "note", elements: [{ tag: "plain_text", content }] };
 }
 
-function footerStatus(status: Exclude<FooterStatus, null>, blocks: Block[]): object {
-	if (status === "thinking") return noteMd("🧠 正在思考...");
-	if (status === "streaming") return noteMd("✍️ 正在输出...");
-	// tool_running
-	const runningTool = [...blocks].reverse().find(
-		(b) => b.kind === "tool" && b.tool.status === "running",
-	);
-	if (runningTool && runningTool.kind === "tool") {
-		return noteMd(`🔧 正在调用 \`${runningTool.tool.name}\``);
-	}
-	return noteMd("🔧 正在调用工具...");
+function hr(): object {
+	return { tag: "hr" };
 }
 
-function metaFooter(state: RunState): object {
-	const parts: string[] = [];
-	if (state.meta.durationMs !== undefined) {
-		parts.push(`⏱ ${(state.meta.durationMs / 1000).toFixed(1)}s`);
-	}
-	if (state.meta.model) {
-		parts.push(state.meta.model);
-	}
-	return noteMd(parts.length > 0 ? parts.join("  ·  ") : "✅ 已完成");
+/** 最后一个元素不是 hr 才需要分割线 */
+function needsSep(elements: object[]): boolean {
+	if (elements.length === 0) return false;
+	const last = elements[elements.length - 1] as Record<string, unknown>;
+	return last.tag !== "hr";
 }
 
-function summaryText(state: RunState): string {
-	if (state.terminal === "interrupted") return "已中断";
-	if (state.terminal === "error") return "出错";
-	if (state.terminal === "done") return "已完成";
-	if (state.footer === "tool_running") {
-		const runningTool = [...state.blocks].reverse().find(
-			(b) => b.kind === "tool" && b.tool.status === "running",
-		);
-		if (runningTool && runningTool.kind === "tool") return `正在调用 ${runningTool.tool.name}`;
-		return "正在调用工具";
-	}
-	if (state.footer === "streaming") return "正在输出";
-	if (state.footer === "thinking") return "思考中";
-	return "处理中";
-}
-
-function truncate(s: string, max: number): string {
-	return s.length > max ? `${s.slice(0, max)}…（已截断）` : s;
-}
-
-function toolHeaderText(tool: ToolEntry): string {
-	const icon = tool.status === "error" ? "❌" : tool.status === "done" ? "✅" : "🔄";
-	const name = tool.name;
-	const summary = toolInputSummary(tool);
-	const summaryPart = summary ? ` \`${summary}\`` : "";
-	return `${icon} **${name}**${summaryPart}`;
-}
-
-function toolInputSummary(tool: ToolEntry): string {
+function toolInputPreview(tool: ToolEntry): string {
 	const input = tool.input;
 	if (!input || typeof input !== "object") return "";
 	const obj = input as Record<string, unknown>;
+	if (tool.name === "read" && typeof obj.filePath === "string") return clip(obj.filePath, 80);
+	if (tool.name === "bash" && typeof obj.command === "string") return clip(obj.command, 80);
+	if (tool.name === "write" && typeof obj.filePath === "string") return clip(obj.filePath, 80);
+	if (tool.name === "edit" && typeof obj.filePath === "string") return clip(obj.filePath, 80);
+	if (tool.name === "grep" && typeof obj.pattern === "string") return clip(obj.pattern, 80);
 	if (typeof obj.command === "string") return clip(obj.command, 80);
 	if (typeof obj.file_path === "string") return clip(obj.file_path, 80);
 	if (typeof obj.path === "string") return clip(obj.path, 80);
@@ -246,18 +244,13 @@ function toolInputSummary(tool: ToolEntry): string {
 	return "";
 }
 
-function toolBodyMd(tool: ToolEntry): string {
-	const parts: string[] = [];
-	if (tool.input && typeof tool.input === "object") {
-		try {
-			const inputStr = JSON.stringify(tool.input, null, 2);
-			parts.push("**Input**\n```json\n" + truncate(inputStr, 1500) + "\n```");
-		} catch { /* ignore */ }
-	}
-	if (tool.output) {
-		parts.push("**Output**\n```\n" + truncate(tool.output, TOOL_BODY_MAX) + "\n```");
-	}
-	return parts.join("\n\n");
+function fmt(ts: number): string {
+	const d = new Date(ts);
+	return `${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())}`;
+}
+
+function p2(n: number): string {
+	return n.toString().padStart(2, "0");
 }
 
 function clip(s: string, max: number): string {

--- a/src/main/feishu/CardRenderer.ts
+++ b/src/main/feishu/CardRenderer.ts
@@ -1,0 +1,265 @@
+/**
+ * CardRenderer — RunState → CardKit 2.0 卡片 JSON 的纯函数渲染器
+ *
+ * 参考 Proma 的 card-renderer-v2.ts：
+ * - streaming_mode 标志告诉飞书这是动态卡
+ * - 工具调用 >= 3 时合并为摘要面板
+ * - 底部 summary 是手机端通知预览的短文本
+ * - 可折叠面板展示工具输入输出
+ */
+
+import type { Block, FooterStatus, RunState, ToolEntry } from "./CardRunState";
+
+const REASONING_MAX = 1500;
+const TEXT_BLOCK_MAX = 20_000;
+const MIN_TOOLS_TO_COLLAPSE = 3;
+const TOOL_BODY_MAX = 4000;
+
+export interface RenderOptions {
+	header?: string;
+	stopHint?: string;
+	showToolCalls?: boolean;
+}
+
+interface ToolGroup { kind: "tools"; tools: ToolEntry[] }
+interface TextGroup { kind: "text"; content: string }
+type Group = ToolGroup | TextGroup;
+
+export function renderRunCard(state: RunState, opts: RenderOptions = {}): object {
+	const showToolCalls = opts.showToolCalls !== false;
+	const elements: object[] = [];
+
+	// 思考过程面板
+	if (state.reasoning.content) {
+		elements.push(reasoningPanel(state.reasoning.content, state.reasoning.active));
+	}
+
+	// 内容块
+	const visibleBlocks = showToolCalls
+		? state.blocks
+		: state.blocks.filter((b) => b.kind !== "tool");
+
+	for (const group of groupBlocks(visibleBlocks)) {
+		if (group.kind === "text") {
+			if (group.content.trim()) {
+				elements.push(markdown(truncate(group.content, TEXT_BLOCK_MAX)));
+			}
+		} else {
+			elements.push(...renderToolGroup(group.tools, state.terminal !== "running"));
+		}
+	}
+
+	// 终态标记
+	if (state.terminal === "interrupted") {
+		elements.push(noteMd("_已被中断_"));
+	} else if (state.terminal === "error" && state.errorMsg) {
+		elements.push(noteMd(`❌ Agent 失败：${state.errorMsg}`));
+	} else if (state.terminal === "done" && elements.length === 0) {
+		elements.push(noteMd("_（Agent 未返回内容）_"));
+	}
+
+	// 运行中：显示 footer + 停止提示
+	if (state.terminal === "running") {
+		if (state.footer) elements.push(footerStatus(state.footer, state.blocks));
+		if (opts.stopHint) elements.push(noteMd(opts.stopHint));
+	} else {
+		// 完成后：显示耗时等 meta
+		elements.push(metaFooter(state));
+	}
+
+	const card: Record<string, unknown> = {
+		schema: "2.0",
+		config: {
+			streaming_mode: state.terminal === "running",
+			summary: { content: summaryText(state) },
+		},
+		body: { elements },
+	};
+
+	if (opts.header) {
+		card.header = {
+			title: { tag: "plain_text", content: opts.header },
+			template: state.terminal === "error" ? "red" : state.terminal === "running" ? "blue" : "default",
+		};
+	}
+
+	return card;
+}
+
+function* groupBlocks(blocks: Block[]): Generator<Group> {
+	let toolBuf: ToolEntry[] = [];
+	for (const b of blocks) {
+		if (b.kind === "tool") {
+			toolBuf.push(b.tool);
+		} else {
+			if (toolBuf.length > 0) {
+				yield { kind: "tools", tools: toolBuf };
+				toolBuf = [];
+			}
+			yield { kind: "text", content: b.content };
+		}
+	}
+	if (toolBuf.length > 0) yield { kind: "tools", tools: toolBuf };
+}
+
+function renderToolGroup(tools: ToolEntry[], finalized: boolean): object[] {
+	if (tools.length === 0) return [];
+	if (tools.length < MIN_TOOLS_TO_COLLAPSE) {
+		return tools.map((t) => toolPanel(t));
+	}
+	if (finalized) {
+		return [toolSummaryPanel(tools, true)];
+	}
+	// 运行期：已完成的合并成摘要，最新的单独
+	const prior = tools.slice(0, -1);
+	const latest = tools[tools.length - 1];
+	const out: object[] = [];
+	if (prior.length > 0) out.push(toolSummaryPanel(prior, false));
+	if (latest) out.push(toolPanel(latest));
+	return out;
+}
+
+function reasoningPanel(content: string, active: boolean): object {
+	const title = active ? "**🧠 思考中...**" : "**💭 思考完成（点击查看）**";
+	return collapsiblePanel({
+		title,
+		expanded: active,
+		border: "grey",
+		body: truncate(content, REASONING_MAX),
+	});
+}
+
+function toolPanel(tool: ToolEntry): object {
+	return collapsiblePanel({
+		title: toolHeaderText(tool),
+		expanded: false,
+		border: tool.status === "error" ? "red" : "grey",
+		body: toolBodyMd(tool) || "_无输出_",
+	});
+}
+
+function toolSummaryPanel(tools: ToolEntry[], finalized: boolean): object {
+	const suffix = finalized ? "（已结束）" : "";
+	const title = `**${tools.length} 个工具调用${suffix}**`;
+	const headerList = tools.map((t) => `- ${toolHeaderText(t)}`).join("\n");
+	return {
+		tag: "collapsible_panel",
+		expanded: false,
+		header: panelHeader(title),
+		border: { color: "blue", corner_radius: "5px" },
+		vertical_spacing: "8px",
+		padding: "8px 8px 8px 8px",
+		elements: [{ tag: "markdown", content: headerList, text_size: "notation" }],
+	};
+}
+
+function collapsiblePanel(opts: { title: string; expanded: boolean; border: "grey" | "red" | "blue"; body: string }): object {
+	return {
+		tag: "collapsible_panel",
+		expanded: opts.expanded,
+		header: panelHeader(opts.title),
+		border: { color: opts.border, corner_radius: "5px" },
+		vertical_spacing: "8px",
+		padding: "8px 8px 8px 8px",
+		elements: [{ tag: "markdown", content: opts.body, text_size: "notation" }],
+	};
+}
+
+function panelHeader(titleMd: string): object {
+	return {
+		title: { tag: "markdown", content: titleMd },
+		vertical_align: "center",
+		icon: { tag: "standard_icon", token: "down-small-ccm_outlined", size: "16px 16px" },
+		icon_position: "follow_text",
+		icon_expanded_angle: -180,
+	};
+}
+
+function markdown(content: string): object {
+	return { tag: "markdown", content };
+}
+
+function noteMd(content: string): object {
+	return { tag: "markdown", content, text_size: "notation" };
+}
+
+function footerStatus(status: Exclude<FooterStatus, null>, blocks: Block[]): object {
+	if (status === "thinking") return noteMd("🧠 正在思考...");
+	if (status === "streaming") return noteMd("✍️ 正在输出...");
+	// tool_running
+	const runningTool = [...blocks].reverse().find(
+		(b) => b.kind === "tool" && b.tool.status === "running",
+	);
+	if (runningTool && runningTool.kind === "tool") {
+		return noteMd(`🔧 正在调用 \`${runningTool.tool.name}\``);
+	}
+	return noteMd("🔧 正在调用工具...");
+}
+
+function metaFooter(state: RunState): object {
+	const parts: string[] = [];
+	if (state.meta.durationMs !== undefined) {
+		parts.push(`⏱ ${(state.meta.durationMs / 1000).toFixed(1)}s`);
+	}
+	if (state.meta.model) {
+		parts.push(state.meta.model);
+	}
+	return noteMd(parts.length > 0 ? parts.join("  ·  ") : "✅ 已完成");
+}
+
+function summaryText(state: RunState): string {
+	if (state.terminal === "interrupted") return "已中断";
+	if (state.terminal === "error") return "出错";
+	if (state.terminal === "done") return "已完成";
+	if (state.footer === "tool_running") {
+		const runningTool = [...state.blocks].reverse().find(
+			(b) => b.kind === "tool" && b.tool.status === "running",
+		);
+		if (runningTool && runningTool.kind === "tool") return `正在调用 ${runningTool.tool.name}`;
+		return "正在调用工具";
+	}
+	if (state.footer === "streaming") return "正在输出";
+	if (state.footer === "thinking") return "思考中";
+	return "处理中";
+}
+
+function truncate(s: string, max: number): string {
+	return s.length > max ? `${s.slice(0, max)}…（已截断）` : s;
+}
+
+function toolHeaderText(tool: ToolEntry): string {
+	const icon = tool.status === "error" ? "❌" : tool.status === "done" ? "✅" : "🔄";
+	const name = tool.name;
+	const summary = toolInputSummary(tool);
+	const summaryPart = summary ? ` \`${summary}\`` : "";
+	return `${icon} **${name}**${summaryPart}`;
+}
+
+function toolInputSummary(tool: ToolEntry): string {
+	const input = tool.input;
+	if (!input || typeof input !== "object") return "";
+	const obj = input as Record<string, unknown>;
+	if (typeof obj.command === "string") return clip(obj.command, 80);
+	if (typeof obj.file_path === "string") return clip(obj.file_path, 80);
+	if (typeof obj.path === "string") return clip(obj.path, 80);
+	if (typeof obj.pattern === "string") return clip(obj.pattern, 80);
+	return "";
+}
+
+function toolBodyMd(tool: ToolEntry): string {
+	const parts: string[] = [];
+	if (tool.input && typeof tool.input === "object") {
+		try {
+			const inputStr = JSON.stringify(tool.input, null, 2);
+			parts.push("**Input**\n```json\n" + truncate(inputStr, 1500) + "\n```");
+		} catch { /* ignore */ }
+	}
+	if (tool.output) {
+		parts.push("**Output**\n```\n" + truncate(tool.output, TOOL_BODY_MAX) + "\n```");
+	}
+	return parts.join("\n\n");
+}
+
+function clip(s: string, max: number): string {
+	return s.length <= max ? s : s.slice(0, max) + "…";
+}

--- a/src/main/feishu/CardRunState.ts
+++ b/src/main/feishu/CardRunState.ts
@@ -1,0 +1,213 @@
+/**
+ * CardRunState — 飞书流式卡片的运行时状态机
+ *
+ * 参考 Proma 的 card-run-state.ts 实现。
+ * 把 AgentManager 的事件累积成结构化的 RunState，
+ * 便于渲染层无时序地把状态转成 CardKit 2.0 JSON。
+ *
+ * 所有 reducer 是纯函数：reduce(state, event) → state。
+ */
+
+export type ToolStatus = "running" | "done" | "error";
+
+export interface ToolEntry {
+	id: string;
+	name: string;
+	input?: unknown;
+	status: ToolStatus;
+	output?: string;
+}
+
+export type Block =
+	| { kind: "text"; content: string; streaming: boolean }
+	| { kind: "tool"; tool: ToolEntry };
+
+export type FooterStatus = "thinking" | "tool_running" | "streaming" | null;
+
+export type Terminal = "running" | "done" | "interrupted" | "error";
+
+export interface RunState {
+	blocks: Block[];
+	reasoning: { content: string; active: boolean };
+	footer: FooterStatus;
+	terminal: Terminal;
+	errorMsg?: string;
+	startedAt: number;
+	meta: {
+		durationMs?: number;
+		model?: string;
+	};
+}
+
+export function createInitialState(): RunState {
+	return {
+		blocks: [],
+		reasoning: { content: "", active: false },
+		footer: "thinking",
+		terminal: "running",
+		startedAt: Date.now(),
+		meta: {},
+	};
+}
+
+/** 从 AgentManager 事件 reduce 状态 */
+export function reduceFromPiEvent(state: RunState, event: Record<string, unknown>): RunState {
+	switch (event.type) {
+		case "agent_start":
+			return { ...state, footer: "thinking" };
+
+		case "message_start": {
+			const msg = event.message as Record<string, unknown> | undefined;
+			if (msg?.role === "assistant") {
+				return appendText(state, "");
+			}
+			return state;
+		}
+
+		case "message_update": {
+			const assistantEvent = event.assistantMessageEvent as Record<string, unknown> | undefined;
+			if (!assistantEvent) return state;
+
+			if (assistantEvent.type === "text_delta") {
+				const text = (assistantEvent as { text?: string }).text ?? "";
+				if (text) return appendText(state, text);
+			}
+			if (assistantEvent.type === "thinking_delta") {
+				const thinking = (assistantEvent as { thinking?: string }).thinking ?? "";
+				if (thinking) return appendThinking(state, thinking);
+			}
+			if (assistantEvent.type === "toolcall_start") {
+				const toolCall = (assistantEvent as { toolCall?: Record<string, unknown> }).toolCall;
+				if (toolCall && typeof toolCall.id === "string" && typeof toolCall.name === "string") {
+					return startTool(state, toolCall.id, toolCall.name, toolCall.input);
+				}
+			}
+			if (assistantEvent.type === "toolcall_end") {
+				const toolCall = (assistantEvent as { toolCall?: Record<string, unknown> }).toolCall;
+				if (toolCall && typeof toolCall.id === "string") {
+					return completeTool(state, toolCall.id, "", toolCall.isError === true);
+				}
+			}
+			if (assistantEvent.type === "done") {
+				return { ...state, footer: null };
+			}
+			return state;
+		}
+
+		case "tool_execution_start": {
+			const toolName = typeof event.toolName === "string" ? event.toolName : "tool";
+			const toolId = `tool_${toolName}_${Date.now()}`;
+			return startTool(state, toolId, toolName, event.args);
+		}
+
+		case "tool_execution_end": {
+			const toolName = typeof event.toolName === "string" ? event.toolName : "tool";
+			// 找到最近的同名 running tool
+			const toolBlock = [...state.blocks].reverse().find(
+				(b) => b.kind === "tool" && b.tool.name === toolName && b.tool.status === "running",
+			);
+			if (toolBlock && toolBlock.kind === "tool") {
+				return completeTool(state, toolBlock.tool.id, "", event.isError === true);
+			}
+			return state;
+		}
+
+		case "agent_end": {
+			if (event.stopReason === "error" || event.error) {
+				return markError(state, String(event.error || event.errorMessage || "Agent 运行出错"));
+			}
+			return markDone(state);
+		}
+
+		default:
+			return state;
+	}
+}
+
+// ===== 内部 reducer =====
+
+function closeStreamingText(blocks: Block[]): Block[] {
+	return blocks.map((b) =>
+		b.kind === "text" && b.streaming ? { ...b, streaming: false } : b,
+	);
+}
+
+function appendText(state: RunState, delta: string): RunState {
+	const last = state.blocks[state.blocks.length - 1];
+	if (last && last.kind === "text" && last.streaming) {
+		const next: Block = { ...last, content: last.content + delta };
+		return {
+			...state,
+			blocks: [...state.blocks.slice(0, -1), next],
+			reasoning: { ...state.reasoning, active: false },
+			footer: "streaming",
+		};
+	}
+	return {
+		...state,
+		blocks: [...closeStreamingText(state.blocks), { kind: "text", content: delta, streaming: true }],
+		reasoning: { ...state.reasoning, active: false },
+		footer: delta ? "streaming" : "thinking",
+	};
+}
+
+function appendThinking(state: RunState, delta: string): RunState {
+	return {
+		...state,
+		reasoning: { content: state.reasoning.content + delta, active: true },
+		footer: "thinking",
+	};
+}
+
+function startTool(state: RunState, id: string, name: string, input?: unknown): RunState {
+	const tool: ToolEntry = { id, name, input, status: "running" };
+	return {
+		...state,
+		blocks: [...closeStreamingText(state.blocks), { kind: "tool", tool }],
+		reasoning: { ...state.reasoning, active: false },
+		footer: "tool_running",
+	};
+}
+
+function completeTool(state: RunState, id: string, output: string, isError: boolean): RunState {
+	const blocks = state.blocks.map((b) => {
+		if (b.kind !== "tool" || b.tool.id !== id) return b;
+		return {
+			...b,
+			tool: { ...b.tool, status: isError ? ("error" as const) : ("done" as const), output },
+		};
+	});
+	return { ...state, blocks };
+}
+
+export function markDone(state: RunState): RunState {
+	return {
+		...state,
+		blocks: closeStreamingText(state.blocks),
+		reasoning: { ...state.reasoning, active: false },
+		terminal: "done",
+		footer: null,
+		meta: { ...state.meta, durationMs: Date.now() - state.startedAt },
+	};
+}
+
+export function markInterrupted(state: RunState): RunState {
+	return {
+		...state,
+		blocks: closeStreamingText(state.blocks),
+		reasoning: { ...state.reasoning, active: false },
+		terminal: "interrupted",
+		footer: null,
+	};
+}
+
+export function markError(state: RunState, message: string): RunState {
+	return {
+		...state,
+		blocks: closeStreamingText(state.blocks),
+		reasoning: { ...state.reasoning, active: false },
+		terminal: "error",
+		footer: null,
+		errorMsg: message,
+	};
+}

--- a/src/main/feishu/CardRunState.ts
+++ b/src/main/feishu/CardRunState.ts
@@ -136,11 +136,13 @@ export function reduceFromPiEvent(state: RunState, event: Record<string, unknown
 			if (!assistantEvent) return state;
 
 			if (assistantEvent.type === "text_delta") {
-				const text = (assistantEvent as { text?: string }).text ?? "";
+				// AgentManager 发出的字段是 delta，兼容 delta 和 text 两种格式
+				const text = (assistantEvent as { delta?: string; text?: string }).delta ?? (assistantEvent as { text?: string }).text ?? "";
 				if (text) return appendText(state, text);
 			}
 			if (assistantEvent.type === "thinking_delta") {
-				const thinking = (assistantEvent as { thinking?: string }).thinking ?? "";
+				// AgentManager 发出的字段是 delta，兼容 delta 和 thinking 两种格式
+				const thinking = (assistantEvent as { delta?: string; thinking?: string }).delta ?? (assistantEvent as { thinking?: string }).thinking ?? "";
 				if (thinking) return appendThinking(state, thinking);
 			}
 			if (assistantEvent.type === "toolcall_start") {

--- a/src/main/feishu/CardRunState.ts
+++ b/src/main/feishu/CardRunState.ts
@@ -1,9 +1,13 @@
 /**
- * CardRunState — 飞书流式卡片的运行时状态机
+ * CardRunState — 飞书流式卡片的运行时状态机 v2
  *
  * 参考 Proma 的 card-run-state.ts 实现。
  * 把 AgentManager 的事件累积成结构化的 RunState，
  * 便于渲染层无时序地把状态转成 CardKit 2.0 JSON。
+ *
+ * v2 新增：
+ * - trail：活动轨迹（Agent 每一步操作的时间线日志）
+ * - outputText：assistant 累积输出文本（用于流式渲染输出区域）
  *
  * 所有 reducer 是纯函数：reduce(state, event) → state。
  */
@@ -26,6 +30,16 @@ export type FooterStatus = "thinking" | "tool_running" | "streaming" | null;
 
 export type Terminal = "running" | "done" | "interrupted" | "error";
 
+/** 活动轨迹条目 */
+export interface TrailEntry {
+	id: string;
+	timestamp: number;
+	type: "agent" | "tool" | "compaction" | "retry" | "error" | "info";
+	text: string;
+	detail?: string;
+	status: "running" | "done" | "error";
+}
+
 export interface RunState {
 	blocks: Block[];
 	reasoning: { content: string; active: boolean };
@@ -37,7 +51,14 @@ export interface RunState {
 		durationMs?: number;
 		model?: string;
 	};
+	/** 活动轨迹：Agent 每一步操作的时间线 */
+	trail: TrailEntry[];
+	/** assistant 累积输出文本 */
+	outputText: string;
 }
+
+let _trailSeq = 0;
+function nextTrailId(): string { return `trail_${Date.now()}_${++_trailSeq}`; }
 
 export function createInitialState(): RunState {
 	return {
@@ -47,14 +68,60 @@ export function createInitialState(): RunState {
 		terminal: "running",
 		startedAt: Date.now(),
 		meta: {},
+		trail: [],
+		outputText: "",
 	};
 }
+
+// ===== Trail helpers =====
+
+function addTrail(state: RunState, type: TrailEntry["type"], text: string, status: TrailEntry["status"] = "running", detail?: string): RunState {
+	const entry: TrailEntry = { id: nextTrailId(), timestamp: Date.now(), type, text, status, detail };
+	return { ...state, trail: [...state.trail, entry] };
+}
+
+function updateLastTrailStatus(state: RunState, status: TrailEntry["status"], detail?: string): RunState {
+	if (state.trail.length === 0) return state;
+	const last = state.trail[state.trail.length - 1];
+	if (last.status === status) return state;
+	const updated: TrailEntry = { ...last, status, ...(detail ? { detail } : {}) };
+	return { ...state, trail: [...state.trail.slice(0, -1), updated] };
+}
+
+/** 按文本匹配更新最后一条匹配条目的状态 */
+function updateLastTrailByText(state: RunState, text: string, status: TrailEntry["status"], newText?: string): RunState {
+	for (let i = state.trail.length - 1; i >= 0; i--) {
+		if (state.trail[i].text === text && state.trail[i].status === "running") {
+			const updated: TrailEntry = { ...state.trail[i], status, text: newText ?? state.trail[i].text };
+			const trail = [...state.trail];
+			trail[i] = updated;
+			return { ...state, trail };
+		}
+	}
+	return state;
+}
+
+function finalizeAllTrail(state: RunState): RunState {
+	const trail = state.trail.map((t) => t.status === "running" ? { ...t, status: "done" as const } : t);
+	return { ...state, trail };
+}
+
+// ===== 主 reducer =====
 
 /** 从 AgentManager 事件 reduce 状态 */
 export function reduceFromPiEvent(state: RunState, event: Record<string, unknown>): RunState {
 	switch (event.type) {
 		case "agent_start":
-			return { ...state, footer: "thinking" };
+			return addTrail(
+				{ ...state, footer: "thinking" },
+				"agent", "agent 启动", "done",
+			);
+
+		case "turn_start": {
+			// 内部计数：统计已有轮次数 + 1
+			const turnCount = state.trail.filter((t) => t.type === "agent" && t.text.includes("轮对话")).length + 1;
+			return addTrail(state, "agent", `第 ${turnCount} 轮对话`, "running");
+		}
 
 		case "message_start": {
 			const msg = event.message as Record<string, unknown> | undefined;
@@ -79,13 +146,13 @@ export function reduceFromPiEvent(state: RunState, event: Record<string, unknown
 			if (assistantEvent.type === "toolcall_start") {
 				const toolCall = (assistantEvent as { toolCall?: Record<string, unknown> }).toolCall;
 				if (toolCall && typeof toolCall.id === "string" && typeof toolCall.name === "string") {
-					return startTool(state, toolCall.id, toolCall.name, toolCall.input);
+					return startToolInState(state, toolCall.id, toolCall.name, toolCall.input as Record<string, unknown> | undefined);
 				}
 			}
 			if (assistantEvent.type === "toolcall_end") {
 				const toolCall = (assistantEvent as { toolCall?: Record<string, unknown> }).toolCall;
 				if (toolCall && typeof toolCall.id === "string") {
-					return completeTool(state, toolCall.id, "", toolCall.isError === true);
+					return completeToolInState(state, toolCall.id, toolCall.isError === true);
 				}
 			}
 			if (assistantEvent.type === "done") {
@@ -97,7 +164,7 @@ export function reduceFromPiEvent(state: RunState, event: Record<string, unknown
 		case "tool_execution_start": {
 			const toolName = typeof event.toolName === "string" ? event.toolName : "tool";
 			const toolId = `tool_${toolName}_${Date.now()}`;
-			return startTool(state, toolId, toolName, event.args);
+			return startToolInState(state, toolId, toolName, event.args as Record<string, unknown> | undefined);
 		}
 
 		case "tool_execution_end": {
@@ -107,16 +174,31 @@ export function reduceFromPiEvent(state: RunState, event: Record<string, unknown
 				(b) => b.kind === "tool" && b.tool.name === toolName && b.tool.status === "running",
 			);
 			if (toolBlock && toolBlock.kind === "tool") {
-				return completeTool(state, toolBlock.tool.id, "", event.isError === true);
+				return completeToolInState(state, toolBlock.tool.id, event.isError === true);
 			}
 			return state;
 		}
 
+		case "compaction_start": {
+			const reason = typeof event.reason === "string" ? event.reason : "";
+			return addTrail(state, "compaction", `上下文压缩${reason ? ": " + reason : ""}`, "running");
+		}
+
+		case "auto_retry_start": {
+			const attempt = typeof event.attempt === "number" ? event.attempt : "?";
+			const max = typeof event.maxAttempts === "number" ? event.maxAttempts : "?";
+			return addTrail(state, "retry", `自动重试: ${attempt}/${max}`, "running");
+		}
+
+		case "auto_retry_end": {
+			return updateLastTrailStatus(state, event.success === false ? "error" : "done");
+		}
+
 		case "agent_end": {
 			if (event.stopReason === "error" || event.error) {
-				return markError(state, String(event.error || event.errorMessage || "Agent 运行出错"));
+				return markError(finalizeAllTrail(state), String(event.error || event.errorMessage || "Agent 运行出错"));
 			}
-			return markDone(state);
+			return markDone(finalizeAllTrail(state));
 		}
 
 		default:
@@ -134,51 +216,109 @@ function closeStreamingText(blocks: Block[]): Block[] {
 
 function appendText(state: RunState, delta: string): RunState {
 	const last = state.blocks[state.blocks.length - 1];
+	const newOutputText = state.outputText + delta;
+	const isFirstOutput = state.outputText.length === 0 && delta.length > 0;
+
+	let next: RunState;
 	if (last && last.kind === "text" && last.streaming) {
-		const next: Block = { ...last, content: last.content + delta };
-		return {
+		const nextBlock: Block = { ...last, content: last.content + delta };
+		next = {
 			...state,
-			blocks: [...state.blocks.slice(0, -1), next],
+			blocks: [...state.blocks.slice(0, -1), nextBlock],
 			reasoning: { ...state.reasoning, active: false },
 			footer: "streaming",
+			outputText: newOutputText,
+		};
+	} else {
+		next = {
+			...state,
+			blocks: [...closeStreamingText(state.blocks), { kind: "text", content: delta, streaming: true }],
+			reasoning: { ...state.reasoning, active: false },
+			footer: delta ? "streaming" : "thinking",
+			outputText: newOutputText,
 		};
 	}
-	return {
-		...state,
-		blocks: [...closeStreamingText(state.blocks), { kind: "text", content: delta, streaming: true }],
-		reasoning: { ...state.reasoning, active: false },
-		footer: delta ? "streaming" : "thinking",
-	};
+
+	// 首次输出时：标记思考完成 + 添加输出轨迹
+	if (isFirstOutput) {
+		next = addTrail(next, "agent", "开始输出", "running");
+		// 标记上一个"开始思考"为完成
+		next = updateLastTrailByText(next, "开始思考", "done", "思考完成");
+	}
+	return next;
 }
 
 function appendThinking(state: RunState, delta: string): RunState {
-	return {
+	const isFirstThinking = state.reasoning.content.length === 0;
+	const next = {
 		...state,
 		reasoning: { content: state.reasoning.content + delta, active: true },
-		footer: "thinking",
+		footer: "thinking" as FooterStatus,
 	};
+	// 第一次思考时追加轨迹条目
+	if (isFirstThinking) {
+		return addTrail(next, "agent", "开始思考", "running");
+	}
+	return next;
 }
 
-function startTool(state: RunState, id: string, name: string, input?: unknown): RunState {
+function startToolInState(state: RunState, id: string, name: string, input?: Record<string, unknown>): RunState {
+	const detail = toolInputSummary(name, input);
 	const tool: ToolEntry = { id, name, input, status: "running" };
-	return {
-		...state,
-		blocks: [...closeStreamingText(state.blocks), { kind: "tool", tool }],
-		reasoning: { ...state.reasoning, active: false },
-		footer: "tool_running",
-	};
+	return addTrail(
+		{
+			...state,
+			blocks: [...closeStreamingText(state.blocks), { kind: "tool", tool }],
+			reasoning: { ...state.reasoning, active: false },
+			footer: "tool_running",
+		},
+		"tool",
+		`工具调用: ${name}`,
+		"running",
+		detail,
+	);
 }
 
-function completeTool(state: RunState, id: string, output: string, isError: boolean): RunState {
+function completeToolInState(state: RunState, id: string, isError: boolean): RunState {
 	const blocks = state.blocks.map((b) => {
 		if (b.kind !== "tool" || b.tool.id !== id) return b;
 		return {
 			...b,
-			tool: { ...b.tool, status: isError ? ("error" as const) : ("done" as const), output },
+			tool: { ...b.tool, status: isError ? ("error" as const) : ("done" as const) as ToolStatus },
 		};
 	});
-	return { ...state, blocks };
+	// 也更新 trail 中最后一个对应状态的 tool
+	const trail = state.trail.map((t, i) => {
+		if (t.type === "tool" && t.status === "running" && i === lastRunningToolIndex(state.trail)) {
+			return { ...t, status: isError ? ("error" as const) : ("done" as const), text: t.text.replace("工具调用", isError ? "工具失败" : "工具完成") };
+		}
+		return t;
+	});
+	return { ...state, blocks, trail };
 }
+
+function lastRunningToolIndex(trail: TrailEntry[]): number {
+	for (let i = trail.length - 1; i >= 0; i--) {
+		if (trail[i].type === "tool" && trail[i].status === "running") return i;
+	}
+	return -1;
+}
+
+function toolInputSummary(name: string, input: Record<string, unknown> | undefined): string | undefined {
+	if (!input) return undefined;
+	if (name === "read" && typeof input.filePath === "string") return truncate(input.filePath, 80);
+	if (name === "bash" && typeof input.command === "string") return truncate(input.command, 80);
+	if (name === "write" && typeof input.filePath === "string") return truncate(input.filePath, 80);
+	if (name === "edit" && typeof input.filePath === "string") return truncate(input.filePath, 80);
+	if (name === "grep" && typeof input.pattern === "string") return truncate(input.pattern, 80);
+	return undefined;
+}
+
+function truncate(s: string, max: number): string {
+	return s.length <= max ? s : s.slice(0, max) + "…";
+}
+
+// ===== 终态标记 =====
 
 export function markDone(state: RunState): RunState {
 	return {

--- a/src/main/feishu/CardStream.ts
+++ b/src/main/feishu/CardStream.ts
@@ -1,0 +1,168 @@
+/**
+ * CardStream — 飞书 CardKit 2.0 流式卡片
+ *
+ * 参考 Proma 的 CardStream 实现：
+ * 1. 先用 cardkit.v1.card.create 创建卡片模板
+ * 2. 再用 im.message.create/reply 发送卡片消息
+ * 3. 后续更新用 cardkit.v1.card.update + sequence 递增
+ * 4. 400ms 节流，终态强制 flush
+ *
+ * 这比 TaskStatusCard 的 im.v1.message.patch 方式更流畅，
+ * 因为 CardKit 2.0 支持增量更新，不需要每次发送完整卡片。
+ */
+
+import type { LarkClient } from "./types";
+
+const THROTTLE_MS = 400;
+const MAX_UPDATE_RETRIES = 2;
+
+export class CardStream {
+	private sequence = 1;
+	private pendingCard: object | null = null;
+	private pendingTimer: NodeJS.Timeout | null = null;
+	private inFlight: Promise<void> | null = null;
+	private closed = false;
+
+	private constructor(
+		private readonly client: LarkClient,
+		private readonly cardId: string,
+		public readonly messageId: string,
+		public readonly chatId: string,
+	) {}
+
+	/**
+	 * 创建 CardKit 2.0 卡片实例并发送到指定 chat。
+	 * 返回的 CardStream 持有 card_id 和 message_id，后续可继续 update。
+	 */
+	static async open(
+		client: LarkClient,
+		chatId: string,
+		initialCard: object,
+		opts: { replyToMessageId?: string } = {},
+	): Promise<CardStream> {
+		// 1. 创建卡片模板
+		const createResp = await client.request<{
+			code?: number;
+			data?: { card_id?: string };
+			msg?: string;
+		}>({
+			method: "POST",
+			url: "https://open.feishu.cn/open-apis/cardkit/v1/card",
+			data: { type: "card_json", data: JSON.stringify(initialCard) },
+		});
+
+		const cardId = createResp.data?.card_id;
+		if (!cardId) {
+			throw new Error(`cardkit.card.create 未返回 card_id: ${JSON.stringify(createResp).slice(0, 200)}`);
+		}
+
+		// 2. 发送卡片消息
+		const content = JSON.stringify({ type: "card", data: { card_id: cardId } });
+		let messageId: string | undefined;
+
+		if (opts.replyToMessageId) {
+			const sent = await client.im.message.reply({
+				path: { message_id: opts.replyToMessageId },
+				data: { msg_type: "interactive", content },
+			});
+			messageId = (sent as { data?: { message_id?: string } })?.data?.message_id;
+		} else {
+			const sent = await client.im.message.create({
+				params: { receive_id_type: "chat_id" },
+				data: { receive_id: chatId, msg_type: "interactive", content },
+			});
+			messageId = (sent as { data?: { message_id?: string } })?.data?.message_id;
+		}
+
+		if (!messageId) {
+			throw new Error("发送 card 消息未返回 message_id");
+		}
+
+		return new CardStream(client, cardId, messageId, chatId);
+	}
+
+	/** 排队一次更新，实际请求会在 THROTTLE_MS 后合并发送 */
+	update(card: object): void {
+		if (this.closed) return;
+		this.pendingCard = card;
+		this.scheduleFlush();
+	}
+
+	/** 立刻刷新到最新 pending 卡片，终态必调 */
+	async flush(card?: object): Promise<void> {
+		if (this.closed) return;
+		if (card) this.pendingCard = card;
+		if (this.pendingTimer) {
+			clearTimeout(this.pendingTimer);
+			this.pendingTimer = null;
+		}
+		await this.drain();
+	}
+
+	/** 关闭，禁止后续更新 */
+	async close(): Promise<void> {
+		this.closed = true;
+		if (this.pendingTimer) {
+			clearTimeout(this.pendingTimer);
+			this.pendingTimer = null;
+		}
+		if (this.inFlight) {
+			await this.inFlight.catch(() => {});
+		}
+	}
+
+	private scheduleFlush(): void {
+		if (this.pendingTimer || this.inFlight) return;
+		this.pendingTimer = setTimeout(() => {
+			this.pendingTimer = null;
+			void this.drain();
+		}, THROTTLE_MS);
+		this.pendingTimer.unref?.();
+	}
+
+	private async drain(): Promise<void> {
+		if (this.inFlight) {
+			await this.inFlight.catch(() => {});
+		}
+		if (!this.pendingCard || this.closed) return;
+
+		const card = this.pendingCard;
+		this.pendingCard = null;
+		const seq = this.sequence++;
+
+		this.inFlight = this.sendUpdate(card, seq).finally(() => {
+			this.inFlight = null;
+			if (this.pendingCard && !this.closed) {
+				this.scheduleFlush();
+			}
+		});
+		await this.inFlight;
+	}
+
+	private async sendUpdate(card: object, sequence: number): Promise<void> {
+		let attempt = 0;
+		while (true) {
+			try {
+				await this.client.request({
+					method: "PUT",
+					url: `https://open.feishu.cn/open-apis/cardkit/v1/card/${this.cardId}`,
+					data: {
+						card: { type: "card_json", data: JSON.stringify(card) },
+						sequence,
+					},
+				});
+				return;
+			} catch (err) {
+				attempt++;
+				if (attempt > MAX_UPDATE_RETRIES) {
+					console.error("[飞书 CardStream] cardkit.card.update 失败（已达最大重试）", {
+						cardId: this.cardId, sequence,
+						err: err instanceof Error ? err.message : String(err),
+					});
+					return;
+				}
+				await new Promise((r) => setTimeout(r, 200 * attempt));
+			}
+		}
+	}
+}

--- a/src/main/feishu/CardStream.ts
+++ b/src/main/feishu/CardStream.ts
@@ -1,23 +1,22 @@
 /**
- * CardStream — 飞书 CardKit 2.0 流式卡片
+ * CardStream — 飞书流式卡片（简化版 v2）
  *
- * 参考 Proma 的 CardStream 实现：
- * 1. 先用 cardkit.v1.card.create 创建卡片模板
- * 2. 再用 im.message.create/reply 发送卡片消息
- * 3. 后续更新用 cardkit.v1.card.update + sequence 递增
- * 4. 400ms 节流，终态强制 flush
+ * 放弃 CardKit 2.0 的 cardkit.v1.card.create + cardkit.v1.card.update，
+ * 改用 Proma/pi-feishu-lark 的 im.v1.message.patch 方式：
  *
- * 这比 TaskStatusCard 的 im.v1.message.patch 方式更流畅，
- * 因为 CardKit 2.0 支持增量更新，不需要每次发送完整卡片。
+ * 1. im.message.create/reply 发送初始卡片（含 update_multi: true）
+ * 2. im.v1.message.patch 原子替换卡片内容
+ * 3. 200ms 节流，终态强制 flush
+ *
+ * 每次 patch 飞书都会立即重新渲染卡片，视觉上是真正的"流式"效果。
  */
 
 import type { LarkClient } from "./types";
 
-const THROTTLE_MS = 400;
+const THROTTLE_MS = 200;
 const MAX_UPDATE_RETRIES = 2;
 
 export class CardStream {
-	private sequence = 1;
 	private pendingCard: object | null = null;
 	private pendingTimer: NodeJS.Timeout | null = null;
 	private inFlight: Promise<void> | null = null;
@@ -25,14 +24,13 @@ export class CardStream {
 
 	private constructor(
 		private readonly client: LarkClient,
-		private readonly cardId: string,
 		public readonly messageId: string,
 		public readonly chatId: string,
 	) {}
 
 	/**
-	 * 创建 CardKit 2.0 卡片实例并发送到指定 chat。
-	 * 返回的 CardStream 持有 card_id 和 message_id，后续可继续 update。
+	 * 发送初始卡片并返回 CardStream。
+	 * 只调用一次 im.message.create/reply，后续更新用 im.v1.message.patch。
 	 */
 	static async open(
 		client: LarkClient,
@@ -40,45 +38,27 @@ export class CardStream {
 		initialCard: object,
 		opts: { replyToMessageId?: string } = {},
 	): Promise<CardStream> {
-		// 1. 创建卡片模板
-		const createResp = await client.request<{
-			code?: number;
-			data?: { card_id?: string };
-			msg?: string;
-		}>({
-			method: "POST",
-			url: "https://open.feishu.cn/open-apis/cardkit/v1/card",
-			data: { type: "card_json", data: JSON.stringify(initialCard) },
-		});
-
-		const cardId = createResp.data?.card_id;
-		if (!cardId) {
-			throw new Error(`cardkit.card.create 未返回 card_id: ${JSON.stringify(createResp).slice(0, 200)}`);
-		}
-
-		// 2. 发送卡片消息
-		const content = JSON.stringify({ type: "card", data: { card_id: cardId } });
 		let messageId: string | undefined;
 
 		if (opts.replyToMessageId) {
 			const sent = await client.im.message.reply({
 				path: { message_id: opts.replyToMessageId },
-				data: { msg_type: "interactive", content },
+				data: { msg_type: "interactive", content: JSON.stringify(initialCard) },
 			});
 			messageId = (sent as { data?: { message_id?: string } })?.data?.message_id;
 		} else {
 			const sent = await client.im.message.create({
 				params: { receive_id_type: "chat_id" },
-				data: { receive_id: chatId, msg_type: "interactive", content },
+				data: { receive_id: chatId, msg_type: "interactive", content: JSON.stringify(initialCard) },
 			});
 			messageId = (sent as { data?: { message_id?: string } })?.data?.message_id;
 		}
 
 		if (!messageId) {
-			throw new Error("发送 card 消息未返回 message_id");
+			throw new Error("发送卡片消息未返回 message_id");
 		}
 
-		return new CardStream(client, cardId, messageId, chatId);
+		return new CardStream(client, messageId, chatId);
 	}
 
 	/** 排队一次更新，实际请求会在 THROTTLE_MS 后合并发送 */
@@ -128,9 +108,8 @@ export class CardStream {
 
 		const card = this.pendingCard;
 		this.pendingCard = null;
-		const seq = this.sequence++;
 
-		this.inFlight = this.sendUpdate(card, seq).finally(() => {
+		this.inFlight = this.sendUpdate(card).finally(() => {
 			this.inFlight = null;
 			if (this.pendingCard && !this.closed) {
 				this.scheduleFlush();
@@ -139,24 +118,20 @@ export class CardStream {
 		await this.inFlight;
 	}
 
-	private async sendUpdate(card: object, sequence: number): Promise<void> {
+	private async sendUpdate(card: object): Promise<void> {
 		let attempt = 0;
 		while (true) {
 			try {
-				await this.client.request({
-					method: "PUT",
-					url: `https://open.feishu.cn/open-apis/cardkit/v1/card/${this.cardId}`,
-					data: {
-						card: { type: "card_json", data: JSON.stringify(card) },
-						sequence,
-					},
+				await this.client.im.v1.message.patch({
+					path: { message_id: this.messageId },
+					data: { content: JSON.stringify(card) },
 				});
 				return;
 			} catch (err) {
 				attempt++;
 				if (attempt > MAX_UPDATE_RETRIES) {
-					console.error("[飞书 CardStream] cardkit.card.update 失败（已达最大重试）", {
-						cardId: this.cardId, sequence,
+					console.error("[飞书 CardStream] patch 失败（已达最大重试）", {
+						messageId: this.messageId,
 						err: err instanceof Error ? err.message : String(err),
 					});
 					return;

--- a/src/main/feishu/CardStream.ts
+++ b/src/main/feishu/CardStream.ts
@@ -21,6 +21,9 @@ export class CardStream {
 	private pendingTimer: NodeJS.Timeout | null = null;
 	private inFlight: Promise<void> | null = null;
 	private closed = false;
+	/** 最近一次 patch 是否失败（用于上层判断是否需要降级兜底） */
+	public lastPatchFailed = false;
+	public lastPatchError = "";
 
 	private constructor(
 		private readonly client: LarkClient,
@@ -95,7 +98,10 @@ export class CardStream {
 		if (this.pendingTimer || this.inFlight) return;
 		this.pendingTimer = setTimeout(() => {
 			this.pendingTimer = null;
-			void this.drain();
+			this.drain().catch(() => {
+				// 非终态更新失败由 lastPatchFailed 标记记录，
+				// 终态 flush 会走 handleAgentEvent 的显式路径
+			});
 		}, THROTTLE_MS);
 		this.pendingTimer.unref?.();
 	}
@@ -120,22 +126,37 @@ export class CardStream {
 
 	private async sendUpdate(card: object): Promise<void> {
 		let attempt = 0;
+		let lastErr: unknown;
 		while (true) {
 			try {
 				await this.client.im.v1.message.patch({
 					path: { message_id: this.messageId },
 					data: { content: JSON.stringify(card) },
 				});
+				this.lastPatchFailed = false;
+				this.lastPatchError = "";
 				return;
 			} catch (err) {
+				lastErr = err;
 				attempt++;
 				if (attempt > MAX_UPDATE_RETRIES) {
+					const errMsg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+					// 尝试提取飞书 API 错误详情
+					let apiDetail = "";
+					if (lastErr && typeof lastErr === "object" && "code" in (lastErr as Record<string, unknown>)) {
+						const e = lastErr as Record<string, unknown>;
+						apiDetail = ` [API code=${e.code}, msg=${e.msg}]`;
+					}
+					this.lastPatchFailed = true;
+					this.lastPatchError = errMsg + apiDetail;
 					console.error("[飞书 CardStream] patch 失败（已达最大重试）", {
 						messageId: this.messageId,
-						err: err instanceof Error ? err.message : String(err),
+						cardSize: JSON.stringify(card).length,
+						err: errMsg + apiDetail,
 					});
-					return;
+					throw new Error(`CardStream patch 失败: ${errMsg}${apiDetail}`);
 				}
+				console.warn(`[飞书 CardStream] patch 重试 ${attempt}/${MAX_UPDATE_RETRIES}:`, lastErr instanceof Error ? lastErr.message : String(lastErr));
 				await new Promise((r) => setTimeout(r, 200 * attempt));
 			}
 		}

--- a/src/main/feishu/FeishuBridge.ts
+++ b/src/main/feishu/FeishuBridge.ts
@@ -90,6 +90,8 @@ export class FeishuBridge {
 	private streamingCards = new Map<string, CardStream>();
 	// 流式状态：sessionId → RunState
 	private streamingRunStates = new Map<string, RunState>();
+	// 卡片未创建时的缓存事件（并行模式下 Agent 先启动，事件暂存于此）
+	private pendingCardEvents = new Map<string, unknown[]>();
 
 	private unsubscribeLocalEvents: (() => void) | null = null;
 	// 哪些 session 是飞书发起的（不需要 session mirror）
@@ -123,6 +125,7 @@ export class FeishuBridge {
 		this.chatBindings.delete(chatId);
 		this.streamingCards.delete(binding.sessionId);
 		this.streamingRunStates.delete(binding.sessionId);
+		this.pendingCardEvents.delete(binding.sessionId);
 		this.pendingImages.delete(chatId);
 		this.pendingFiles.delete(chatId);
 		this.lastUserMessageId.delete(chatId);
@@ -210,6 +213,7 @@ export class FeishuBridge {
 		for (const [, card] of this.streamingCards) { card.close().catch(() => {}); }
 		this.streamingCards.clear();
 		this.streamingRunStates.clear();
+		this.pendingCardEvents.clear();
 
 		const ws = this.wsClient as { stop?: () => void } | null;
 		if (ws?.stop) try { ws.stop(); } catch {}
@@ -254,6 +258,26 @@ export class FeishuBridge {
 		const value = actionValue as Record<string, unknown>;
 		// 目前无卡片按钮交互需求（停止命令走 /stop）
 		return undefined;
+	}
+
+	// ===== 闪电确认 =====
+
+	/** ⚡ 闪电确认：收到消息后立即 fire-and-forget 一条 text 回复，让用户感知 Bot 已响应 */
+	private async sendLightningConfirm(chatId: string, replyToMessageId?: string): Promise<void> {
+		if (!this.client) return;
+		try {
+			if (replyToMessageId) {
+				await this.client.im.message.reply({
+					path: { message_id: replyToMessageId },
+					data: { msg_type: "text", content: JSON.stringify({ text: "⚡ 已收到" }) },
+				});
+			} else {
+				await this.client.im.message.create({
+					params: { receive_id_type: "chat_id" },
+					data: { receive_id: chatId, msg_type: "text", content: JSON.stringify({ text: "⚡ 已收到" }) },
+				});
+			}
+		} catch { /* fire-and-forget */ }
 	}
 
 	// ===== 消息处理 =====
@@ -351,6 +375,11 @@ export class FeishuBridge {
 			if (this.recentContent.size > 2000) this.recentContent.delete(this.recentContent.keys().next().value as string);
 
 			log(`[飞书 Bridge] 准备调用 Agent: ${chatId}, "${text.slice(0, 60)}", images=${imageAttachments.length}`);
+
+			// ⚡ 闪电确认：fire-and-forget，不等待
+			const replyToMsgId = chatType === "group" ? messageId : undefined;
+			void this.sendLightningConfirm(chatId, replyToMsgId).catch(() => {});
+
 			await this.runAgent(msgCtx, text, imageAttachments, fileAttachments);
 		} finally { this.processingChats.delete(chatId); }
 	}
@@ -374,7 +403,7 @@ export class FeishuBridge {
 		}
 	}
 
-	// ===== Agent 执行（流式卡片模式） =====
+	// ===== Agent 执行（流式卡片 + 并行优化） =====
 
 	private async runAgent(ctx: FeishuMessageContext, text: string, imageAttachments: FeishuImageAttachment[], fileAttachments: FeishuFileAttachment[]): Promise<void> {
 		const { chatId } = ctx;
@@ -384,67 +413,108 @@ export class FeishuBridge {
 		// 关闭已有流式卡片
 		const existingCard = this.streamingCards.get(binding.sessionId);
 		if (existingCard) { await existingCard.flush(markInterrupted(createInitialState())).catch(() => {}); await existingCard.close().catch(() => {}); this.streamingCards.delete(binding.sessionId); this.streamingRunStates.delete(binding.sessionId); }
+		this.pendingCardEvents.delete(binding.sessionId);
 
 		// 图片 → ImageContent (base64)
 		const images: ImageContent[] = imageAttachments.map((att) => ({ type: "image" as const, data: att.data.toString("base64"), mimeType: att.mediaType }));
 		let finalText = text;
 		if (fileAttachments.length > 0) { const names = fileAttachments.map((f) => f.fileName).join(", "); finalText = finalText ? `${finalText}\n\n[附件: ${names}]` : `处理以下文件: ${names}`; }
 
-		// 创建流式卡片
+		// 🔥 立即初始化状态机 + 缓存队列（卡片可能尚未创建）
 		const initialState = createInitialState();
 		this.streamingRunStates.set(binding.sessionId, initialState);
+		this.pendingCardEvents.set(binding.sessionId, []);
 
 		const prefix = ctx.chatType === "group" && ctx.groupName ? `${ctx.groupName}` : "";
-		const headerTitle = prefix ? `${prefix} · Agent 处理中` : "Agent 处理中";
+		const runningHeader = prefix ? `${prefix} · Agent 处理中` : "Agent 处理中";
+
+		// 🔥 并行启动：CardStream 创建 + Agent 推理（互不阻塞）
+		const cardPromise = CardStream.open(
+			this.client!, chatId,
+			renderRunCard(initialState, { header: runningHeader, stopHint: "发送 /stop 可终止当前任务" }),
+			{ replyToMessageId: ctx.chatType === "group" ? ctx.messageId : undefined },
+		).catch((e) => { logErr("[飞书 Bridge] 流式卡片创建失败:", e); return null as CardStream | null; });
 
 		try {
-			const cardStream = await CardStream.open(this.client!, chatId, renderRunCard(initialState, { header: headerTitle, stopHint: "发送 /stop 可终止当前任务" }), { replyToMessageId: ctx.chatType === "group" ? ctx.messageId : undefined });
-			this.streamingCards.set(binding.sessionId, cardStream);
+			// Agent 先行启动（不等待卡片创建完成）
+			await this.agentManager.sendPrompt({ agentId: binding.sessionId, message: finalText, ...(images.length > 0 ? { images } : {}) });
 		} catch (e) {
-			logErr("[飞书 Bridge] 流式卡片创建失败，降级为文本提示:", e);
+			// sendPrompt 失败 → 清理状态
+			this.streamingRunStates.delete(binding.sessionId);
+			this.pendingCardEvents.delete(binding.sessionId);
+			this.streamingCards.delete(binding.sessionId);
+			throw e;
+		}
+
+		// 等待卡片创建完成，回放缓存事件
+		const cardStream = await cardPromise;
+		const hasCard = cardStream !== null;
+		if (cardStream) {
+			this.streamingCards.set(binding.sessionId, cardStream);
+			this.replayBufferedEvents(binding.sessionId, cardStream, runningHeader);
+		} else {
+			this.pendingCardEvents.delete(binding.sessionId);
 			await this.sendSmartMessage(chatId, "🔄 Agent 处理中...");
 		}
 
 		const startTime = Date.now();
 
 		try {
-			await this.agentManager.sendPrompt({ agentId: binding.sessionId, message: finalText, ...(images.length > 0 ? { images } : {}) });
-			// agent_end 事件会在 handleAgentEvent 中关闭卡片并发最终结果
+			// agent_end 事件会在 handleAgentEvent 中 flush 终态卡片
 			await this.waitForAgentEnd(binding.sessionId, 300_000);
 
-			const messages = this.agentManager.getMessages(binding.sessionId);
-			const lastAssistant = messages.filter((m) => m.role === "assistant").pop();
-			const resultText = lastAssistant?.text ?? "";
-
-			// 关闭流式卡片（终态）
-			const finalState = this.streamingRunStates.get(binding.sessionId) ?? markDone(createInitialState());
-			if (finalState.terminal === "running") { markDone(finalState); }
-
-			const cardStream = this.streamingCards.get(binding.sessionId);
-			if (cardStream) {
-				await cardStream.flush(renderRunCard(markDone(finalState), { header: prefix ? `${prefix} · ✅ 完成` : "✅ 完成" })).catch(() => {});
-				await cardStream.close().catch(() => {});
+			// 如果流式卡片已创建，结果已展示在卡片中，无需额外发送
+			if (hasCard) {
+				// 清理可能残留的状态（handleAgentEvent 已处理大部分）
 				this.streamingCards.delete(binding.sessionId);
-			}
-			this.streamingRunStates.delete(binding.sessionId);
-
-			// 最终结果：智能消息模式发送
-			if (resultText.trim()) {
-				const duration = ((Date.now() - startTime) / 1000).toFixed(1);
-				await this.sendSmartMessage(chatId, `${resultText}\n\n---\n⏱ ${duration}s`);
+				this.streamingRunStates.delete(binding.sessionId);
+				this.pendingCardEvents.delete(binding.sessionId);
+			} else {
+				// 降级：无流式卡片，用文本消息发送最终结果
+				const messages = this.agentManager.getMessages(binding.sessionId);
+				const lastAssistant = messages.filter((m) => m.role === "assistant").pop();
+				const resultText = lastAssistant?.text ?? "";
+				this.streamingRunStates.delete(binding.sessionId);
+				this.pendingCardEvents.delete(binding.sessionId);
+				if (resultText.trim()) {
+					const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+					await this.sendSmartMessage(chatId, `${resultText}\n\n---\n⏱ ${duration}s`);
+				}
 			}
 		} catch (e) {
 			const msg = e instanceof Error ? e.message : String(e);
 			const errState = markError(createInitialState(), msg.slice(0, 96));
-			const cardStream = this.streamingCards.get(binding.sessionId);
-			if (cardStream) {
-				await cardStream.flush(renderRunCard(errState, { header: "❌ 失败" })).catch(() => {});
-				await cardStream.close().catch(() => {});
+			const finalCardStream = this.streamingCards.get(binding.sessionId);
+			if (finalCardStream) {
+				await finalCardStream.flush(renderRunCard(errState, { header: "❌ 失败" })).catch(() => {});
+				await finalCardStream.close().catch(() => {});
 				this.streamingCards.delete(binding.sessionId);
 			}
 			this.streamingRunStates.delete(binding.sessionId);
+			this.pendingCardEvents.delete(binding.sessionId);
 			await this.sendSmartMessage(chatId, `❌ Agent 错误: ${msg}`);
 		}
+	}
+
+	/** 回放卡片创建期间缓存的 Agent 事件 */
+	private replayBufferedEvents(sessionId: string, cardStream: CardStream, headerTitle: string): void {
+		const pending = this.pendingCardEvents.get(sessionId);
+		if (!pending || pending.length === 0) { this.pendingCardEvents.delete(sessionId); return; }
+
+		log(`[飞书 Bridge] 回放 ${pending.length} 个缓存事件到卡片`);
+		let currentState = this.streamingRunStates.get(sessionId) ?? createInitialState();
+		for (const ev of pending) {
+			const nextState = reduceFromPiEvent(currentState, ev as Record<string, unknown>);
+			if (nextState !== currentState) {
+				currentState = nextState;
+				this.streamingRunStates.set(sessionId, nextState);
+				cardStream.update(renderRunCard(nextState, {
+					header: headerTitle,
+					stopHint: nextState.terminal === "running" ? "发送 /stop 可终止当前任务" : undefined,
+				}));
+			}
+		}
+		this.pendingCardEvents.delete(sessionId);
 	}
 
 	private waitForAgentEnd(sessionId: string, timeoutMs: number): Promise<void> {
@@ -466,13 +536,18 @@ export class FeishuBridge {
 		if (!event || typeof event !== "object") return;
 		const typed = event as Record<string, unknown>;
 
-		// ==== 流式卡片更新（飞书发起的会话 + Session Mirror） ====
+		// ==== 流式状态更新（无论卡片是否就绪都更新 runState）====
 		const runState = this.streamingRunStates.get(agentId);
-		const cardStream = this.streamingCards.get(agentId);
-		if (runState && cardStream) {
+		if (runState) {
 			const nextState = reduceFromPiEvent(runState, typed);
 			if (nextState !== runState) {
 				this.streamingRunStates.set(agentId, nextState);
+			}
+
+			// 卡片更新或事件缓存
+			const cardStream = this.streamingCards.get(agentId);
+			if (cardStream) {
+				// 卡片已就绪 → 直接更新
 				const chatId = this.sessionToChat.get(agentId) ?? "";
 				const prefix = this.chatBindings.get(chatId)?.groupName ?? "";
 				const headerTitle = (prefix ? `${prefix} · ` : "") + (nextState.terminal === "running" ? "Agent 处理中" : "✅ 完成");
@@ -485,6 +560,13 @@ export class FeishuBridge {
 					void cardStream.flush(card).then(() => cardStream.close()).catch(() => {});
 					this.streamingRunStates.delete(agentId);
 					this.streamingCards.delete(agentId);
+					this.pendingCardEvents.delete(agentId);
+				}
+			} else {
+				// 卡片尚未创建 → 缓存事件（并行模式）
+				const pending = this.pendingCardEvents.get(agentId);
+				if (pending) {
+					pending.push(typed);
 				}
 			}
 		}
@@ -571,16 +653,35 @@ export class FeishuBridge {
 			return undefined;
 		}
 
-		// 已有绑定：检查是否需要修复空群（之前创建时没加用户）
-		const existingChatId = this.sessionToChat.get(sessionId);
+		const groupName = `Pi Agent - ${(sessionTitle || `新会话 ${sessionId.slice(0, 8)}`).slice(0, 50)}`;
+
+		// 1. 先按 sessionId 找已有绑定
+		let existingChatId = this.sessionToChat.get(sessionId);
+
+		// 2. sessionId 没匹配 → 按 groupName 在所有绑定中搜索（重启后 sessionId 可能变）
+		if (!existingChatId) {
+			for (const [chatId, binding] of this.chatBindings) {
+				if (binding.groupName === groupName && binding.source === "session-mirror") {
+					log(`[飞书 Session Mirror] 按群名匹配到已有群: ${groupName} → ${chatId}`);
+					existingChatId = chatId;
+					// 更新 sessionId 映射
+					this.sessionToChat.set(sessionId, chatId);
+					// 更新绑定中的 sessionId
+					binding.sessionId = sessionId;
+					this.persistBindings();
+					break;
+				}
+			}
+		}
+
+		// 3. 已有绑定：检查是否需要修复空群
 		if (existingChatId) {
 			const effectiveUserOpenId = this.botConfig.defaultUserOpenId || this.userOpenId;
 			if (effectiveUserOpenId) {
 				const binding = this.chatBindings.get(existingChatId);
 				if (binding && !binding.userId) {
-					// 之前创建的群没有用户，补加
 					log(`[飞书 Session Mirror] 检测到空群 ${existingChatId}，尝试补加用户 ${effectiveUserOpenId}`);
-					await this.repairEmptyGroup(existingChatId, effectiveUserOpenId);
+					await this.repairEmptyGroup(existingChatId, effectiveUserOpenId).catch(() => {});
 					binding.userId = effectiveUserOpenId;
 					this.persistBindings();
 				}
@@ -588,7 +689,7 @@ export class FeishuBridge {
 			return existingChatId;
 		}
 
-		const groupName = `Pi Agent - ${(sessionTitle || `新会话 ${sessionId.slice(0, 8)}`).slice(0, 50)}`;
+		// 4. 完全没匹配 → 创建新群
 		log(`[飞书 Session Mirror] 正在创建群: ${groupName}`);
 
 		// 用户 open_id 获取优先级：配置 > 自动记住
@@ -706,6 +807,7 @@ export class FeishuBridge {
 		}
 		this.streamingCards.delete(sessionId);
 		this.streamingRunStates.delete(sessionId);
+		this.pendingCardEvents.delete(sessionId);
 	}
 
 	private async handleStopCommand(ctx: FeishuMessageContext): Promise<void> {
@@ -719,6 +821,7 @@ export class FeishuBridge {
 			void card.flush(renderRunCard(markInterrupted(state))).then(() => card.close()).catch(() => {});
 			this.streamingCards.delete(binding.sessionId);
 			this.streamingRunStates.delete(binding.sessionId);
+			this.pendingCardEvents.delete(binding.sessionId);
 		}
 
 		await this.agentManager.abort(binding.sessionId);
@@ -838,17 +941,42 @@ export class FeishuBridge {
 		const bindings = loadBindings(this.botConfig.id);
 		for (const b of bindings) {
 			const tabs = this.agentManager.list();
-			const tab = tabs.find((t) => t.id === b.sessionId);
+			let tab = tabs.find((t) => t.id === b.sessionId);
+
+			// sessionId 不匹配当前 tab → 尝试按群名匹配（重启后 sessionId 可能变）
+			if (!tab && b.groupName && b.source === "session-mirror") {
+				for (const t of tabs) {
+					const expectedName = `Pi Agent - ${(t.title || `新会话 ${t.id.slice(0, 8)}`).slice(0, 50)}`;
+					if (expectedName === b.groupName) {
+						tab = t;
+						log(`[飞书 Bridge] 按群名恢复绑定: ${b.groupName} → sessionId ${t.id}`);
+						break;
+					}
+				}
+			}
+
 			if (tab) {
 				const binding: FeishuChatBinding = {
-					chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: b.sessionId,
+					chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: tab.id,
 					workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
 					source: b.source as "feishu" | "session-mirror", chatType: b.chatType as "p2p" | "group",
 					groupName: b.groupName, createdAt: b.createdAt,
 				};
 				this.chatBindings.set(b.chatId, binding);
-				this.sessionToChat.set(b.sessionId, b.chatId);
-				if (b.source === "feishu" || b.source === "session-mirror") this.feishuSessions.add(b.sessionId);
+				this.sessionToChat.set(tab.id, b.chatId);
+				if (b.source === "feishu" || b.source === "session-mirror") this.feishuSessions.add(tab.id);
+			} else {
+				// session-mirror 绑定：即使没有匹配的 tab 也保留，后续 ensureSessionMirror 会处理
+				if (b.source === "session-mirror") {
+					log(`[飞书 Bridge] 保留无主绑定（等后续匹配）: ${b.groupName ?? b.chatId}`);
+					const binding: FeishuChatBinding = {
+						chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: b.sessionId,
+						workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
+						source: b.source as "feishu" | "session-mirror", chatType: b.chatType as "p2p" | "group",
+						groupName: b.groupName, createdAt: b.createdAt,
+					};
+					this.chatBindings.set(b.chatId, binding);
+				}
 			}
 		}
 		if (this.chatBindings.size > 0) log(`[飞书 Bridge] 已恢复 ${this.chatBindings.size} 个聊天绑定`);

--- a/src/main/feishu/FeishuBridge.ts
+++ b/src/main/feishu/FeishuBridge.ts
@@ -1,0 +1,891 @@
+/**
+ * FeishuBridge — 飞书桥接主类 v3
+ *
+ * 核心升级：
+ * - CardKit 2.0 流式卡片：骨架卡→实时更新→终态 flush
+ *   看到工具调用名称、思考过程、输出文本等细节
+ * - 智能消息模式：text/post/interactive 解决表格渲染
+ * - Session Mirror：Pi 创建会话→飞书自动拉群（1会话=1群）
+ * - Pi→飞书实时同步：AgentManager 事件驱动
+ */
+
+import type { BrowserWindow } from "electron";
+import { ipcChannels } from "../../shared/ipc";
+import type {
+	FeishuBotConfig,
+	FeishuBridgeStatus,
+	FeishuChatBinding,
+	FeishuChatMessage,
+	FeishuTestResult,
+	ImageContent,
+} from "../../shared/types";
+import type {
+	FeishuGroupInfo,
+	FeishuGroupMember,
+	FeishuImageAttachment,
+	FeishuFileAttachment,
+	FeishuMessageContext,
+	LarkSDK,
+	LarkClient,
+} from "./types";
+import {
+	listBots,
+	addBot,
+	removeBot,
+	updateBot,
+	getDecryptedBotAppSecret,
+	loadBindings,
+	saveBindings,
+	type FeishuChatBindingPersist,
+} from "./FeishuConfig";
+import { chooseMessageMode, buildPostMessages, buildMarkdownCards } from "./rich-text";
+import { CardStream } from "./CardStream";
+import { createInitialState, reduceFromPiEvent, markInterrupted, markError, markDone, type RunState } from "./CardRunState";
+import { renderRunCard } from "./CardRenderer";
+import type { AgentManager } from "../pi/AgentManager";
+
+// ===== 常量 =====
+const DEDUP_MAX = 200;
+const GROUP_CACHE_TTL = 3600_000;
+
+// ===== 安全日志 =====
+function safeLog(level: "log" | "warn" | "error", ...args: unknown[]): void {
+	try { console[level](...args); } catch { /* EPIPE */ }
+}
+const log = (...args: unknown[]) => safeLog("log", ...args);
+const warn = (...args: unknown[]) => safeLog("warn", ...args);
+const logErr = (...args: unknown[]) => safeLog("error", ...args);
+
+export class FeishuBridge {
+	private wsClient: unknown = null;
+	private client: LarkClient | null = null;
+	private botConfig: FeishuBotConfig;
+	private agentManager: AgentManager;
+	private getWindow: () => BrowserWindow | null;
+	private getProjects: () => Array<{ id: string; name: string; path: string }>;
+
+	private status: FeishuBridgeStatus = { status: "disconnected", activeBindings: 0 };
+	private botOpenId: string | null = null;
+	private userOpenId: string | null = null; // 记住最近一个用户，用于自动拉群
+
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private reconnectAttempts = 0;
+	private readonly maxReconnectAttempts = 10;
+
+	private recentMessageIds = new Set<string>();
+	private recentEventIds = new Set<string>();
+	private recentContent = new Map<string, number>();
+	private processingChats = new Set<string>();
+
+	private chatBindings = new Map<string, FeishuChatBinding>();
+	private sessionToChat = new Map<string, string>();
+
+	private groupInfoCache = new Map<string, FeishuGroupInfo>();
+	private userNameCache = new Map<string, string>();
+
+	private pendingImages = new Map<string, FeishuImageAttachment[]>();
+	private pendingFiles = new Map<string, FeishuFileAttachment[]>();
+
+	// 流式卡片：sessionId → CardStream
+	private streamingCards = new Map<string, CardStream>();
+	// 流式状态：sessionId → RunState
+	private streamingRunStates = new Map<string, RunState>();
+
+	private unsubscribeLocalEvents: (() => void) | null = null;
+	// 哪些 session 是飞书发起的（不需要 session mirror）
+	private feishuSessions = new Set<string>();
+
+	private lastUserMessageId = new Map<string, string>();
+
+	constructor(
+		botConfig: FeishuBotConfig,
+		agentManager: AgentManager,
+		getWindow: () => BrowserWindow | null,
+		getProjects: () => Array<{ id: string; name: string; path: string }>,
+	) {
+		this.botConfig = botConfig;
+		this.agentManager = agentManager;
+		this.getWindow = getWindow;
+		this.getProjects = getProjects;
+	}
+
+	getStatus(): FeishuBridgeStatus { return { ...this.status }; }
+	listBindings(): FeishuChatBinding[] { return Array.from(this.chatBindings.values()); }
+
+	// ===== 绑定管理 =====
+
+	removeBinding(chatId: string): boolean {
+		const binding = this.chatBindings.get(chatId);
+		if (!binding) return false;
+		try { this.agentManager.stop(binding.sessionId); } catch { /* ignore */ }
+		this.sessionToChat.delete(binding.sessionId);
+		this.feishuSessions.delete(binding.sessionId);
+		this.chatBindings.delete(chatId);
+		this.streamingCards.delete(binding.sessionId);
+		this.streamingRunStates.delete(binding.sessionId);
+		this.pendingImages.delete(chatId);
+		this.pendingFiles.delete(chatId);
+		this.lastUserMessageId.delete(chatId);
+		this.updateStatus({ activeBindings: this.chatBindings.size });
+		this.persistBindings();
+		log(`[飞书 Bridge] 已移除绑定: ${chatId}`);
+		return true;
+	}
+
+	updateBinding(chatId: string, patch: Partial<Omit<FeishuChatBinding, "chatId" | "botId" | "sessionId">>): FeishuChatBinding | undefined {
+		const binding = this.chatBindings.get(chatId);
+		if (!binding) return undefined;
+		Object.assign(binding, patch);
+		this.persistBindings();
+		return { ...binding };
+	}
+
+	// ===== 生命周期 =====
+
+	async start(): Promise<void> {
+		const { appId } = this.botConfig;
+		const plainSecret = getDecryptedBotAppSecret(this.botConfig.id);
+		if (!appId || !plainSecret) throw new Error("请先配置 App ID 和 App Secret");
+
+		this.updateStatus({ status: "connecting" });
+
+		try {
+			const lark = (await import("@larksuiteoapi/node-sdk")) as unknown as LarkSDK;
+			this.client = new lark.Client({
+				appId, appSecret: plainSecret,
+				appType: lark.AppType.SelfBuild, domain: lark.Domain.Feishu,
+				loggerLevel: lark.LoggerLevel.error,
+			} as Record<string, unknown>) as LarkClient;
+
+			try {
+				const botInfoResp = await this.client.request<{
+					code?: number; bot?: { open_id?: string; app_name?: string };
+					data?: { bot?: { open_id?: string; app_name?: string } };
+				}>({ method: "GET", url: "https://open.feishu.cn/open-apis/bot/v3/info/" });
+				this.botOpenId = botInfoResp?.bot?.open_id ?? botInfoResp?.data?.bot?.open_id ?? null;
+				if (this.botOpenId) {
+					log(`[飞书 Bridge] Bot 自身 open_id: ${this.botOpenId}`);
+					// 防止用户误把 Bot 的 open_id 填成自己的
+					if (this.botConfig.defaultUserOpenId === this.botOpenId) {
+						warn(`[飞书 Bridge] ⚠️ 配置中的 defaultUserOpenId 是 Bot 自己的 open_id，不是你的！`);
+						warn(`[飞书 Bridge] 💡 请在飞书中给 Bot 发送 /whoami 获取你的真实 open_id，然后填入配置`);
+					}
+				}
+			} catch (e) { warn("[飞书 Bridge] 获取 Bot info 失败（非致命）:", e); }
+
+			const dispatcher = new lark.EventDispatcher({ loggerLevel: lark.LoggerLevel.error }).register({
+				"im.message.receive_v1": async (data: unknown) => {
+					await this.handleRawMessage(data as Record<string, unknown>).catch((err) =>
+						logErr("[飞书 Bridge] handleRawMessage 异常:", err));
+				},
+				"im.message.reaction.created_v1": async () => {},
+				"im.chat.member.bot.added_v1": async () => {},
+				"card.action.trigger": async (data: unknown) => this.handleCardAction(data as Record<string, unknown>),
+			});
+
+			const ws = new lark.WSClient({
+				appId, appSecret: plainSecret, domain: lark.Domain.Feishu, loggerLevel: lark.LoggerLevel.error,
+			});
+			this.wsClient = ws;
+			ws.start({ eventDispatcher: dispatcher });
+			log("[飞书 Bridge] WSClient 已启动");
+
+			this.reconnectAttempts = 0;
+			this.unsubscribeLocalEvents = this.agentManager.addLocalEventListener(
+				(agentId, event) => this.handleAgentEvent(agentId, event),
+			);
+			this.loadPersistedBindings();
+			this.updateStatus({ status: "connected", activeBindings: this.chatBindings.size, connectedAt: Date.now(), botOpenId: this.botOpenId ?? undefined });
+			log("[飞书 Bridge] 已连接");
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.updateStatus({ status: "error", errorMessage: message });
+			logErr("[飞书 Bridge] 启动失败:", error);
+			this.scheduleReconnect(); throw error;
+		}
+	}
+
+	stop(): void {
+		if (this.unsubscribeLocalEvents) { this.unsubscribeLocalEvents(); this.unsubscribeLocalEvents = null; }
+		for (const [, card] of this.streamingCards) { card.close().catch(() => {}); }
+		this.streamingCards.clear();
+		this.streamingRunStates.clear();
+
+		const ws = this.wsClient as { stop?: () => void } | null;
+		if (ws?.stop) try { ws.stop(); } catch {}
+		if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+		this.wsClient = null; this.client = null;
+		this.chatBindings.clear(); this.sessionToChat.clear(); this.feishuSessions.clear();
+		this.pendingImages.clear(); this.pendingFiles.clear();
+		this.recentMessageIds.clear(); this.recentEventIds.clear(); this.recentContent.clear();
+		this.processingChats.clear(); this.lastUserMessageId.clear();
+		this.groupInfoCache.clear(); this.userNameCache.clear(); this.botOpenId = null;
+		this.updateStatus({ status: "disconnected", activeBindings: 0 });
+		log("[飞书 Bridge] 已停止");
+	}
+
+	// ===== 配置热更新 =====
+
+	/** 运行时更新 botConfig（用于用户在面板编辑 open_id 后无需重连） */
+	updateBotConfig(patch: Partial<FeishuBotConfig>): void {
+		this.botConfig = { ...this.botConfig, ...patch };
+		log("[飞书 Bridge] 配置已热更新:", Object.keys(patch).join(", "));
+	}
+
+	// ===== 测试连接 =====
+
+	async testConnection(appId: string, appSecret: string): Promise<FeishuTestResult> {
+		try {
+			const lark = (await import("@larksuiteoapi/node-sdk")) as unknown as LarkSDK;
+			const client = new lark.Client({ appId, appSecret, appType: lark.AppType.SelfBuild } as Record<string, unknown>) as LarkClient;
+			const resp = await client.auth.tenantAccessToken.internal({ data: { app_id: appId, app_secret: appSecret } });
+			if ((resp as Record<string, unknown>).code === 0) return { success: true, message: "连接成功！", botName: `App ${appId.slice(0, 8)}...` };
+			return { success: false, message: `飞书 API 错误: ${(resp as Record<string, unknown>).msg ?? "未知错误"}` };
+		} catch (error) {
+			return { success: false, message: `连接失败: ${error instanceof Error ? error.message : String(error)}` };
+		}
+	}
+
+	// ===== 卡片交互回调 =====
+
+	private async handleCardAction(data: Record<string, unknown>): Promise<Record<string, unknown> | undefined> {
+		const actionValue = (data as { action?: { value?: unknown } })?.action?.value;
+		if (!actionValue || typeof actionValue !== "object") return undefined;
+		const value = actionValue as Record<string, unknown>;
+		// 目前无卡片按钮交互需求（停止命令走 /stop）
+		return undefined;
+	}
+
+	// ===== 消息处理 =====
+
+	private async handleRawMessage(data: Record<string, unknown>): Promise<void> {
+		const event = (data?.event ?? data) as Record<string, unknown>;
+		if (!event) return;
+		const sender = event.sender as Record<string, unknown> | undefined;
+		if (sender?.sender_type === "bot") return;
+		await this.handleMessage(event);
+	}
+
+	private async handleMessage(data: Record<string, unknown>): Promise<void> {
+		if (!this.client) return;
+		const eventId = data.event_id as string | undefined;
+		if (eventId && this.recentEventIds.has(eventId)) return;
+		if (eventId) { this.recentEventIds.add(eventId); if (this.recentEventIds.size > DEDUP_MAX) this.recentEventIds.delete(this.recentEventIds.values().next().value as string); }
+
+		const message = (data as { message?: Record<string, unknown> }).message;
+		if (!message) return;
+		const sender = (data as { sender?: Record<string, unknown> }).sender;
+		if ((sender?.sender_type as string) !== "user") return;
+
+		const messageId = message.message_id as string;
+		if (messageId && this.recentMessageIds.has(messageId)) return;
+		if (messageId) { this.recentMessageIds.add(messageId); if (this.recentMessageIds.size > DEDUP_MAX) this.recentMessageIds.delete(this.recentMessageIds.values().next().value as string); }
+
+		const chatId = message.chat_id as string;
+		const messageType = message.message_type as string;
+		const chatType = message.chat_type as string;
+		const userId = (sender?.sender_id as Record<string, unknown>)?.open_id as string ?? "unknown";
+		const mentions = message.mentions as Array<{ name: string; id: string | { open_id: string; union_id: string; user_id: string } }> | undefined;
+
+		// 记住用户 open_id（用于自动拉群）
+		if (userId && userId !== "unknown") this.userOpenId = userId;
+
+		if (this.processingChats.has(chatId)) { log(`[飞书 Bridge] 跳过重入消息: ${chatId}`); return; }
+		this.processingChats.add(chatId);
+
+		try {
+			if (chatType === "group" && this.botConfig.requireMention !== false && !this.isBotMentioned(mentions)) return;
+			if (chatType === "group" && messageId) this.lastUserMessageId.set(chatId, messageId);
+
+			const supportedTypes = new Set(["text", "image", "post", "file"]);
+			if (!supportedTypes.has(messageType)) { log(`[飞书 Bridge] 不支持的消息类型: ${messageType}`); return; }
+
+			let text = "";
+			const imageAttachments: FeishuImageAttachment[] = [];
+			const fileAttachments: FeishuFileAttachment[] = [];
+
+			if (messageType === "text") {
+				const content = JSON.parse(message.content as string) as { text?: string };
+				text = (content.text ?? "").replace(/@_user_\d+/g, "").trim();
+			} else if (messageType === "post") {
+				const content = JSON.parse(message.content as string) as { title?: string; content?: Array<Array<{ tag: string; text?: string }>> };
+				const parts: string[] = [];
+				if (content.title) parts.push(content.title);
+				for (const line of content.content ?? []) for (const node of line) if (node.tag === "text" && node.text) parts.push(node.text);
+				text = parts.join(" ").replace(/@_user_\d+/g, "").trim();
+			} else if (messageType === "image") {
+				const content = JSON.parse(message.content as string) as { image_key?: string };
+				if (content.image_key) { try { const imgData = await this.downloadImage(messageId, content.image_key); imageAttachments.push({ imageKey: content.image_key, data: imgData, mediaType: this.inferImageMediaType(imgData) }); } catch (e) { logErr("[飞书 Bridge] 下载图片失败:", e); await this.sendSmartMessage(chatId, "⚠️ 图片下载失败，请重试。"); return; } }
+			} else if (messageType === "file") {
+				const content = JSON.parse(message.content as string) as { file_key?: string; file_name?: string };
+				if (content.file_key) { try { const fileData = await this.downloadFile(messageId, content.file_key); if (fileData.length > 50 * 1024 * 1024) { await this.sendSmartMessage(chatId, "文件过大（超过 50MB），暂不支持处理。"); return; } fileAttachments.push({ fileKey: content.file_key, fileName: content.file_name || `feishu-${content.file_key}`, data: fileData }); } catch (e) { logErr("[飞书 Bridge] 下载文件失败:", e); await this.sendSmartMessage(chatId, "⚠️ 文件下载失败，请重试。"); return; } }
+			}
+
+			if (!text && (imageAttachments.length > 0 || fileAttachments.length > 0)) {
+				if (imageAttachments.length > 0) { const existing = this.pendingImages.get(chatId) ?? []; existing.push(...imageAttachments); this.pendingImages.set(chatId, existing); }
+				if (fileAttachments.length > 0) { const existing = this.pendingFiles.get(chatId) ?? []; existing.push(...fileAttachments); this.pendingFiles.set(chatId, existing); }
+				const parts: string[] = []; const ic = this.pendingImages.get(chatId)?.length ?? 0; const fc = this.pendingFiles.get(chatId)?.length ?? 0;
+				if (ic > 0) parts.push(`${ic} 张图片`); if (fc > 0) parts.push(`${fc} 个文件`);
+				await this.sendSmartMessage(chatId, `已收到${parts.join("和")}，请继续发送文字消息来触发处理。`);
+				return;
+			}
+
+			if (text && this.pendingImages.has(chatId)) { imageAttachments.unshift(...this.pendingImages.get(chatId)!); this.pendingImages.delete(chatId); }
+			if (text && this.pendingFiles.has(chatId)) { fileAttachments.unshift(...this.pendingFiles.get(chatId)!); this.pendingFiles.delete(chatId); }
+			if (!text && imageAttachments.length === 0 && fileAttachments.length === 0) return;
+
+			let groupName: string | undefined; let senderName: string | undefined;
+			if (chatType === "group") { const [gi, un] = await Promise.all([this.getGroupInfo(chatId), this.getUserName(userId)]); groupName = gi?.name; senderName = un; }
+
+			const msgCtx: FeishuMessageContext = { chatId, senderOpenId: userId, senderName, messageId, chatType: chatType as "p2p" | "group", groupName };
+
+			if (text.startsWith("/")) { await this.handleCommand(msgCtx, text); return; }
+
+			const dedupParts = [chatId, userId, text];
+			if (imageAttachments.length > 0) dedupParts.push("img", ...imageAttachments.map((a) => a.imageKey));
+			if (fileAttachments.length > 0) dedupParts.push("file", ...fileAttachments.map((f) => f.fileKey));
+			const contentKey = dedupParts.join("\u0000");
+			const lastTime = this.recentContent.get(contentKey);
+			if (lastTime && Date.now() - lastTime <= 5000) { log(`[飞书 Bridge] 重复内容已跳过: ${text.slice(0, 50)}`); return; }
+			this.recentContent.set(contentKey, Date.now());
+			if (this.recentContent.size > 2000) this.recentContent.delete(this.recentContent.keys().next().value as string);
+
+			log(`[飞书 Bridge] 准备调用 Agent: ${chatId}, "${text.slice(0, 60)}", images=${imageAttachments.length}`);
+			await this.runAgent(msgCtx, text, imageAttachments, fileAttachments);
+		} finally { this.processingChats.delete(chatId); }
+	}
+
+	// ===== 命令处理 =====
+
+	private async handleCommand(ctx: FeishuMessageContext, text: string): Promise<void> {
+		const { chatId, senderOpenId: userId } = ctx;
+		const [command] = text.split(/\s+/);
+		switch (command?.toLowerCase()) {
+			case "/help": case "/h": await this.sendHelpCard(chatId); break;
+			case "/new": case "/n": await this.createNewSession(ctx); break;
+			case "/stop": case "/s": await this.handleStopCommand(ctx); break;
+			case "/status": await this.handleStatusCommand(ctx); break;
+			case "/whoami":
+				await this.sendSmartMessage(chatId,
+					`你的 open_id: \`${userId}\`\n\n📋 你可以将此 ID 填入 PiDeck 飞书配置中的「你的 Open ID」字段，以便新建会话时自动拉你进群。`
+				);
+				break;
+			default: await this.sendSmartMessage(chatId, `未知命令: ${command}。输入 /help 查看帮助。`);
+		}
+	}
+
+	// ===== Agent 执行（流式卡片模式） =====
+
+	private async runAgent(ctx: FeishuMessageContext, text: string, imageAttachments: FeishuImageAttachment[], fileAttachments: FeishuFileAttachment[]): Promise<void> {
+		const { chatId } = ctx;
+		let binding = this.chatBindings.get(chatId);
+		if (!binding) { await this.createNewSession(ctx); binding = this.chatBindings.get(chatId); if (!binding) return; }
+
+		// 关闭已有流式卡片
+		const existingCard = this.streamingCards.get(binding.sessionId);
+		if (existingCard) { await existingCard.flush(markInterrupted(createInitialState())).catch(() => {}); await existingCard.close().catch(() => {}); this.streamingCards.delete(binding.sessionId); this.streamingRunStates.delete(binding.sessionId); }
+
+		// 图片 → ImageContent (base64)
+		const images: ImageContent[] = imageAttachments.map((att) => ({ type: "image" as const, data: att.data.toString("base64"), mimeType: att.mediaType }));
+		let finalText = text;
+		if (fileAttachments.length > 0) { const names = fileAttachments.map((f) => f.fileName).join(", "); finalText = finalText ? `${finalText}\n\n[附件: ${names}]` : `处理以下文件: ${names}`; }
+
+		// 创建流式卡片
+		const initialState = createInitialState();
+		this.streamingRunStates.set(binding.sessionId, initialState);
+
+		const prefix = ctx.chatType === "group" && ctx.groupName ? `${ctx.groupName}` : "";
+		const headerTitle = prefix ? `${prefix} · Agent 处理中` : "Agent 处理中";
+
+		try {
+			const cardStream = await CardStream.open(this.client!, chatId, renderRunCard(initialState, { header: headerTitle, stopHint: "发送 /stop 可终止当前任务" }), { replyToMessageId: ctx.chatType === "group" ? ctx.messageId : undefined });
+			this.streamingCards.set(binding.sessionId, cardStream);
+		} catch (e) {
+			logErr("[飞书 Bridge] 流式卡片创建失败，降级为文本提示:", e);
+			await this.sendSmartMessage(chatId, "🔄 Agent 处理中...");
+		}
+
+		const startTime = Date.now();
+
+		try {
+			await this.agentManager.sendPrompt({ agentId: binding.sessionId, message: finalText, ...(images.length > 0 ? { images } : {}) });
+			// agent_end 事件会在 handleAgentEvent 中关闭卡片并发最终结果
+			await this.waitForAgentEnd(binding.sessionId, 300_000);
+
+			const messages = this.agentManager.getMessages(binding.sessionId);
+			const lastAssistant = messages.filter((m) => m.role === "assistant").pop();
+			const resultText = lastAssistant?.text ?? "";
+
+			// 关闭流式卡片（终态）
+			const finalState = this.streamingRunStates.get(binding.sessionId) ?? markDone(createInitialState());
+			if (finalState.terminal === "running") { markDone(finalState); }
+
+			const cardStream = this.streamingCards.get(binding.sessionId);
+			if (cardStream) {
+				await cardStream.flush(renderRunCard(markDone(finalState), { header: prefix ? `${prefix} · ✅ 完成` : "✅ 完成" })).catch(() => {});
+				await cardStream.close().catch(() => {});
+				this.streamingCards.delete(binding.sessionId);
+			}
+			this.streamingRunStates.delete(binding.sessionId);
+
+			// 最终结果：智能消息模式发送
+			if (resultText.trim()) {
+				const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+				await this.sendSmartMessage(chatId, `${resultText}\n\n---\n⏱ ${duration}s`);
+			}
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			const errState = markError(createInitialState(), msg.slice(0, 96));
+			const cardStream = this.streamingCards.get(binding.sessionId);
+			if (cardStream) {
+				await cardStream.flush(renderRunCard(errState, { header: "❌ 失败" })).catch(() => {});
+				await cardStream.close().catch(() => {});
+				this.streamingCards.delete(binding.sessionId);
+			}
+			this.streamingRunStates.delete(binding.sessionId);
+			await this.sendSmartMessage(chatId, `❌ Agent 错误: ${msg}`);
+		}
+	}
+
+	private waitForAgentEnd(sessionId: string, timeoutMs: number): Promise<void> {
+		return new Promise((resolve) => {
+			const timer = setTimeout(() => { cleanup(); resolve(); }, timeoutMs);
+			const handler = (agentId: string, event: unknown) => {
+				if (agentId !== sessionId) return;
+				if (!event || typeof event !== "object") return;
+				if ((event as Record<string, unknown>).type === "agent_end") { cleanup(); resolve(); }
+			};
+			const unsub = this.agentManager.addLocalEventListener(handler);
+			const cleanup = () => { clearTimeout(timer); unsub(); };
+		});
+	}
+
+	// ===== Agent 事件处理（流式卡片 + Session Mirror） =====
+
+	private handleAgentEvent(agentId: string, event: unknown): void {
+		if (!event || typeof event !== "object") return;
+		const typed = event as Record<string, unknown>;
+
+		// ==== 流式卡片更新（飞书发起的会话 + Session Mirror） ====
+		const runState = this.streamingRunStates.get(agentId);
+		const cardStream = this.streamingCards.get(agentId);
+		if (runState && cardStream) {
+			const nextState = reduceFromPiEvent(runState, typed);
+			if (nextState !== runState) {
+				this.streamingRunStates.set(agentId, nextState);
+				const chatId = this.sessionToChat.get(agentId) ?? "";
+				const prefix = this.chatBindings.get(chatId)?.groupName ?? "";
+				const headerTitle = (prefix ? `${prefix} · ` : "") + (nextState.terminal === "running" ? "Agent 处理中" : "✅ 完成");
+
+				const card = renderRunCard(nextState, { header: headerTitle, stopHint: nextState.terminal === "running" ? "发送 /stop 可终止当前任务" : undefined });
+				if (nextState.terminal === "running") {
+					cardStream.update(card);
+				} else {
+					// 终态：强制 flush + close
+					void cardStream.flush(card).then(() => cardStream.close()).catch(() => {});
+					this.streamingRunStates.delete(agentId);
+					this.streamingCards.delete(agentId);
+				}
+			}
+		}
+
+		// ==== Session Mirror: Pi 侧会话 → 飞书实时同步 ====
+		if (!this.feishuSessions.has(agentId) && typed.type === "agent_end") {
+			// 非飞书发起的 session 完成 → 同步结果到飞书
+			const chatId = this.sessionToChat.get(agentId);
+			if (chatId && this.client) {
+				this.syncPiMessageToFeishu(agentId, chatId).catch((e) =>
+					logErr("[飞书 Bridge] 同步 Pi 消息到飞书失败:", e));
+			}
+		}
+	}
+
+	/** 将 Pi Agent 回复同步到飞书（带去重，避免同一结果重复推送） */
+	private async syncPiMessageToFeishu(agentId: string, chatId: string): Promise<void> {
+		if (!this.client) return;
+		const messages = this.agentManager.getMessages(agentId);
+		const assistantMessages = messages.filter((m) => m.role === "assistant");
+		const lastAssistant = assistantMessages.pop();
+		if (!lastAssistant?.text?.trim()) return;
+
+		// 去重：用最后一条 assistant 消息的 id + text 前50字符做指纹
+		const fingerprint = `${lastAssistant.id}|${lastAssistant.text.slice(0, 50)}`;
+		const syncedFingerprints = (this as Record<string, unknown>).__feishuSyncFp as Set<string> | undefined;
+		if (syncedFingerprints?.has(fingerprint)) return;
+
+		if (!syncedFingerprints) {
+			(this as Record<string, unknown>).__feishuSyncFp = new Set<string>();
+		}
+		((this as Record<string, unknown>).__feishuSyncFp as Set<string>).add(fingerprint);
+
+		await this.sendSmartMessage(chatId, lastAssistant.text);
+	}
+
+	/** 将 PiDeck 中的用户消息转发到飞书群（双向同步：Pi → 飞书） */
+	async forwardUserMessageToFeishu(agentId: string, text: string): Promise<void> {
+		if (!this.client || !text.trim()) return;
+		const chatId = this.sessionToChat.get(agentId);
+		if (!chatId) {
+			// 没有绑定，尝试创建 session mirror
+			const tab = this.agentManager.list().find(t => t.id === agentId);
+			if (tab) {
+				await this.ensureSessionMirror(agentId, tab.title);
+			}
+			return;
+		}
+		// 带上 PiDeck 标识，方便在飞书中区分消息来源
+		await this.sendSmartMessage(chatId, `💻 **PiDeck**:\n${text}`);
+	}
+
+	// ===== 会话管理 =====
+
+	private async createNewSession(ctx: FeishuMessageContext, _title?: string): Promise<void> {
+		const { chatId } = ctx;
+		const projects = this.getProjects();
+		if (projects.length === 0) { await this.sendSmartMessage(chatId, "❌ 请先在 PiDeck 中添加项目（工作区），然后重试。"); return; }
+		const projectId = projects[0].id;
+
+		try {
+			const tab = await this.agentManager.create({ projectId });
+			const binding: FeishuChatBinding = {
+				chatId, botId: this.botConfig.id, userId: ctx.senderOpenId, sessionId: tab.id,
+				workspaceId: this.botConfig.defaultWorkspaceId ?? "", source: "feishu", chatType: ctx.chatType,
+				groupName: ctx.groupName, createdAt: Date.now(),
+			};
+			this.chatBindings.set(chatId, binding);
+			this.sessionToChat.set(tab.id, chatId);
+			this.feishuSessions.add(tab.id);
+			this.updateStatus({ activeBindings: this.chatBindings.size });
+			this.persistBindings();
+			await this.sendSmartMessage(chatId, `✅ 已创建会话 (${tab.id.slice(0, 8)})`);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			await this.sendSmartMessage(chatId, `❌ 创建会话失败: ${msg}`);
+		}
+	}
+
+	/** Session Mirror: Pi 侧创建会话时自动拉群（1会话=1群） */
+	async ensureSessionMirror(sessionId: string, sessionTitle?: string): Promise<string | undefined> {
+		if (!this.client || this.status.status !== "connected") {
+			log("[飞书 Session Mirror] Bridge 未连接，跳过自动拉群");
+			return undefined;
+		}
+
+		// 已有绑定：检查是否需要修复空群（之前创建时没加用户）
+		const existingChatId = this.sessionToChat.get(sessionId);
+		if (existingChatId) {
+			const effectiveUserOpenId = this.botConfig.defaultUserOpenId || this.userOpenId;
+			if (effectiveUserOpenId) {
+				const binding = this.chatBindings.get(existingChatId);
+				if (binding && !binding.userId) {
+					// 之前创建的群没有用户，补加
+					log(`[飞书 Session Mirror] 检测到空群 ${existingChatId}，尝试补加用户 ${effectiveUserOpenId}`);
+					await this.repairEmptyGroup(existingChatId, effectiveUserOpenId);
+					binding.userId = effectiveUserOpenId;
+					this.persistBindings();
+				}
+			}
+			return existingChatId;
+		}
+
+		const groupName = `Pi Agent - ${(sessionTitle || `新会话 ${sessionId.slice(0, 8)}`).slice(0, 50)}`;
+		log(`[飞书 Session Mirror] 正在创建群: ${groupName}`);
+
+		// 用户 open_id 获取优先级：配置 > 自动记住
+		let effectiveUserOpenId: string | undefined = this.botConfig.defaultUserOpenId || this.userOpenId || undefined;
+
+		// 安全检查：防止误把 Bot 自己的 open_id 当成用户的
+		if (effectiveUserOpenId && effectiveUserOpenId === this.botOpenId) {
+			warn(`[飞书 Session Mirror] ⚠️ 配置的 open_id (${effectiveUserOpenId}) 是 Bot 自己的，已忽略`);
+			warn(`[飞书 Session Mirror] 💡 请在飞书中给 Bot 发 /whoami，Bot 会回复你真正的用户 open_id`);
+			effectiveUserOpenId = undefined;
+		}
+
+		if (!effectiveUserOpenId) {
+			log("[飞书 Session Mirror] ⚠️ 用户 open_id 未获取，群聊将只有 Bot");
+			log("[飞书 Session Mirror] 💡 提示：在飞书中给 Bot 发送任意消息或 /whoami，即可自动记录；或将 open_id 填入配置中的「你的 Open ID」字段");
+		}
+
+		try {
+			// 构建 data 对象，空 user_id_list 时不传该字段
+			const chatData: Record<string, unknown> = {
+				name: groupName, chat_mode: "group", chat_type: "private", external: false,
+			};
+			if (effectiveUserOpenId) {
+				chatData.user_id_list = [effectiveUserOpenId];
+			}
+
+			const resp = await this.client.im.chat.create({
+				data: chatData,
+				params: { user_id_type: "open_id" },
+			});
+
+			// 兼容多种 Lark SDK 响应格式
+			const respAny = resp as Record<string, unknown>;
+			const chatId = (respAny?.data as Record<string, unknown>)?.chat_id as string
+				?? respAny?.chat_id as string
+				?? undefined;
+			if (!chatId) {
+				logErr("[飞书 Session Mirror] 创建群未返回 chat_id, 原始响应:", JSON.stringify(resp).slice(0, 200));
+				return undefined;
+			}
+
+			log(`[飞书 Session Mirror] 群创建成功: chatId=${chatId}, 成员数=${effectiveUserOpenId ? 2 : 1}`);
+
+			// 创建绑定
+			const binding: FeishuChatBinding = {
+				chatId, botId: this.botConfig.id, userId: effectiveUserOpenId ?? "",
+				sessionId, workspaceId: this.botConfig.defaultWorkspaceId ?? "",
+				source: "session-mirror" as const, chatType: "group", groupName, createdAt: Date.now(),
+			};
+			this.chatBindings.set(chatId, binding);
+			this.sessionToChat.set(sessionId, chatId);
+			this.updateStatus({ activeBindings: this.chatBindings.size });
+			this.persistBindings();
+
+			await this.sendSmartMessage(chatId, `🤖 Pi Agent 会话已创建\n会话 ID: ${sessionId.slice(0, 8)}\n\n直接发消息即可与 Agent 对话。`);
+			return chatId;
+		} catch (e) {
+			const errMsg = e instanceof Error ? e.message : String(e);
+			logErr("[飞书 Session Mirror] 创建群失败:", errMsg);
+			// 如果是权限问题，提示用户
+			if (errMsg.includes("permission") || errMsg.includes("scope") || errMsg.includes("230001")) {
+				logErr("[飞书 Session Mirror] 可能缺少 im:chat 权限，请在飞书开放平台→权限管理中开启「获取群聊信息」权限");
+			}
+			return undefined;
+		}
+	}
+
+	/** 修复空群：将用户加入已有但只有 Bot 的群聊 */
+	private async repairEmptyGroup(chatId: string, userOpenId: string): Promise<void> {
+		if (!this.client) return;
+		try {
+			await this.client.im.chat.members.add({
+				path: { chat_id: chatId },
+				data: { id_list: [userOpenId] },
+				params: { member_id_type: "open_id" },
+			});
+			log(`[飞书 Session Mirror] 已将用户 ${userOpenId} 补加入群 ${chatId}`);
+		} catch (e) {
+			logErr("[飞书 Session Mirror] 补加成员失败:", e);
+		}
+	}
+
+	/** Session Mirror: Agent 运行前为 Pi 侧会话打开流式卡片 */
+	async startSessionMirrorRun(sessionId: string, sessionTitle?: string): Promise<void> {
+		if (!this.client || this.status.status !== "connected") return;
+
+		// 确保有群
+		await this.ensureSessionMirror(sessionId, sessionTitle);
+
+		const binding = this.sessionToChat.get(sessionId)
+			? this.chatBindings.get(this.sessionToChat.get(sessionId)!)
+			: undefined;
+		if (!binding || binding.source !== "session-mirror") return;
+		if (this.streamingCards.has(sessionId)) return;
+
+		const initialState = createInitialState();
+		this.streamingRunStates.set(sessionId, initialState);
+
+		const headerTitle = `${binding.groupName ?? `Pi Agent`} · Agent 处理中`;
+		try {
+			const cardStream = await CardStream.open(this.client!, binding.chatId, renderRunCard(initialState, { header: headerTitle, stopHint: "发送 /stop 可终止当前任务" }));
+			this.streamingCards.set(sessionId, cardStream);
+		} catch (e) {
+			logErr("[飞书 Session Mirror] 流式卡片创建失败:", e);
+			this.streamingRunStates.delete(sessionId);
+		}
+	}
+
+	stopSessionMirrorRun(sessionId: string): void {
+		const state = this.streamingRunStates.get(sessionId);
+		const card = this.streamingCards.get(sessionId);
+		if (state && card) {
+			const finalState = markInterrupted(state);
+			void card.flush(renderRunCard(finalState)).then(() => card.close()).catch(() => {});
+		}
+		this.streamingCards.delete(sessionId);
+		this.streamingRunStates.delete(sessionId);
+	}
+
+	private async handleStopCommand(ctx: FeishuMessageContext): Promise<void> {
+		const binding = this.chatBindings.get(ctx.chatId);
+		if (!binding) { await this.sendSmartMessage(ctx.chatId, "当前没有绑定的会话。"); return; }
+
+		// 关闭流式卡片
+		const state = this.streamingRunStates.get(binding.sessionId);
+		const card = this.streamingCards.get(binding.sessionId);
+		if (state && card) {
+			void card.flush(renderRunCard(markInterrupted(state))).then(() => card.close()).catch(() => {});
+			this.streamingCards.delete(binding.sessionId);
+			this.streamingRunStates.delete(binding.sessionId);
+		}
+
+		await this.agentManager.abort(binding.sessionId);
+		await this.sendSmartMessage(ctx.chatId, "⏹ 已停止 Agent");
+	}
+
+	private async handleStatusCommand(ctx: FeishuMessageContext): Promise<void> {
+		const binding = this.chatBindings.get(ctx.chatId);
+		const lines = ["**飞书 Bridge 状态**", `状态: ${this.status.status}`, `绑定数: ${this.chatBindings.size}`, binding ? `会话: ${binding.sessionId.slice(0, 8)}` : "会话: 未绑定"];
+		await this.sendCardMessage(ctx.chatId, { config: { wide_screen_mode: true, update_multi: true }, header: { title: { tag: "plain_text", content: "当前状态" }, template: "blue" }, elements: [{ tag: "markdown", content: lines.join("\n") }] });
+	}
+
+	// ===== 飞书消息发送（智能模式） =====
+
+	private async sendSmartMessage(chatId: string, text: string): Promise<void> {
+		if (!this.client) return;
+		const mode = chooseMessageMode(text);
+		try {
+			if (mode === "interactive") {
+				for (const card of buildMarkdownCards(text)) {
+					await this.client.im.message.create({ params: { receive_id_type: "chat_id" }, data: { receive_id: chatId, msg_type: "interactive", content: JSON.stringify(card) } });
+				}
+			} else if (mode === "post") {
+				for (const post of buildPostMessages(text)) {
+					await this.client.im.message.create({ params: { receive_id_type: "chat_id" }, data: { receive_id: chatId, msg_type: "post", content: JSON.stringify(post) } });
+				}
+			} else {
+				await this.client.im.message.create({ params: { receive_id_type: "chat_id" }, data: { receive_id: chatId, msg_type: "text", content: JSON.stringify({ text }) } });
+			}
+		} catch (e) { logErr("[飞书 Bridge] 发送消息失败:", e); }
+	}
+
+	private async sendCardMessage(chatId: string, card: Record<string, unknown>): Promise<void> {
+		if (!this.client) return;
+		try { await this.client.im.message.create({ params: { receive_id_type: "chat_id" }, data: { receive_id: chatId, msg_type: "interactive", content: JSON.stringify(card) } }); } catch (e) { logErr("[飞书 Bridge] 发送卡片失败:", e); }
+	}
+
+	private async sendHelpCard(chatId: string): Promise<void> {
+		await this.sendCardMessage(chatId, {
+			config: { wide_screen_mode: true, update_multi: true },
+			header: { title: { tag: "plain_text", content: "🤖 Pi Agent 帮助" }, template: "green" },
+			elements: [{ tag: "markdown", content: ["**可用命令**", "", "`/new` 或 `/n` — 创建新会话", "`/stop` 或 `/s` — 停止当前 Agent", "`/status` — 查看当前状态", "`/whoami` — 查看你的 open_id（用于自动拉群配置）", "`/help` 或 `/h` — 查看帮助", "", "直接发送文字消息即可与 Agent 对话。", "", "💡 **Pi 中创建会话时，飞书自动拉群**", "在 PiDeck 中新建会话后，飞书会自动创建一个群聊。", "如需自动拉你进群，请先配置「你的 Open ID」（发 /whoami 获取）。"].join("\n") }],
+		});
+	}
+
+	// ===== 图片/文件下载 =====
+
+	private async downloadImage(messageId: string, imageKey: string): Promise<Buffer> {
+		if (!this.client) throw new Error("飞书 Client 未初始化");
+		try { return await this.downloadMessageResource(messageId, imageKey, "image"); } catch { warn("[飞书 Bridge] messageResource 失败，回退到 image.get"); }
+		return this.downloadViaImageGet(imageKey);
+	}
+	private async downloadMessageResource(messageId: string, fileKey: string, type: "image" | "file"): Promise<Buffer> {
+		const resp = this.client!.im.messageResource.get({ path: { message_id: messageId, file_key: fileKey }, params: { type } });
+		return this.streamToBuffer(resp);
+	}
+	private async downloadViaImageGet(imageKey: string): Promise<Buffer> {
+		const resp = await this.client!.request({ method: "GET", url: `https://open.feishu.cn/open-apis/im/v1/images/${imageKey}` });
+		return this.streamToBuffer(resp);
+	}
+	private async downloadFile(messageId: string, fileKey: string): Promise<Buffer> { return this.downloadMessageResource(messageId, fileKey, "file"); }
+
+	private async streamToBuffer(result: unknown): Promise<Buffer> {
+		const resp = result as Record<string, unknown>;
+		if (typeof resp?.getReadableStream === "function") { const chunks: Buffer[] = []; const readable = (resp.getReadableStream as () => NodeJS.ReadableStream)(); for await (const chunk of readable as AsyncIterable<Buffer | string>) { chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)); } return Buffer.concat(chunks); }
+		if (typeof (result as AsyncIterable<unknown>)?.[Symbol.asyncIterator] === "function") { const chunks: Buffer[] = []; for await (const chunk of result as AsyncIterable<Buffer | string>) { chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)); } return Buffer.concat(chunks); }
+		if (typeof resp?.writeFile === "function") { const { readFileSync, unlinkSync } = await import("node:fs"); const tmp = `/tmp/feishu-dl-${Date.now()}.tmp`; await (resp.writeFile as (p: string) => Promise<void>)(tmp); const data = readFileSync(tmp); try { unlinkSync(tmp); } catch {} return data; }
+		logErr("[飞书 Bridge] streamToBuffer 未知格式:", typeof result); throw new Error("无法读取飞书文件流");
+	}
+
+	// ===== 群聊辅助 =====
+
+	private isBotMentioned(mentions: Array<{ name: string; id: string | { open_id: string; union_id: string; user_id: string } }> | undefined): boolean {
+		if (!mentions || mentions.length === 0) return false;
+		for (const m of mentions) { const openId = typeof m.id === "string" ? m.id : m.id.open_id; if (openId === "all") continue; if (openId === this.botOpenId) return true; }
+		return false;
+	}
+
+	private async getGroupInfo(chatId: string): Promise<FeishuGroupInfo | null> {
+		const cached = this.groupInfoCache.get(chatId);
+		if (cached && Date.now() - cached.cachedAt < GROUP_CACHE_TTL) return cached;
+		if (!this.client) return null;
+		try {
+			const [chatResp, members] = await Promise.all([this.client.im.chat.get({ path: { chat_id: chatId } }), this.fetchGroupMembers(chatId)]);
+			const name = (chatResp as { data?: { name?: string } }).data?.name ?? "未知群组";
+			const info: FeishuGroupInfo = { chatId, name, members, cachedAt: Date.now() };
+			this.groupInfoCache.set(chatId, info); return info;
+		} catch (e) { warn("[飞书 Bridge] 获取群聊信息失败:", e); return null; }
+	}
+
+	private async fetchGroupMembers(chatId: string): Promise<FeishuGroupMember[]> {
+		if (!this.client) return [];
+		try {
+			const resp = await this.client.im.chat.members.get({ path: { chat_id: chatId }, params: { user_id_type: "open_id", page_size: 100 } });
+			return ((resp as { data?: { items?: Array<{ open_id: string; name?: string }> } }).data?.items ?? []).map((m) => ({ openId: m.open_id, name: m.name ?? m.open_id }));
+		} catch (e) { warn("[飞书 Bridge] 获取群成员失败:", e); return []; }
+	}
+
+	private async getUserName(userId: string): Promise<string> {
+		const cached = this.userNameCache.get(userId);
+		if (cached) return cached;
+		this.userNameCache.set(userId, userId); return userId;
+	}
+
+	private inferImageMediaType(data: Buffer): string {
+		if (data.length < 4) return "image/png";
+		if (data[0] === 0x89 && data[1] === 0x50) return "image/png";
+		if (data[0] === 0xff && data[1] === 0xd8) return "image/jpeg";
+		if (data[0] === 0x47 && data[1] === 0x49) return "image/gif";
+		if (data[0] === 0x52 && data[1] === 0x49) return "image/webp";
+		return "image/png";
+	}
+
+	// ===== 持久化 =====
+
+	private loadPersistedBindings(): void {
+		const bindings = loadBindings(this.botConfig.id);
+		for (const b of bindings) {
+			const tabs = this.agentManager.list();
+			const tab = tabs.find((t) => t.id === b.sessionId);
+			if (tab) {
+				const binding: FeishuChatBinding = {
+					chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: b.sessionId,
+					workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
+					source: b.source as "feishu" | "session-mirror", chatType: b.chatType as "p2p" | "group",
+					groupName: b.groupName, createdAt: b.createdAt,
+				};
+				this.chatBindings.set(b.chatId, binding);
+				this.sessionToChat.set(b.sessionId, b.chatId);
+				if (b.source === "feishu" || b.source === "session-mirror") this.feishuSessions.add(b.sessionId);
+			}
+		}
+		if (this.chatBindings.size > 0) log(`[飞书 Bridge] 已恢复 ${this.chatBindings.size} 个聊天绑定`);
+		this.updateStatus({ activeBindings: this.chatBindings.size });
+	}
+
+	private persistBindings(): void {
+		const bindings: FeishuChatBindingPersist[] = Array.from(this.chatBindings.values()).map((b) => ({
+			chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: b.sessionId,
+			workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
+			source: b.source, chatType: b.chatType, groupName: b.groupName, createdAt: b.createdAt,
+		}));
+		saveBindings(this.botConfig.id, bindings);
+	}
+
+	// ===== 状态推送 =====
+
+	private updateStatus(partial: Partial<FeishuBridgeStatus>): void {
+		this.status = { ...this.status, ...partial };
+		const win = this.getWindow();
+		if (win && !win.isDestroyed()) win.webContents.send(ipcChannels.feishuStatus, this.status);
+	}
+
+	pushMessage(message: FeishuChatMessage): void {
+		const win = this.getWindow();
+		if (win && !win.isDestroyed()) win.webContents.send(ipcChannels.feishuMessages, message);
+	}
+
+	// ===== 重连 =====
+
+	private scheduleReconnect(): void {
+		if (this.reconnectTimer) return;
+		this.reconnectAttempts++;
+		if (this.reconnectAttempts > this.maxReconnectAttempts) { logErr(`[飞书 Bridge] 重连失败，已达最大尝试次数 ${this.maxReconnectAttempts}`); this.updateStatus({ status: "error", errorMessage: "连接失败，请手动重连" }); return; }
+		const delay = Math.min(5000 * Math.pow(1.5, this.reconnectAttempts - 1), 60000);
+		log(`[飞书 Bridge] 将在 ${(delay / 1000).toFixed(1)}s 后重连 (${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
+		this.updateStatus({ status: "connecting" });
+		this.reconnectTimer = setTimeout(async () => { this.reconnectTimer = null; try { await this.start(); } catch {} }, delay);
+	}
+}

--- a/src/main/feishu/FeishuBridge.ts
+++ b/src/main/feishu/FeishuBridge.ts
@@ -83,8 +83,8 @@ export class FeishuBridge {
 	private groupInfoCache = new Map<string, FeishuGroupInfo>();
 	private userNameCache = new Map<string, string>();
 
-	private pendingImages = new Map<string, FeishuImageAttachment[]>();
-	private pendingFiles = new Map<string, FeishuFileAttachment[]>();
+	// ===== 图片/文件即时处理（参考 Proma 思路：不做 pending 等待，收到即处理） =====
+	private imageConfirmTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 	// 流式卡片：sessionId → CardStream
 	private streamingCards = new Map<string, CardStream>();
@@ -92,6 +92,8 @@ export class FeishuBridge {
 	private streamingRunStates = new Map<string, RunState>();
 	// 卡片未创建时的缓存事件（并行模式下 Agent 先启动，事件暂存于此）
 	private pendingCardEvents = new Map<string, unknown[]>();
+	// 记录卡片更新失败的 session（用于 runAgent 降级兜底）
+	private cardUpdateFailed = new Set<string>();
 
 	private unsubscribeLocalEvents: (() => void) | null = null;
 	// 哪些 session 是飞书发起的（不需要 session mirror）
@@ -114,6 +116,14 @@ export class FeishuBridge {
 	getStatus(): FeishuBridgeStatus { return { ...this.status }; }
 	listBindings(): FeishuChatBinding[] { return Array.from(this.chatBindings.values()); }
 
+	/** 刷新绑定：重新从磁盘加载并匹配当前 agent 列表 */
+	reloadBindings(): void {
+		this.sessionToChat.clear();
+		this.feishuSessions.clear();
+		this.loadPersistedBindings();
+		log(`[飞书 Bridge] 手动刷新绑定完成，活跃绑定: ${this.chatBindings.size}`);
+	}
+
 	// ===== 绑定管理 =====
 
 	removeBinding(chatId: string): boolean {
@@ -126,11 +136,14 @@ export class FeishuBridge {
 		this.streamingCards.delete(binding.sessionId);
 		this.streamingRunStates.delete(binding.sessionId);
 		this.pendingCardEvents.delete(binding.sessionId);
-		this.pendingImages.delete(chatId);
-		this.pendingFiles.delete(chatId);
+		this.cardUpdateFailed.delete(binding.sessionId);
+		// 清理图片确认定时器（如果有）
+		const timer = this.imageConfirmTimers.get(chatId);
+		if (timer) { clearTimeout(timer); this.imageConfirmTimers.delete(chatId); }
 		this.lastUserMessageId.delete(chatId);
 		this.updateStatus({ activeBindings: this.chatBindings.size });
 		this.persistBindings();
+		this.pushBindings();
 		log(`[飞书 Bridge] 已移除绑定: ${chatId}`);
 		return true;
 	}
@@ -220,10 +233,12 @@ export class FeishuBridge {
 		if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
 		this.wsClient = null; this.client = null;
 		this.chatBindings.clear(); this.sessionToChat.clear(); this.feishuSessions.clear();
-		this.pendingImages.clear(); this.pendingFiles.clear();
 		this.recentMessageIds.clear(); this.recentEventIds.clear(); this.recentContent.clear();
 		this.processingChats.clear(); this.lastUserMessageId.clear();
 		this.groupInfoCache.clear(); this.userNameCache.clear(); this.botOpenId = null;
+		this.cardUpdateFailed.clear();
+		for (const [, timer] of this.imageConfirmTimers) { clearTimeout(timer); }
+		this.imageConfirmTimers.clear();
 		this.updateStatus({ status: "disconnected", activeBindings: 0 });
 		log("[飞书 Bridge] 已停止");
 	}
@@ -318,7 +333,11 @@ export class FeishuBridge {
 		this.processingChats.add(chatId);
 
 		try {
-			if (chatType === "group" && this.botConfig.requireMention !== false && !this.isBotMentioned(mentions)) return;
+			if (chatType === "group" && this.botConfig.requireMention !== false && !this.isBotMentioned(mentions)) {
+			// session-mirror 群（Bot 自建群）允许无 @mention 消息
+			const binding = this.chatBindings.get(chatId);
+			if (!binding || binding.source !== "session-mirror") return;
+		}
 			if (chatType === "group" && messageId) this.lastUserMessageId.set(chatId, messageId);
 
 			const supportedTypes = new Set(["text", "image", "post", "file"]);
@@ -332,10 +351,23 @@ export class FeishuBridge {
 				const content = JSON.parse(message.content as string) as { text?: string };
 				text = (content.text ?? "").replace(/@_user_\d+/g, "").trim();
 			} else if (messageType === "post") {
-				const content = JSON.parse(message.content as string) as { title?: string; content?: Array<Array<{ tag: string; text?: string }>> };
+				const content = JSON.parse(message.content as string) as { title?: string; content?: Array<Array<{ tag: string; text?: string; image_key?: string }>> };
 				const parts: string[] = [];
 				if (content.title) parts.push(content.title);
-				for (const line of content.content ?? []) for (const node of line) if (node.tag === "text" && node.text) parts.push(node.text);
+				for (const line of content.content ?? []) {
+					for (const node of line) {
+						if (node.tag === "text" && node.text) {
+							parts.push(node.text);
+						} else if ((node.tag === "img" || node.tag === "image") && node.image_key) {
+							try {
+								const imgData = await this.downloadImage(messageId, node.image_key);
+								imageAttachments.push({ imageKey: node.image_key, data: imgData, mediaType: this.inferImageMediaType(imgData) });
+							} catch (e) {
+								logErr("[飞书 Bridge] post 图片下载失败:", e);
+							}
+						}
+					}
+				}
 				text = parts.join(" ").replace(/@_user_\d+/g, "").trim();
 			} else if (messageType === "image") {
 				const content = JSON.parse(message.content as string) as { image_key?: string };
@@ -345,17 +377,19 @@ export class FeishuBridge {
 				if (content.file_key) { try { const fileData = await this.downloadFile(messageId, content.file_key); if (fileData.length > 50 * 1024 * 1024) { await this.sendSmartMessage(chatId, "文件过大（超过 50MB），暂不支持处理。"); return; } fileAttachments.push({ fileKey: content.file_key, fileName: content.file_name || `feishu-${content.file_key}`, data: fileData }); } catch (e) { logErr("[飞书 Bridge] 下载文件失败:", e); await this.sendSmartMessage(chatId, "⚠️ 文件下载失败，请重试。"); return; } }
 			}
 
-			if (!text && (imageAttachments.length > 0 || fileAttachments.length > 0)) {
-				if (imageAttachments.length > 0) { const existing = this.pendingImages.get(chatId) ?? []; existing.push(...imageAttachments); this.pendingImages.set(chatId, existing); }
-				if (fileAttachments.length > 0) { const existing = this.pendingFiles.get(chatId) ?? []; existing.push(...fileAttachments); this.pendingFiles.set(chatId, existing); }
-				const parts: string[] = []; const ic = this.pendingImages.get(chatId)?.length ?? 0; const fc = this.pendingFiles.get(chatId)?.length ?? 0;
-				if (ic > 0) parts.push(`${ic} 张图片`); if (fc > 0) parts.push(`${fc} 个文件`);
-				await this.sendSmartMessage(chatId, `已收到${parts.join("和")}，请继续发送文字消息来触发处理。`);
-				return;
+			// ===== 即时处理模式（参考 Proma：收到图片/文件立即处理，不做 pending 等待） =====
+			// 图片/文件 + 文字 → 一起处理
+			// 仅图片 → 自动附加 "请根据图片内容进行分析" 作为 prompt
+			// 仅文件 → 自动附加 "请处理以下文件内容" 作为 prompt
+			if (!text && imageAttachments.length > 0 && fileAttachments.length === 0) {
+				text = "请根据图片内容进行分析。";
+			} else if (!text && fileAttachments.length > 0) {
+				const imageCount = imageAttachments.length;
+				const fileNames = fileAttachments.map((f) => f.fileName).join(", ");
+				text = imageCount > 0
+					? `请根据 ${imageCount} 张图片和以下文件内容进行分析。\n文件: ${fileNames}`
+					: `请处理以下文件内容。\n文件: ${fileNames}`;
 			}
-
-			if (text && this.pendingImages.has(chatId)) { imageAttachments.unshift(...this.pendingImages.get(chatId)!); this.pendingImages.delete(chatId); }
-			if (text && this.pendingFiles.has(chatId)) { fileAttachments.unshift(...this.pendingFiles.get(chatId)!); this.pendingFiles.delete(chatId); }
 			if (!text && imageAttachments.length === 0 && fileAttachments.length === 0) return;
 
 			let groupName: string | undefined; let senderName: string | undefined;
@@ -399,6 +433,10 @@ export class FeishuBridge {
 					`你的 open_id: \`${userId}\`\n\n📋 你可以将此 ID 填入 PiDeck 飞书配置中的「你的 Open ID」字段，以便新建会话时自动拉你进群。`
 				);
 				break;
+			case "/refresh": case "/r":
+				this.reloadBindings();
+				await this.sendSmartMessage(chatId, `✅ 已刷新绑定 (${this.chatBindings.size} 个活跃)`);
+				break;
 			default: await this.sendSmartMessage(chatId, `未知命令: ${command}。输入 /help 查看帮助。`);
 		}
 	}
@@ -408,7 +446,24 @@ export class FeishuBridge {
 	private async runAgent(ctx: FeishuMessageContext, text: string, imageAttachments: FeishuImageAttachment[], fileAttachments: FeishuFileAttachment[]): Promise<void> {
 		const { chatId } = ctx;
 		let binding = this.chatBindings.get(chatId);
-		if (!binding) { await this.createNewSession(ctx); binding = this.chatBindings.get(chatId); if (!binding) return; }
+
+		// ===== 绑定失效恢复：重启后 sessionId 对应的 agent 不存在时，自动恢复或重建 =====
+		if (binding) {
+			const agentExists = this.agentManager.list().some((t) => t.id === binding!.sessionId);
+			if (!agentExists) {
+				log(`[飞书 Bridge] 绑定 ${chatId} 的 agent ${binding.sessionId.slice(0, 8)} 不存在，尝试恢复...`);
+				const resumed = await this.resumeOrCreateAgent(binding);
+				if (!resumed) {
+					await this.sendSmartMessage(chatId, "⚠️ 会话恢复失败，请尝试 /new 创建新会话");
+					return;
+				}
+				binding = resumed;
+			}
+		} else {
+			await this.createNewSession(ctx);
+			binding = this.chatBindings.get(chatId);
+			if (!binding) return;
+		}
 
 		// 关闭已有流式卡片
 		const existingCard = this.streamingCards.get(binding.sessionId);
@@ -463,8 +518,24 @@ export class FeishuBridge {
 			// agent_end 事件会在 handleAgentEvent 中 flush 终态卡片
 			await this.waitForAgentEnd(binding.sessionId, 300_000);
 
+			// 等待一小段时间让 handleAgentEvent 的异步 flush 完成
+			await new Promise((r) => setTimeout(r, 800));
+
 			// 如果流式卡片已创建，结果已展示在卡片中，无需额外发送
 			if (hasCard) {
+				// 检查卡片更新是否失败（patch 错误被静默吞掉的情况）
+				if (this.cardUpdateFailed.has(binding.sessionId)) {
+					this.cardUpdateFailed.delete(binding.sessionId);
+					log(`[飞书 Bridge] 卡片更新失败，降级为文本消息`);
+					// 降级：用文本消息发送最终结果
+					const messages = this.agentManager.getMessages(binding.sessionId);
+					const lastAssistant = messages.filter((m) => m.role === "assistant").pop();
+					const resultText = lastAssistant?.text ?? "";
+					if (resultText.trim()) {
+						const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+						await this.sendSmartMessage(chatId, `${resultText}\n\n---\n⏱ ${duration}s`);
+					}
+				}
 				// 清理可能残留的状态（handleAgentEvent 已处理大部分）
 				this.streamingCards.delete(binding.sessionId);
 				this.streamingRunStates.delete(binding.sessionId);
@@ -492,6 +563,7 @@ export class FeishuBridge {
 			}
 			this.streamingRunStates.delete(binding.sessionId);
 			this.pendingCardEvents.delete(binding.sessionId);
+			this.cardUpdateFailed.delete(binding.sessionId);
 			await this.sendSmartMessage(chatId, `❌ Agent 错误: ${msg}`);
 		}
 	}
@@ -556,8 +628,17 @@ export class FeishuBridge {
 				if (nextState.terminal === "running") {
 					cardStream.update(card);
 				} else {
-					// 终态：强制 flush + close
-					void cardStream.flush(card).then(() => cardStream.close()).catch(() => {});
+					// 终态：强制 flush + close，记录失败以便 runAgent 降级兜底
+					void cardStream.flush(card).then(() => {
+						// flush 成功 → 检查实际 patch 是否成功
+						if (cardStream.lastPatchFailed) {
+							this.cardUpdateFailed.add(agentId);
+							log(`[飞书 Bridge] 终态卡片 patch 失败: ${cardStream.lastPatchError}`);
+						}
+					}).then(() => cardStream.close()).catch((e) => {
+						this.cardUpdateFailed.add(agentId);
+						logErr("[飞书 Bridge] 终态卡片 flush/close 异常:", e);
+					});
 					this.streamingRunStates.delete(agentId);
 					this.streamingCards.delete(agentId);
 					this.pendingCardEvents.delete(agentId);
@@ -611,7 +692,7 @@ export class FeishuBridge {
 			// 没有绑定，尝试创建 session mirror
 			const tab = this.agentManager.list().find(t => t.id === agentId);
 			if (tab) {
-				await this.ensureSessionMirror(agentId, tab.title);
+				await this.ensureSessionMirror(agentId, tab.title, tab.sessionPath);
 			}
 			return;
 		}
@@ -631,7 +712,7 @@ export class FeishuBridge {
 			const tab = await this.agentManager.create({ projectId });
 			const binding: FeishuChatBinding = {
 				chatId, botId: this.botConfig.id, userId: ctx.senderOpenId, sessionId: tab.id,
-				workspaceId: this.botConfig.defaultWorkspaceId ?? "", source: "feishu", chatType: ctx.chatType,
+				sessionPath: tab.sessionPath, workspaceId: this.botConfig.defaultWorkspaceId ?? "", source: "feishu", chatType: ctx.chatType,
 				groupName: ctx.groupName, createdAt: Date.now(),
 			};
 			this.chatBindings.set(chatId, binding);
@@ -639,6 +720,7 @@ export class FeishuBridge {
 			this.feishuSessions.add(tab.id);
 			this.updateStatus({ activeBindings: this.chatBindings.size });
 			this.persistBindings();
+			this.pushBindings();
 			await this.sendSmartMessage(chatId, `✅ 已创建会话 (${tab.id.slice(0, 8)})`);
 		} catch (e) {
 			const msg = e instanceof Error ? e.message : String(e);
@@ -646,8 +728,69 @@ export class FeishuBridge {
 		}
 	}
 
+	/**
+	 * 绑定失效恢复：当 sessionId 对应的 agent 不存在时，
+	 * 尝试用 sessionPath 恢复会话；若无法恢复则创建新 agent 并复用已有绑定（不留群）。
+	 * 参考了 Proma 的 ConversationManager 思路：用 chatId 作为稳定 key，
+	 * 会话文件持久化，重启后优先恢复而不是重建。
+	 */
+	private async resumeOrCreateAgent(binding: FeishuChatBinding): Promise<FeishuChatBinding | undefined> {
+		const projects = this.getProjects();
+		if (projects.length === 0) {
+			log("[飞书 Bridge] 恢复会话失败：无可用项目");
+			return undefined;
+		}
+		const projectId = projects[0].id;
+
+		// 1. 尝试用 sessionPath 恢复已有会话
+		if (binding.sessionPath) {
+			const { existsSync } = await import("node:fs");
+			if (existsSync(binding.sessionPath)) {
+				try {
+					const tab = await this.agentManager.create({
+						projectId,
+						sessionPath: binding.sessionPath,
+						title: binding.groupName || `飞书会话`,
+					});
+					log(`[飞书 Bridge] 会话恢复成功: ${tab.id} (从 ${binding.sessionPath})`);
+					binding.sessionId = tab.id;
+					binding.sessionPath = tab.sessionPath;
+					this.sessionToChat.set(tab.id, binding.chatId);
+					this.feishuSessions.add(tab.id);
+					this.chatBindings.set(binding.chatId, binding);
+					this.persistBindings();
+					this.pushBindings();
+					return binding;
+				} catch (e) {
+					log(`[飞书 Bridge] sessionPath 恢复失败: ${e instanceof Error ? e.message : String(e)}`);
+				}
+			} else {
+				log(`[飞书 Bridge] sessionPath 不存在: ${binding.sessionPath}`);
+			}
+		}
+
+		// 2. sessionPath 不可用 → 创建新 agent，复用已有 chatId 绑定（不新建群）
+		try {
+			const tab = await this.agentManager.create({ projectId, title: binding.groupName || `飞书会话` });
+			log(`[飞书 Bridge] 已为新 agent ${tab.id} 复用绑定 ${binding.chatId}`);
+			binding.sessionId = tab.id;
+			binding.sessionPath = tab.sessionPath;
+			this.sessionToChat.set(tab.id, binding.chatId);
+			this.feishuSessions.add(tab.id);
+			this.chatBindings.set(binding.chatId, binding);
+			this.persistBindings();
+			this.pushBindings();
+			await this.sendSmartMessage(binding.chatId, `🔄 会话已恢复，新 ID: ${tab.id.slice(0, 8)}`);
+			return binding;
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			logErr(`[飞书 Bridge] 新建 agent 失败: ${msg}`);
+			return undefined;
+		}
+	}
+
 	/** Session Mirror: Pi 侧创建会话时自动拉群（1会话=1群） */
-	async ensureSessionMirror(sessionId: string, sessionTitle?: string): Promise<string | undefined> {
+	async ensureSessionMirror(sessionId: string, sessionTitle?: string, sessionPath?: string): Promise<string | undefined> {
 		if (!this.client || this.status.status !== "connected") {
 			log("[飞书 Session Mirror] Bridge 未连接，跳过自动拉群");
 			return undefined;
@@ -655,31 +798,59 @@ export class FeishuBridge {
 
 		const groupName = `Pi Agent - ${(sessionTitle || `新会话 ${sessionId.slice(0, 8)}`).slice(0, 50)}`;
 
-		// 1. 先按 sessionId 找已有绑定
+		// 1. 按 sessionId 找已有绑定
 		let existingChatId = this.sessionToChat.get(sessionId);
 
-		// 2. sessionId 没匹配 → 按 groupName 在所有绑定中搜索（重启后 sessionId 可能变）
-		if (!existingChatId) {
-			for (const [chatId, binding] of this.chatBindings) {
-				if (binding.groupName === groupName && binding.source === "session-mirror") {
-					log(`[飞书 Session Mirror] 按群名匹配到已有群: ${groupName} → ${chatId}`);
-					existingChatId = chatId;
+		// 2. sessionId 没匹配 → 尝试按 sessionPath 找已有绑定
+		//    （重启后 sessionId 变但 sessionPath 不变，可精准复用旧群）
+		if (!existingChatId && sessionPath) {
+			for (const [cid, binding] of this.chatBindings) {
+				if (binding.sessionPath && binding.sessionPath === sessionPath) {
+					existingChatId = cid;
+					log(`[飞书 Session Mirror] 按 sessionPath 复用旧群: ${cid} (path: ${sessionPath})`);
 					// 更新 sessionId 映射
-					this.sessionToChat.set(sessionId, chatId);
-					// 更新绑定中的 sessionId
 					binding.sessionId = sessionId;
+					this.sessionToChat.set(sessionId, cid);
+					this.feishuSessions.add(sessionId);
 					this.persistBindings();
 					break;
 				}
 			}
 		}
 
-		// 3. 已有绑定：检查是否需要修复空群
+		// 3. 已有绑定：检查是否需要修复空群，确保 sessionId 映射正确；或者尝试复用孤立的 session-mirror 群
+		if (!existingChatId) {
+			// 3a. 没有直接匹配 → 尝试复用孤立的 session-mirror 群（重启后 sessionId 变化导致的孤儿）
+			for (const [cid, binding] of this.chatBindings) {
+				if (
+					binding.source === "session-mirror" &&
+					binding.botId === this.botConfig.id &&
+					!this.agentManager.list().some(t => t.id === binding.sessionId)
+				) {
+					const oldSessionId = binding.sessionId;
+					existingChatId = cid;
+					binding.sessionId = sessionId;
+					if (sessionPath) binding.sessionPath = sessionPath;
+					this.sessionToChat.set(sessionId, cid);
+					this.feishuSessions.add(sessionId);
+					log(`[飞书 Session Mirror] 复用孤立飞书群: ${cid} (原 ${oldSessionId?.slice(0, 8)} → ${sessionId.slice(0, 8)})`);
+					this.persistBindings();
+					this.pushBindings();
+					break;
+				}
+			}
+		}
+
 		if (existingChatId) {
 			const effectiveUserOpenId = this.botConfig.defaultUserOpenId || this.userOpenId;
-			if (effectiveUserOpenId) {
-				const binding = this.chatBindings.get(existingChatId);
-				if (binding && !binding.userId) {
+			const binding = this.chatBindings.get(existingChatId);
+			if (binding) {
+				// 确保当前 sessionId 也有映射（可能刚通过 sessionPath 匹配到）
+				if (binding.sessionId !== sessionId) {
+					this.sessionToChat.set(sessionId, existingChatId);
+					this.feishuSessions.add(sessionId);
+				}
+				if (effectiveUserOpenId && !binding.userId) {
 					log(`[飞书 Session Mirror] 检测到空群 ${existingChatId}，尝试补加用户 ${effectiveUserOpenId}`);
 					await this.repairEmptyGroup(existingChatId, effectiveUserOpenId).catch(() => {});
 					binding.userId = effectiveUserOpenId;
@@ -734,15 +905,18 @@ export class FeishuBridge {
 			log(`[飞书 Session Mirror] 群创建成功: chatId=${chatId}, 成员数=${effectiveUserOpenId ? 2 : 1}`);
 
 			// 创建绑定
+			// 找到对应的 agent tab 以获取 sessionPath
+			const agentTab = this.agentManager.list().find((t) => t.id === sessionId);
 			const binding: FeishuChatBinding = {
 				chatId, botId: this.botConfig.id, userId: effectiveUserOpenId ?? "",
-				sessionId, workspaceId: this.botConfig.defaultWorkspaceId ?? "",
+				sessionId, sessionPath: agentTab?.sessionPath, workspaceId: this.botConfig.defaultWorkspaceId ?? "",
 				source: "session-mirror" as const, chatType: "group", groupName, createdAt: Date.now(),
 			};
 			this.chatBindings.set(chatId, binding);
 			this.sessionToChat.set(sessionId, chatId);
 			this.updateStatus({ activeBindings: this.chatBindings.size });
 			this.persistBindings();
+			this.pushBindings();
 
 			await this.sendSmartMessage(chatId, `🤖 Pi Agent 会话已创建\n会话 ID: ${sessionId.slice(0, 8)}\n\n直接发消息即可与 Agent 对话。`);
 			return chatId;
@@ -773,11 +947,11 @@ export class FeishuBridge {
 	}
 
 	/** Session Mirror: Agent 运行前为 Pi 侧会话打开流式卡片 */
-	async startSessionMirrorRun(sessionId: string, sessionTitle?: string): Promise<void> {
+	async startSessionMirrorRun(sessionId: string, sessionTitle?: string, sessionPath?: string): Promise<void> {
 		if (!this.client || this.status.status !== "connected") return;
 
 		// 确保有群
-		await this.ensureSessionMirror(sessionId, sessionTitle);
+		await this.ensureSessionMirror(sessionId, sessionTitle, sessionPath);
 
 		const binding = this.sessionToChat.get(sessionId)
 			? this.chatBindings.get(this.sessionToChat.get(sessionId)!)
@@ -863,7 +1037,7 @@ export class FeishuBridge {
 		await this.sendCardMessage(chatId, {
 			config: { wide_screen_mode: true, update_multi: true },
 			header: { title: { tag: "plain_text", content: "🤖 Pi Agent 帮助" }, template: "green" },
-			elements: [{ tag: "markdown", content: ["**可用命令**", "", "`/new` 或 `/n` — 创建新会话", "`/stop` 或 `/s` — 停止当前 Agent", "`/status` — 查看当前状态", "`/whoami` — 查看你的 open_id（用于自动拉群配置）", "`/help` 或 `/h` — 查看帮助", "", "直接发送文字消息即可与 Agent 对话。", "", "💡 **Pi 中创建会话时，飞书自动拉群**", "在 PiDeck 中新建会话后，飞书会自动创建一个群聊。", "如需自动拉你进群，请先配置「你的 Open ID」（发 /whoami 获取）。"].join("\n") }],
+			elements: [{ tag: "markdown", content: ["**可用命令**", "", "`/new` 或 `/n` — 创建新会话", "`/stop` 或 `/s` — 停止当前 Agent", "`/status` — 查看当前状态", "`/whoami` — 查看你的 open_id（用于自动拉群配置）", "`/refresh` 或 `/r` — 手动刷新绑定", "`/help` 或 `/h` — 查看帮助", "", "直接发送文字消息即可与 Agent 对话。", "", "💡 **Pi 中创建会话时，飞书自动拉群**", "在 PiDeck 中新建会话后，飞书会自动创建一个群聊。", "如需自动拉你进群，请先配置「你的 Open ID」（发 /whoami 获取）。"].join("\n") }],
 		});
 	}
 
@@ -875,7 +1049,7 @@ export class FeishuBridge {
 		return this.downloadViaImageGet(imageKey);
 	}
 	private async downloadMessageResource(messageId: string, fileKey: string, type: "image" | "file"): Promise<Buffer> {
-		const resp = this.client!.im.messageResource.get({ path: { message_id: messageId, file_key: fileKey }, params: { type } });
+		const resp = await this.client!.im.messageResource.get({ path: { message_id: messageId, file_key: fileKey }, params: { type } });
 		return this.streamToBuffer(resp);
 	}
 	private async downloadViaImageGet(imageKey: string): Promise<Buffer> {
@@ -958,6 +1132,7 @@ export class FeishuBridge {
 			if (tab) {
 				const binding: FeishuChatBinding = {
 					chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: tab.id,
+					sessionPath: tab.sessionPath ?? b.sessionPath,
 					workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
 					source: b.source as "feishu" | "session-mirror", chatType: b.chatType as "p2p" | "group",
 					groupName: b.groupName, createdAt: b.createdAt,
@@ -966,17 +1141,22 @@ export class FeishuBridge {
 				this.sessionToChat.set(tab.id, b.chatId);
 				if (b.source === "feishu" || b.source === "session-mirror") this.feishuSessions.add(tab.id);
 			} else {
-				// session-mirror 绑定：即使没有匹配的 tab 也保留，后续 ensureSessionMirror 会处理
-				if (b.source === "session-mirror") {
-					log(`[飞书 Bridge] 保留无主绑定（等后续匹配）: ${b.groupName ?? b.chatId}`);
-					const binding: FeishuChatBinding = {
-						chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: b.sessionId,
-						workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
-						source: b.source as "feishu" | "session-mirror", chatType: b.chatType as "p2p" | "group",
-						groupName: b.groupName, createdAt: b.createdAt,
-					};
-					this.chatBindings.set(b.chatId, binding);
-				}
+				// 无匹配 tab: 保留绑定（用存储的 sessionId/sessionPath），
+				// 后续消息到来时 resumeOrCreateAgent 会恢复或重建 agent。
+				// 参考了 Proma 的 ConversationManager 思路：chatId 是稳定 key，
+				// 不依赖 agent 运行状态。
+				log(`[飞书 Bridge] 保留无主绑定（等后续恢复）: ${b.groupName ?? b.chatId}，sessionPath=${b.sessionPath ?? "(无)"}`);
+				const binding: FeishuChatBinding = {
+					chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: b.sessionId,
+					sessionPath: b.sessionPath,
+					workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
+					source: b.source as "feishu" | "session-mirror", chatType: b.chatType as "p2p" | "group",
+					groupName: b.groupName, createdAt: b.createdAt,
+				};
+				this.chatBindings.set(b.chatId, binding);
+				// 即使 agent 不存在，也建立 sessionId → chatId 映射，
+				// 方便后续通过 resumeOrCreateAgent 更新
+				if (b.sessionId) this.sessionToChat.set(b.sessionId, b.chatId);
 			}
 		}
 		if (this.chatBindings.size > 0) log(`[飞书 Bridge] 已恢复 ${this.chatBindings.size} 个聊天绑定`);
@@ -986,6 +1166,7 @@ export class FeishuBridge {
 	private persistBindings(): void {
 		const bindings: FeishuChatBindingPersist[] = Array.from(this.chatBindings.values()).map((b) => ({
 			chatId: b.chatId, botId: b.botId, userId: b.userId, sessionId: b.sessionId,
+			sessionPath: b.sessionPath,
 			workspaceId: b.workspaceId, channelId: b.channelId, modelId: b.modelId,
 			source: b.source, chatType: b.chatType, groupName: b.groupName, createdAt: b.createdAt,
 		}));
@@ -998,6 +1179,14 @@ export class FeishuBridge {
 		this.status = { ...this.status, ...partial };
 		const win = this.getWindow();
 		if (win && !win.isDestroyed()) win.webContents.send(ipcChannels.feishuStatus, this.status);
+	}
+
+	/** 将绑定列表推送到前端（绑定变更时调用） */
+	private pushBindings(): void {
+		const win = this.getWindow();
+		if (win && !win.isDestroyed()) {
+			win.webContents.send(ipcChannels.feishuBindingsChanged, this.listBindings());
+		}
 	}
 
 	pushMessage(message: FeishuChatMessage): void {

--- a/src/main/feishu/FeishuConfig.ts
+++ b/src/main/feishu/FeishuConfig.ts
@@ -1,0 +1,198 @@
+/**
+ * 飞书配置管理
+ *
+ * 多 Bot CRUD + App Secret 加密存储。
+ * 数据持久化到 ~/.pi-desktop/feishu.json
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { app } from "electron";
+import type { FeishuBotConfig } from "../../shared/types";
+
+// ===== 配置文件路径 =====
+
+function getConfigDir(): string {
+	const dir = join(app.getPath("userData"), "pi-desktop");
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	return dir;
+}
+
+function getFeishuConfigPath(): string {
+	return join(getConfigDir(), "feishu.json");
+}
+
+function getFeishuBindingsPath(botId: string): string {
+	return join(getConfigDir(), `feishu-bindings-${botId}.json`);
+}
+
+// ===== 多 Bot 配置 =====
+
+export type FeishuMultiBotConfig = {
+	version: 2;
+	bots: FeishuBotConfig[];
+};
+
+function readConfig(): FeishuMultiBotConfig {
+	const path = getFeishuConfigPath();
+	if (!existsSync(path)) {
+		return { version: 2, bots: [] };
+	}
+	try {
+		const raw = readFileSync(path, "utf-8");
+		const parsed = JSON.parse(raw);
+
+		// 向后兼容 v1 格式（单 Bot）
+		if (parsed.version === 1 && parsed.appId) {
+			return {
+				version: 2,
+				bots: [
+					{
+						id: parsed.id || randomUUID(),
+						name: parsed.name || "默认机器人",
+						enabled: parsed.enabled !== false,
+						appId: parsed.appId || "",
+						appSecret: parsed.appSecret || "",
+						defaultWorkspaceId: parsed.defaultWorkspaceId,
+						requireMention: parsed.requireMention,
+					},
+				],
+			};
+		}
+
+		return parsed as FeishuMultiBotConfig;
+	} catch {
+		return { version: 2, bots: [] };
+	}
+}
+
+function writeConfig(config: FeishuMultiBotConfig): void {
+	const path = getFeishuConfigPath();
+	writeFileSync(path, JSON.stringify(config, null, 2), "utf-8");
+}
+
+// ===== 公开 API =====
+
+/** 列出所有 Bot 配置 */
+export function listBots(): FeishuBotConfig[] {
+	return readConfig().bots;
+}
+
+/** 获取单个 Bot 配置 */
+export function getBot(botId: string): FeishuBotConfig | undefined {
+	return readConfig().bots.find((b) => b.id === botId);
+}
+
+/** 添加 Bot */
+export function addBot(input: {
+	name: string;
+	appId: string;
+	appSecret: string;
+	defaultWorkspaceId?: string;
+	defaultUserOpenId?: string;
+	requireMention?: boolean;
+}): FeishuBotConfig {
+	const config = readConfig();
+	const bot: FeishuBotConfig = {
+		id: randomUUID(),
+		name: input.name,
+		enabled: true,
+		appId: input.appId,
+		appSecret: encryptSecret(input.appSecret),
+		defaultWorkspaceId: input.defaultWorkspaceId,
+		defaultUserOpenId: input.defaultUserOpenId,
+		requireMention: input.requireMention ?? true,
+	};
+	config.bots.push(bot);
+	writeConfig(config);
+	return bot;
+}
+
+/** 更新 Bot 配置 */
+export function updateBot(botId: string, patch: Partial<FeishuBotConfig>): FeishuBotConfig | undefined {
+	const config = readConfig();
+	const index = config.bots.findIndex((b) => b.id === botId);
+	if (index === -1) return undefined;
+
+	// 如果 patch.appSecret 是明文（不是 base64），加密后存储
+	if (patch.appSecret && !isBase64(patch.appSecret)) {
+		patch.appSecret = encryptSecret(patch.appSecret);
+	}
+
+	config.bots[index] = { ...config.bots[index], ...patch };
+	writeConfig(config);
+	return config.bots[index];
+}
+
+/** 删除 Bot */
+export function removeBot(botId: string): boolean {
+	const config = readConfig();
+	const before = config.bots.length;
+	config.bots = config.bots.filter((b) => b.id !== botId);
+	if (config.bots.length === before) return false;
+	writeConfig(config);
+	return true;
+}
+
+/** 解密 App Secret */
+export function getDecryptedBotAppSecret(botId: string): string {
+	const bot = getBot(botId);
+	if (!bot) return "";
+	return decryptSecret(bot.appSecret);
+}
+
+// ===== 绑定持久化 =====
+
+export type FeishuChatBindingPersist = {
+	chatId: string;
+	botId: string;
+	userId: string;
+	sessionId: string;
+	workspaceId: string;
+	channelId?: string;
+	modelId?: string;
+	source: string;
+	chatType: string;
+	groupName?: string;
+	createdAt: number;
+};
+
+export function loadBindings(botId: string): FeishuChatBindingPersist[] {
+	const path = getFeishuBindingsPath(botId);
+	if (!existsSync(path)) return [];
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as FeishuChatBindingPersist[];
+	} catch {
+		return [];
+	}
+}
+
+export function saveBindings(botId: string, bindings: FeishuChatBindingPersist[]): void {
+	const path = getFeishuBindingsPath(botId);
+	writeFileSync(path, JSON.stringify(bindings, null, 2), "utf-8");
+}
+
+// ===== 加密/解密（简化版，用 Electron safeStorage） =====
+
+function encryptSecret(plainSecret: string): string {
+	// Phase 1: 简单 base64，后续可升级为 Electron safeStorage
+	return Buffer.from(plainSecret, "utf-8").toString("base64");
+}
+
+function decryptSecret(encryptedSecret: string): string {
+	if (!encryptedSecret) return "";
+	try {
+		return Buffer.from(encryptedSecret, "base64").toString("utf-8");
+	} catch {
+		return encryptedSecret; // 降级：返回原始值
+	}
+}
+
+function isBase64(str: string): boolean {
+	// Base64 只包含 A-Za-z0-9+/= 字符，且长度是 4 的倍数
+	if (!str || str.length % 4 !== 0) return false;
+	return /^[A-Za-z0-9+/]*={0,2}$/.test(str);
+}

--- a/src/main/feishu/FeishuConfig.ts
+++ b/src/main/feishu/FeishuConfig.ts
@@ -151,6 +151,7 @@ export type FeishuChatBindingPersist = {
 	botId: string;
 	userId: string;
 	sessionId: string;
+	sessionPath?: string;
 	workspaceId: string;
 	channelId?: string;
 	modelId?: string;

--- a/src/main/feishu/TaskStatusCard.ts
+++ b/src/main/feishu/TaskStatusCard.ts
@@ -1,0 +1,316 @@
+/**
+ * TaskStatusCard — 飞书任务状态流式卡片
+ *
+ * 参考 pi-feishu-lark 的 TaskStatusCard 实现：
+ * 1. 先发一张"处理中"骨架卡片
+ * 2. Agent 事件驱动实时更新卡片（400ms 节流）
+ * 3. 终态强制 flush
+ *
+ * 利用飞书 CardKit 2.0 的 update_multi + v1.message.patch API
+ * 实现流式输出效果，而非等待完成后一次性弹出卡片。
+ */
+
+import type { LarkClient } from "./types";
+
+export type TaskStatus = "running" | "done" | "failed" | "stopped" | "inactive";
+
+const MAX_PHASE_CHARS = 96;
+const STILL_RUNNING_MS = 25_000;
+const RUNNING_UPDATE_INTERVAL_MS = 3_000;
+
+export class TaskStatusCard {
+	private cardMessageId: string | undefined;
+	private phase = "开始处理";
+	private status: TaskStatus = "running";
+	private heartbeat: NodeJS.Timeout | undefined;
+	private lastUpdateAt = 0;
+	private lastRunningUpdateAt = 0;
+	private pendingRunningTimer: NodeJS.Timeout | undefined;
+	private pendingRunningPhase: string | undefined;
+	private runningUpdateInFlight = false;
+	private patchQueue: Promise<void> = Promise.resolve();
+	private accumulatedText = "";
+
+	constructor(
+		private readonly key: string,
+		private readonly replyToMessageId: string | undefined,
+		private readonly chatId: string,
+		private readonly client: LarkClient,
+	) {}
+
+	async start() {
+		try {
+			this.cardMessageId = await this.sendCard(
+				buildTaskStatusCard({ key: this.key, status: "running", phase: this.phase }),
+			);
+			this.lastUpdateAt = Date.now();
+			this.lastRunningUpdateAt = this.lastUpdateAt;
+			this.startHeartbeat();
+		} catch (e) {
+			// 卡片发送失败不致命
+			console.error("[飞书 TaskStatusCard] start 失败:", e);
+		}
+	}
+
+	/** 从 Agent 事件更新当前阶段描述 */
+	updateFromEvent(event: unknown) {
+		if (this.status !== "running") return;
+		const phase = describePiEvent(event);
+		if (!phase) return;
+		void this.updateRunningPhase(phase);
+	}
+
+	/** 累积 assistant 文本增量（用于流式展示） */
+	accumulateText(delta: string) {
+		if (this.status !== "running") return;
+		this.accumulatedText += delta;
+		void this.updateRunningPhase(
+			this.accumulatedText.length > 200
+				? this.accumulatedText.slice(0, 200) + "…"
+				: this.accumulatedText,
+		);
+	}
+
+	/** 设置累积文本（agent_end 时用完整内容替换） */
+	setFullText(text: string) {
+		this.accumulatedText = text;
+	}
+
+	async stopImmediately(phase = "用户已停止任务") {
+		await this.finishFinal("stopped", phase);
+	}
+
+	async finish(status: Exclude<TaskStatus, "running" | "inactive">, phase?: string) {
+		await this.finishFinal(status, phase);
+	}
+
+	private async finishFinal(status: Exclude<TaskStatus, "running" | "inactive">, phase: string | undefined) {
+		if (this.status !== "running") return;
+		this.status = status;
+		this.stopHeartbeat();
+		this.clearPendingRunningUpdate();
+		const finalPhase = phase ? normalizePhase(phase) : defaultFinalPhase(status);
+		await this.patch(buildTaskStatusCard({ key: this.key, status, phase: finalPhase }), { final: true, force: true });
+	}
+
+	private updateRunningPhase(phase: string) {
+		const next = normalizePhase(phase);
+		if (!next || next === this.phase || next === this.pendingRunningPhase) return;
+		this.pendingRunningPhase = next;
+		this.scheduleRunningUpdate();
+	}
+
+	private scheduleRunningUpdate() {
+		if (this.status !== "running" || this.runningUpdateInFlight || this.pendingRunningTimer) return;
+		const now = Date.now();
+		const waitMs = Math.max(0, RUNNING_UPDATE_INTERVAL_MS - (now - this.lastRunningUpdateAt));
+		if (waitMs > 0) {
+			this.pendingRunningTimer = setTimeout(() => {
+				this.pendingRunningTimer = undefined;
+				void this.flushRunningUpdate();
+			}, waitMs);
+			this.pendingRunningTimer.unref?.();
+			return;
+		}
+		void this.flushRunningUpdate();
+	}
+
+	private async flushRunningUpdate() {
+		if (this.status !== "running" || this.runningUpdateInFlight) return;
+		const next = this.pendingRunningPhase;
+		this.pendingRunningPhase = undefined;
+		if (!next || next === this.phase) return;
+
+		this.runningUpdateInFlight = true;
+		this.phase = next;
+		this.lastRunningUpdateAt = Date.now();
+		try {
+			await this.patch(buildTaskStatusCard({ key: this.key, status: "running", phase: this.phase }));
+		} finally {
+			this.runningUpdateInFlight = false;
+		}
+		if (this.pendingRunningPhase) this.scheduleRunningUpdate();
+	}
+
+	private async patch(card: object, options: { final?: boolean; force?: boolean } = {}) {
+		if (!this.cardMessageId) return;
+		const messageId = this.cardMessageId;
+		const next = this.patchQueue
+			.catch(() => undefined)
+			.then(async () => {
+				if (!options.final && !options.force && this.status !== "running") return;
+				try {
+					await this.client.im.v1.message.patch({
+						path: { message_id: messageId },
+						data: { content: JSON.stringify(card) },
+					});
+					this.lastUpdateAt = Date.now();
+				} catch (e) {
+					// 更新失败不致命
+					console.error("[飞书 TaskStatusCard] patch 失败:", e);
+					if (options.final) {
+						await sleep(RUNNING_UPDATE_INTERVAL_MS);
+						try {
+							await this.client.im.v1.message.patch({
+								path: { message_id: messageId },
+								data: { content: JSON.stringify(card) },
+							});
+						} catch { /* 最终重试也失败就放弃了 */ }
+					}
+				}
+			});
+		this.patchQueue = next;
+		await next;
+	}
+
+	private async sendCard(card: object): Promise<string | undefined> {
+		try {
+			// 优先 replyToMessageId（回复用户消息），否则 send 到 chatId
+			if (this.replyToMessageId) {
+				const res = await this.client.im.message.reply({
+					path: { message_id: this.replyToMessageId },
+					data: { msg_type: "interactive", content: JSON.stringify(card) },
+				});
+				return (res as { data?: { message_id?: string } })?.data?.message_id;
+			}
+			const res = await this.client.im.message.create({
+				params: { receive_id_type: "chat_id" },
+				data: { receive_id: this.chatId, msg_type: "interactive", content: JSON.stringify(card) },
+			});
+			return (res as { data?: { message_id?: string } })?.data?.message_id;
+		} catch (e) {
+			console.error("[飞书 TaskStatusCard] sendCard 失败:", e);
+			return undefined;
+		}
+	}
+
+	private startHeartbeat() {
+		this.stopHeartbeat();
+		this.heartbeat = setInterval(() => {
+			if (this.status !== "running") return;
+			if (Date.now() - this.lastUpdateAt < STILL_RUNNING_MS) return;
+			void this.updateRunningPhase("仍在处理…");
+		}, STILL_RUNNING_MS);
+		this.heartbeat.unref?.();
+	}
+
+	private stopHeartbeat() {
+		if (!this.heartbeat) return;
+		clearInterval(this.heartbeat);
+		this.heartbeat = undefined;
+	}
+
+	private clearPendingRunningUpdate() {
+		if (this.pendingRunningTimer) {
+			clearTimeout(this.pendingRunningTimer);
+			this.pendingRunningTimer = undefined;
+		}
+		this.pendingRunningPhase = undefined;
+	}
+}
+
+// ===== 卡片构建 =====
+
+export function buildTaskStatusCard(input: { key: string; status: TaskStatus; phase?: string }) {
+	const running = input.status === "running";
+	return {
+		config: { wide_screen_mode: true, update_multi: true },
+		header: {
+			template: headerTemplate(input.status),
+			title: { tag: "plain_text", content: titleForStatus(input.status) },
+		},
+		elements: [
+			...(input.phase ? [{
+				tag: "div" as const,
+				text: {
+					tag: "lark_md" as const,
+					content: `当前阶段：${normalizePhase(input.phase)}`,
+				},
+			}] : []),
+			...(running ? [{
+				tag: "action" as const,
+				actions: [{
+					tag: "button" as const,
+					text: { tag: "plain_text" as const, content: "停止任务" },
+					type: "danger" as const,
+					value: { action: "pi_feishu_stop_task", key: input.key },
+				}],
+			}] : []),
+		],
+	};
+}
+
+// ===== 事件描述 =====
+
+export function describePiEvent(event: unknown): string | undefined {
+	if (!event || typeof event !== "object") return undefined;
+	const raw = event as Record<string, unknown>;
+	switch (raw.type) {
+		case "agent_start":
+			return "agent 启动";
+		case "turn_start":
+			return typeof raw.turnIndex === "number" ? `第 ${Number(raw.turnIndex) + 1} 轮对话` : "turn_start";
+		case "message_start": {
+			const msg = raw.message as Record<string, unknown> | undefined;
+			return msg?.role ? `消息开始: ${msg.role}` : "message_start";
+		}
+		case "message_update": {
+			const assistantEvent = raw.assistantMessageEvent as Record<string, unknown> | undefined;
+			return describeAssistantEvent(assistantEvent);
+		}
+		case "tool_execution_start":
+			return `工具调用: ${raw.toolName || "tool"}`;
+		case "tool_execution_end":
+			return `工具完成: ${raw.toolName || "tool"} ${raw.isError ? "错误" : "成功"}`;
+		case "compaction_start":
+			return raw.reason ? `上下文压缩: ${raw.reason}` : "上下文压缩";
+		case "auto_retry_start":
+			return typeof raw.attempt === "number" ? `自动重试: ${raw.attempt}/${raw.maxAttempts || "?"}` : "自动重试";
+		case "auto_retry_end":
+			return raw.success === false ? "自动重试失败" : "自动重试完成";
+		default:
+			return undefined;
+	}
+}
+
+function describeAssistantEvent(event: Record<string, unknown> | undefined) {
+	if (!event?.type) return "消息更新";
+	if (event.type === "toolcall_end" && (event.toolCall as Record<string, unknown>)?.name)
+		return `工具完成: ${(event.toolCall as Record<string, unknown>).name}`;
+	if (event.type === "done" && event.reason) return `消息完成: ${event.reason}`;
+	if (event.type === "error" && event.reason) return `消息错误: ${event.reason}`;
+	if (String(event.type).endsWith("_delta")) return undefined; // 忽略增量 delta
+	return `消息更新: ${event.type}`;
+}
+
+function normalizePhase(text: string) {
+	const compact = text.replace(/\s+/g, " ").trim();
+	if (compact.length <= MAX_PHASE_CHARS) return compact;
+	return `${compact.slice(0, MAX_PHASE_CHARS - 1)}…`;
+}
+
+function titleForStatus(status: TaskStatus) {
+	if (status === "done") return "✅ 任务完成";
+	if (status === "failed") return "❌ 任务失败";
+	if (status === "stopped") return "⏹ 任务已停止";
+	if (status === "inactive") return "任务已结束";
+	return "🔄 任务进行中";
+}
+
+function headerTemplate(status: TaskStatus) {
+	if (status === "done") return "green";
+	if (status === "failed") return "red";
+	if (status === "stopped") return "grey";
+	if (status === "inactive") return "grey";
+	return "blue";
+}
+
+function defaultFinalPhase(status: Exclude<TaskStatus, "running" | "inactive">): string | undefined {
+	if (status === "done") return undefined;
+	if (status === "failed") return "处理失败";
+	return "用户已停止任务";
+}
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}

--- a/src/main/feishu/rich-text.ts
+++ b/src/main/feishu/rich-text.ts
@@ -1,0 +1,365 @@
+/**
+ * 飞书富文本渲染 — 从 pi-feishu-lark 移植
+ *
+ * 根据文本内容智能选择飞书消息类型：
+ * - text：纯文本（短消息，无格式）
+ * - post：飞书富文本（中等长度，含表格、列表、加粗等）
+ * - interactive：卡片消息（长消息，含代码块、标题等，支持 markdown 渲染）
+ *
+ * 飞书卡片的 markdown 不支持表格，所以含表格的短消息改用 post 格式。
+ */
+
+const POST_LENGTH_THRESHOLD = 250;
+const INTERACTIVE_LENGTH_THRESHOLD = 1200;
+const MAX_POST_CHARS = 3500;
+const MAX_CARD_BYTES = 29 * 1024;
+
+export type FeishuMessageMode = "text" | "post" | "interactive";
+
+/** 根据内容特征自动选择最佳消息模式 */
+export function chooseMessageMode(text: string): FeishuMessageMode {
+	const trimmed = text.trim();
+	if (!trimmed) return "text";
+	const metrics = analyzeText(trimmed);
+	if (
+		trimmed.length >= INTERACTIVE_LENGTH_THRESHOLD ||
+		metrics.hasTable ||
+		metrics.codeBlockCount > 0 ||
+		metrics.headingCount >= 3 ||
+		metrics.listItemCount >= 8 ||
+		metrics.linkCount >= 5
+	) {
+		return "interactive";
+	}
+	if (metrics.lineCount >= 2 && (metrics.looksLikeMarkdown || trimmed.length >= POST_LENGTH_THRESHOLD)) return "post";
+	return "text";
+}
+
+/** 构建 post 富文本消息（飞书原生表格支持） */
+export function buildPostMessages(text: string, language: "zh" | "en" = "zh") {
+	return splitText(text.trim() || "(empty response)", MAX_POST_CHARS).map((chunk, index, chunks) => {
+		const parsed = markdownToPost(chunk, language);
+		const title = chunks.length > 1 ? `${parsed.title} (${index + 1}/${chunks.length})` : parsed.title;
+		const locale = language === "en" ? "en_us" : "zh_cn";
+		const post = {
+			title,
+			content: parsed.content.length ? parsed.content : [[{ tag: "text", text: chunk }]],
+		};
+		return {
+			[locale]: post,
+			[fallbackLocale(locale)]: post,
+		};
+	});
+}
+
+/** 构建 markdown 卡片消息（含智能分片和复制原文按钮） */
+export function buildMarkdownCards(text: string, language: "zh" | "en" = "zh") {
+	return buildMarkdownCardParts(text, language).map((part) => part.card);
+}
+
+export type MarkdownCardPart = {
+	card: object;
+	markdown: string;
+};
+
+export function buildMarkdownCardParts(text: string, language: "zh" | "en" = "zh"): MarkdownCardPart[] {
+	const trimmed = text.trim() || "(empty response)";
+	const { title, body } = extractMarkdownTitle(trimmed, language);
+	const fullCard = createMarkdownCard(title, body || trimmed);
+	if (byteSize(fullCard) < MAX_CARD_BYTES) {
+		const markdown = body || trimmed;
+		return [{ card: createMarkdownCard(title, markdown), markdown }];
+	}
+
+	const parts = splitMarkdownToFit(body || trimmed, title);
+	if (parts.length === 1) return [{ card: createMarkdownCard(title, parts[0]), markdown: parts[0] }];
+	return parts.map((part, index) => ({
+		card: createMarkdownCard(`${title} (${index + 1}/${parts.length})`, part),
+		markdown: part,
+	}));
+}
+
+// ===== 内部工具函数 =====
+
+type PostElement = {
+	tag: "text" | "a";
+	text: string;
+	href?: string;
+	style?: string[];
+};
+
+type LocaleKey = "zh_cn" | "en_us";
+
+function analyzeText(text: string) {
+	const lines = text.split(/\r?\n/);
+	const lineCount = lines.filter((line) => line.trim()).length;
+	const tableLineCount = lines.filter((line) => /^\s*\|.+\|\s*$/.test(line)).length;
+	const hasTableSeparator = lines.some((line) => /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(line));
+	return {
+		lineCount,
+		looksLikeMarkdown: looksLikeMarkdown(text),
+		hasTable: tableLineCount >= 2 && hasTableSeparator,
+		codeBlockCount: (text.match(/```/g) || []).length >= 2 ? Math.floor((text.match(/```/g) || []).length / 2) : 0,
+		headingCount: lines.filter((line) => /^#{1,6}\s+\S/.test(line.trim())).length,
+		listItemCount: lines.filter((line) => /^\s*([-*+]|\d+\.)\s+\S/.test(line)).length,
+		linkCount: (text.match(/\[[^\]\n]+\]\(https?:\/\/[^)\s]+\)/g) || []).length,
+	};
+}
+
+function looksLikeMarkdown(text: string) {
+	return [
+		/^#{1,6}\s+\S/m,
+		/^\s*[-*+]\s+\S/m,
+		/^\s*\d+\.\s+\S/m,
+		/^>\s+\S/m,
+		/```[\s\S]*?```/,
+		/\*\*[^*\n][\s\S]*?\*\*/,
+		/`[^`\n]+`/,
+		/\[[^\]\n]+\]\(https?:\/\/[^)\s]+\)/,
+		/^\s*\|.+\|\s*$/m,
+	].some((pattern) => pattern.test(text));
+}
+
+function markdownToPost(text: string, language: "zh" | "en") {
+	const lines = text.replace(/\r\n/g, "\n").split("\n");
+	const titleIndex = lines.findIndex((line) => line.trim());
+	const firstLine = titleIndex >= 0 ? lines[titleIndex].trim() : "";
+	const heading = firstLine.match(/^#{1,6}\s+(.+)$/);
+	const title = cleanInlineMarkdown(heading?.[1] || firstLine || (language === "en" ? "Pi reply" : "Pi 回复")).slice(0, 120);
+	const content: PostElement[][] = [];
+	let inCodeBlock = false;
+
+	for (let i = 0; i < lines.length; i++) {
+		const raw = lines[i];
+		const trimmed = raw.trim();
+		if (!trimmed) continue;
+		if (i === titleIndex) continue;
+		if (/^```/.test(trimmed)) {
+			inCodeBlock = !inCodeBlock;
+			continue;
+		}
+
+		if (inCodeBlock) {
+			content.push([{ tag: "text", text: raw }]);
+			continue;
+		}
+
+		const headingMatch = trimmed.match(/^#{1,6}\s+(.+)$/);
+		if (headingMatch) {
+			content.push([{ tag: "text", text: cleanInlineMarkdown(headingMatch[1]), style: ["bold"] }]);
+			continue;
+		}
+
+		const quoteMatch = trimmed.match(/^>\s+(.+)$/);
+		if (quoteMatch) {
+			content.push([{ tag: "text", text: `> ${cleanInlineMarkdown(quoteMatch[1])}` }]);
+			continue;
+		}
+
+		const listMatch = trimmed.match(/^([-*+]|\d+\.)\s+(.+)$/);
+		if (listMatch) {
+			content.push([{ tag: "text", text: `${listMatch[1].match(/\d+\./) ? listMatch[1] : "•"} ${cleanInlineMarkdown(listMatch[2])}` }]);
+			continue;
+		}
+
+		// 表格行 → 用特殊分隔符保留表格结构
+		if (/^\s*\|.+\|\s*$/.test(raw)) {
+			content.push([{ tag: "text", text: formatTableLine(raw) }]);
+			continue;
+		}
+
+		content.push(parseInlineElements(trimmed));
+	}
+
+	return { title, content };
+}
+
+function extractMarkdownTitle(text: string, language: "zh" | "en") {
+	const lines = text.replace(/\r\n/g, "\n").split("\n");
+	const titleIndex = lines.findIndex((line) => line.trim());
+	if (titleIndex < 0) return { title: language === "en" ? "Pi reply" : "Pi 回复", body: text };
+	const firstLine = lines[titleIndex].trim();
+	const heading = firstLine.match(/^#{1,6}\s+(.+)$/);
+	const title = cleanInlineMarkdown(heading?.[1] || firstLine || (language === "en" ? "Pi reply" : "Pi 回复")).slice(0, 120);
+	const body = lines
+		.filter((_, index) => index !== titleIndex)
+		.join("\n")
+		.trim();
+	return { title, body };
+}
+
+function createMarkdownCard(title: string, content: string) {
+	return {
+		schema: "2.0",
+		config: { wide_screen_mode: true, update_multi: true },
+		header: {
+			title: { tag: "plain_text", content: title },
+			template: "blue",
+		},
+		body: {
+			elements: [
+				{ tag: "markdown", content },
+			],
+		},
+	};
+}
+
+function splitMarkdownToFit(markdown: string, title: string) {
+	const queue = splitMarkdownBlocks(markdown);
+	const parts: string[] = [];
+	let current = "";
+
+	for (const block of queue) {
+		if (!block.trim()) continue;
+		const candidate = current ? `${current}\n\n${block}` : block;
+		if (fitsMarkdownCard(title, candidate)) {
+			current = candidate;
+			continue;
+		}
+		if (current) {
+			parts.push(current);
+			current = "";
+		}
+		if (fitsMarkdownCard(title, block)) {
+			current = block;
+			continue;
+		}
+		parts.push(...splitOversizedBlock(block, title));
+	}
+
+	if (current) parts.push(current);
+	return parts.length ? parts : [markdown];
+}
+
+function splitMarkdownBlocks(markdown: string) {
+	return splitByHeading(markdown, /^##\s+/m)
+		.flatMap((block) => splitByHeading(block, /^###\s+/m))
+		.flatMap((block) => block.split(/\n{2,}/))
+		.map((block) => block.trim())
+		.filter(Boolean);
+}
+
+function splitByHeading(markdown: string, pattern: RegExp) {
+	const lines = markdown.split("\n");
+	const blocks: string[] = [];
+	let current: string[] = [];
+
+	for (const line of lines) {
+		if (pattern.test(line) && current.length) {
+			blocks.push(current.join("\n").trim());
+			current = [];
+		}
+		current.push(line);
+	}
+	if (current.length) blocks.push(current.join("\n").trim());
+	return blocks.filter(Boolean);
+}
+
+function splitOversizedBlock(block: string, title: string) {
+	const parts: string[] = [];
+	let current = "";
+	for (const line of block.split("\n")) {
+		const candidate = current ? `${current}\n${line}` : line;
+		if (fitsMarkdownCard(title, candidate)) {
+			current = candidate;
+			continue;
+		}
+		if (current) {
+			parts.push(current);
+			current = "";
+		}
+		if (fitsMarkdownCard(title, line)) {
+			current = line;
+			continue;
+		}
+		parts.push(...splitLongText(line, title));
+	}
+	if (current) parts.push(current);
+	return parts;
+}
+
+function splitLongText(text: string, title: string) {
+	const parts: string[] = [];
+	let rest = text;
+	while (rest) {
+		let low = 1;
+		let high = rest.length;
+		let best = 1;
+		while (low <= high) {
+			const mid = Math.floor((low + high) / 2);
+			if (fitsMarkdownCard(title, rest.slice(0, mid))) {
+				best = mid;
+				low = mid + 1;
+			} else {
+				high = mid - 1;
+			}
+		}
+		parts.push(rest.slice(0, best));
+		rest = rest.slice(best);
+	}
+	return parts;
+}
+
+function fitsMarkdownCard(title: string, content: string) {
+	return byteSize(createMarkdownCard(title, content)) < MAX_CARD_BYTES;
+}
+
+function parseInlineElements(text: string): PostElement[] {
+	const out: PostElement[] = [];
+	const linkPattern = /\[([^\]\n]+)\]\((https?:\/\/[^)\s]+)\)/g;
+	let lastIndex = 0;
+	for (const match of text.matchAll(linkPattern)) {
+		const index = match.index ?? 0;
+		if (index > lastIndex) {
+			out.push({ tag: "text", text: cleanInlineMarkdown(text.slice(lastIndex, index)) });
+		}
+		out.push({ tag: "a", text: cleanInlineMarkdown(match[1]), href: match[2] });
+		lastIndex = index + match[0].length;
+	}
+	if (lastIndex < text.length) {
+		out.push({ tag: "text", text: cleanInlineMarkdown(text.slice(lastIndex)) });
+	}
+	return out.length ? out : [{ tag: "text", text }];
+}
+
+function cleanInlineMarkdown(text: string) {
+	return text
+		.replace(/\*\*([^*]+)\*\*/g, "$1")
+		.replace(/__([^_]+)__/g, "$1")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/~~([^~]+)~~/g, "$1")
+		.trim();
+}
+
+function formatTableLine(line: string) {
+	const cells = line
+		.trim()
+		.replace(/^\|/, "")
+		.replace(/\|$/, "")
+		.split("|")
+		.map((cell) => cell.trim());
+	// 分隔行（---等）替换为虚线
+	if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) return "----------------";
+	return cells.join("  |  ");
+}
+
+function splitText(text: string, max: number) {
+	const out: string[] = [];
+	let rest = text;
+	while (rest.length > max) {
+		let cut = rest.lastIndexOf("\n", max);
+		if (cut < max * 0.5) cut = max;
+		out.push(rest.slice(0, cut));
+		rest = rest.slice(cut).trimStart();
+	}
+	out.push(rest);
+	return out;
+}
+
+function byteSize(value: unknown) {
+	return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function fallbackLocale(locale: LocaleKey): LocaleKey {
+	return locale === "zh_cn" ? "en_us" : "zh_cn";
+}

--- a/src/main/feishu/types.ts
+++ b/src/main/feishu/types.ts
@@ -1,0 +1,117 @@
+/**
+ * 飞书桥接 — 内部类型定义
+ *
+ * 这些类型仅在 main 进程内部使用，不暴露给 renderer。
+ */
+
+/** 飞书 mention 信息 */
+export type FeishuMention = {
+	name: string;
+	id: string | { open_id: string; union_id: string; user_id: string };
+};
+
+/** 飞书群聊信息缓存 */
+export type FeishuGroupInfo = {
+	chatId: string;
+	name: string;
+	description?: string;
+	members: FeishuGroupMember[];
+	userCount?: number;
+	cachedAt: number;
+};
+
+/** 飞书群成员 */
+export type FeishuGroupMember = {
+	openId: string;
+	name: string;
+};
+
+/** 飞书图片附件 */
+export type FeishuImageAttachment = {
+	imageKey: string;
+	data: Buffer;
+	mediaType: string;
+};
+
+/** 飞书文件附件 */
+export type FeishuFileAttachment = {
+	fileKey: string;
+	fileName: string;
+	data: Buffer;
+};
+
+/** 飞书消息上下文 */
+export type FeishuMessageContext = {
+	chatId: string;
+	senderOpenId: string;
+	senderName?: string;
+	messageId: string;
+	chatType: "p2p" | "group";
+	groupName?: string;
+};
+
+/** 会话累积缓冲 */
+export type SessionBuffer = {
+	text: string;
+	toolSummaries: Map<string, { name: string; count: number }>;
+	startedAt: number;
+};
+
+/** Agent 执行结果 */
+export type AgentResult = {
+	text: string;
+	toolSummaries: Array<{ name: string; count: number }>;
+	duration: number;
+	error?: string;
+};
+
+/** Lark SDK 类型（延迟加载，用于 WSClient + EventDispatcher 模式） */
+export type LarkSDK = {
+	Client: new (opts: Record<string, unknown>) => LarkClient;
+	WSClient: new (opts: Record<string, unknown>) => {
+		start: (opts: Record<string, unknown>) => void;
+		stop?: () => void;
+	};
+	EventDispatcher: new (opts: Record<string, unknown>) => {
+		register: (handlers: Record<string, (data: unknown) => Promise<unknown | undefined | void>>) => unknown;
+	};
+	Domain: { Feishu: unknown };
+	LoggerLevel: { error: unknown };
+	AppType: { SelfBuild: unknown };
+};
+
+export type LarkClient = {
+	request: <T = Record<string, unknown>>(opts: {
+		method: string;
+		url: string;
+		data?: Record<string, unknown>;
+		params?: Record<string, unknown>;
+	}) => Promise<T>;
+	im: {
+		message: {
+			create: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+			reply: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+		};
+		messageResource: {
+			get: (opts: Record<string, unknown>) => Record<string, unknown>;
+		};
+		chat: {
+			get: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+			create: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+			members: {
+				get: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+				add: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+			};
+		};
+		v1: {
+			message: {
+				patch: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+			};
+		};
+	};
+	auth: {
+		tenantAccessToken: {
+			internal: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+		};
+	};
+};

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -707,7 +707,7 @@ function registerIpc() {
 		const tab = await agentManager.create(input);
 		// Session Mirror: Pi 中创建会话时，飞书自动拉群（1会话=1群）
 		if (feishuBridge && feishuBridge.getStatus().status === "connected") {
-			void feishuBridge.ensureSessionMirror(tab.id, tab.title).catch((e) => {
+			void feishuBridge.ensureSessionMirror(tab.id, tab.title, tab.sessionPath).catch((e) => {
 				console.error("[飞书] 自动拉群失败:", e);
 			});
 		}
@@ -728,11 +728,11 @@ function registerIpc() {
 			const tab = agentManager.list().find(t => t.id === input.agentId);
 			if (tab) {
 				// 1. 确保有飞书群绑定（如果还没有，自动拉群）
-				void feishuBridge.ensureSessionMirror(tab.id, tab.title).catch((e) => {
+				void feishuBridge.ensureSessionMirror(tab.id, tab.title, tab.sessionPath).catch((e) => {
 					console.error("[飞书] ensureSessionMirror 失败:", e);
 				});
 				// 2. 开启流式卡片
-				void feishuBridge.startSessionMirrorRun(tab.id, tab.title).catch((e) => {
+				void feishuBridge.startSessionMirrorRun(tab.id, tab.title, tab.sessionPath).catch((e) => {
 					console.error("[飞书] SessionMirror 流式卡片初始化失败:", e);
 				});
 				// 3. 转发用户消息到飞书（双向同步）

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,12 +13,26 @@ import { is } from "@electron-toolkit/utils";
 // 使用 ?asset 后缀导入图标，electron-vite 会在构建时将其复制到输出目录并提供正确的运行时路径
 // 这解决了打包后 build/ 目录不在 asar 中导致托盘图标丢失的问题
 import iconPath from "../../build/icon.png?asset";
+
+// 开发模式下 stdout 管道可能断开导致 EPIPE 崩溃，全局静默处理
+process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+	if (err.code === "EPIPE") return;
+	throw err;
+});
+process.stderr.on("error", (err: NodeJS.ErrnoException) => {
+	if (err.code === "EPIPE") return;
+	throw err;
+});
 import { ipcChannels } from "../shared/ipc";
 import type {
 	AppSettings,
 	AppUpdateAsset,
 	AppUpdateInfo,
 	CreateAgentInput,
+	FeishuBotConfig,
+	FeishuBridgeStatus,
+	FeishuConnectInput,
+	FeishuTestResult,
 	SendPromptInput,
 	CreatePiSkillInput,
 } from "../shared/types";
@@ -39,6 +53,16 @@ import { TelemetryService } from "./telemetry/TelemetryService";
 import { SkillManager } from "./skills/SkillManager";
 import { ExtensionManager } from "./extensions/ExtensionManager";
 import { WebServiceManager } from "./web/WebServiceManager";
+import { FeishuBridge } from "./feishu/FeishuBridge";
+import {
+	listBots,
+	getBot,
+	addBot as addFeishuBot,
+	removeBot as removeFeishuBot,
+	updateBot as updateFeishuBot,
+	getDecryptedBotAppSecret,
+} from "./feishu/FeishuConfig";
+import type { FeishuChatBinding } from "../shared/types";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
@@ -58,6 +82,7 @@ let skillManager: SkillManager;
 let extensionManager: ExtensionManager;
 let webServiceManager: WebServiceManager;
 let terminalManager: TerminalSessionManager;
+let feishuBridge: FeishuBridge | null = null;
 
 const RELEASES_URL = "https://github.com/ayuayue/pi-desktop/releases";
 const LATEST_RELEASE_API =
@@ -274,6 +299,173 @@ function createWindow() {
 	} else {
 		mainWindow.loadFile(join(__dirname, "../renderer/index.html"));
 	}
+}
+
+// ===== 飞书桥接 IPC =====
+
+/** 自动连接：启动时检查已保存的 Bot 配置，自动连接 */
+async function autoConnectFeishu() {
+	const bots = listBots();
+	if (bots.length === 0) return;
+	// 取第一个启用的 Bot
+	const bot = bots.find((b) => b.enabled);
+	if (!bot) return;
+
+	console.log("[飞书] 检测到已保存的 Bot 配置，自动连接:", bot.name);
+	try {
+		feishuBridge = new FeishuBridge(bot, agentManager, () => mainWindow, () => projectStore.list());
+		await feishuBridge.start();
+		console.log("[飞书] 自动连接成功");
+	} catch (error) {
+		console.error("[飞书] 自动连接失败:", error);
+		feishuBridge = null;
+		// 失败不阻塞启动，用户可手动连接
+	}
+}
+
+function registerFeishuIpc() {
+	// 连接飞书
+	ipcMain.handle(ipcChannels.feishuConnect, async (_event, input: FeishuConnectInput) => {
+		try {
+			// 如果已有连接，先断开
+			if (feishuBridge) {
+				feishuBridge.stop();
+			}
+
+			const botConfig = addFeishuBot({
+				name: input.name || "飞书机器人",
+				appId: input.appId,
+				appSecret: input.appSecret,
+				defaultUserOpenId: input.defaultUserOpenId,
+			});
+
+			feishuBridge = new FeishuBridge(botConfig, agentManager, () => mainWindow, () => projectStore.list());
+			await feishuBridge.start();
+			return { success: true, message: "连接成功" };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return { success: false, message };
+		}
+	});
+
+	// 断开连接
+	ipcMain.handle(ipcChannels.feishuDisconnect, async () => {
+		if (feishuBridge) {
+			feishuBridge.stop();
+			feishuBridge = null;
+		}
+		return { success: true };
+	});
+
+	// 查询状态
+	ipcMain.handle(ipcChannels.feishuStatusRequest, async () => {
+		if (feishuBridge) {
+			return feishuBridge.getStatus();
+		}
+		return { status: "disconnected", activeBindings: 0 } as FeishuBridgeStatus;
+	});
+
+	// Bot 列表
+	ipcMain.handle(ipcChannels.feishuBotsList, async () => {
+		return listBots();
+	});
+
+	// 添加 Bot
+	ipcMain.handle(ipcChannels.feishuBotAdd, async (_event, input: FeishuConnectInput) => {
+		// 同 feishuConnect，但可以添加多个 Bot
+		try {
+			const botConfig = addFeishuBot({
+				name: input.name || "飞书机器人",
+				appId: input.appId,
+				appSecret: input.appSecret,
+				defaultUserOpenId: input.defaultUserOpenId,
+			});
+			return { success: true, bot: botConfig };
+		} catch (error) {
+			return { success: false, error: error instanceof Error ? error.message : String(error) };
+		}
+	});
+
+	// 删除 Bot
+	ipcMain.handle(ipcChannels.feishuBotRemove, async (_event, botId: string) => {
+		if (feishuBridge) {
+			feishuBridge.stop();
+			feishuBridge = null;
+		}
+		return removeFeishuBot(botId);
+	});
+
+	// 更新 Bot 配置
+	ipcMain.handle(ipcChannels.feishuBotConfig, async (_event, botId: string, patch: Partial<FeishuBotConfig>) => {
+		const updated = updateFeishuBot(botId, patch);
+		// 热更新到运行中的 bridge，无需重连
+		if (feishuBridge && feishuBridge.getStatus().status === "connected") {
+			feishuBridge.updateBotConfig(patch);
+			console.log("[飞书] 配置已热更新:", Object.keys(patch).join(", "));
+		}
+		return updated;
+	});
+
+	// 测试连接
+	ipcMain.handle(ipcChannels.feishuTestConnection, async (_event, appId: string, appSecret: string) => {
+		// 创建临时 bridge 实例来测试连接
+		const testBridge = new FeishuBridge(
+			{
+				id: "test",
+				name: "测试",
+				enabled: true,
+				appId,
+				appSecret: "", // 将在 testConnection 中传入
+			},
+			agentManager,
+			() => mainWindow,
+			() => projectStore.list(),
+		);
+		return testBridge.testConnection(appId, appSecret);
+	});
+
+	// 绑定列表
+	ipcMain.handle(ipcChannels.feishuBindingsList, async () => {
+		if (feishuBridge) {
+			return feishuBridge.listBindings();
+		}
+		return [];
+	});
+
+	// 移除绑定
+	ipcMain.handle(ipcChannels.feishuBindingRemove, async (_event, chatId: string) => {
+		if (feishuBridge) {
+			return feishuBridge.removeBinding(chatId);
+		}
+		return false;
+	});
+
+	// 更新绑定
+	ipcMain.handle(ipcChannels.feishuBindingUpdate, async (_event, chatId: string, patch: Partial<FeishuChatBinding>) => {
+		if (feishuBridge) {
+			return feishuBridge.updateBinding(chatId, patch);
+		}
+		return undefined;
+	});
+
+	// 通过已保存的 Bot ID 连接（自动解密 Secret）
+	ipcMain.handle(ipcChannels.feishuConnectByBot, async (_event, botId: string) => {
+		try {
+			if (feishuBridge) {
+				feishuBridge.stop();
+			}
+			const botConfig = getBot(botId);
+			if (!botConfig) {
+				return { success: false, message: "Bot 配置不存在" };
+			}
+			feishuBridge = new FeishuBridge(botConfig, agentManager, () => mainWindow, () => projectStore.list());
+			await feishuBridge.start();
+			return { success: true, message: "连接成功" };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return { success: false, message };
+		}
+	});
 }
 
 function registerIpc() {
@@ -511,9 +703,16 @@ function registerIpc() {
 	);
 
 	ipcMain.handle(ipcChannels.agentsList, () => agentManager.list());
-	ipcMain.handle(ipcChannels.agentsCreate, (_event, input: CreateAgentInput) =>
-		agentManager.create(input),
-	);
+	ipcMain.handle(ipcChannels.agentsCreate, async (_event, input: CreateAgentInput) => {
+		const tab = await agentManager.create(input);
+		// Session Mirror: Pi 中创建会话时，飞书自动拉群（1会话=1群）
+		if (feishuBridge && feishuBridge.getStatus().status === "connected") {
+			void feishuBridge.ensureSessionMirror(tab.id, tab.title).catch((e) => {
+				console.error("[飞书] 自动拉群失败:", e);
+			});
+		}
+		return tab;
+	});
 	ipcMain.handle(
 		ipcChannels.agentsRename,
 		(_event, agentId: string, name: string) =>
@@ -523,12 +722,36 @@ function registerIpc() {
 		terminalManager.closeAgent(agentId);
 		await agentManager.stop(agentId);
 	});
-	ipcMain.handle(ipcChannels.agentsPrompt, (_event, input: SendPromptInput) =>
-		agentManager.sendPrompt(input),
-	);
-	ipcMain.handle(ipcChannels.agentsAbort, (_event, agentId: string) =>
-		agentManager.abort(agentId),
-	);
+	ipcMain.handle(ipcChannels.agentsPrompt, async (_event, input: SendPromptInput) => {
+		// Session Mirror: Pi 中发消息时，为飞书群开启流式卡片 + 转发用户消息
+		if (feishuBridge && feishuBridge.getStatus().status === "connected") {
+			const tab = agentManager.list().find(t => t.id === input.agentId);
+			if (tab) {
+				// 1. 确保有飞书群绑定（如果还没有，自动拉群）
+				void feishuBridge.ensureSessionMirror(tab.id, tab.title).catch((e) => {
+					console.error("[飞书] ensureSessionMirror 失败:", e);
+				});
+				// 2. 开启流式卡片
+				void feishuBridge.startSessionMirrorRun(tab.id, tab.title).catch((e) => {
+					console.error("[飞书] SessionMirror 流式卡片初始化失败:", e);
+				});
+				// 3. 转发用户消息到飞书（双向同步）
+				if (input.message.trim()) {
+					void feishuBridge.forwardUserMessageToFeishu(tab.id, input.message).catch((e) => {
+						console.error("[飞书] 转发 PiDeck 消息失败:", e);
+					});
+				}
+			}
+		}
+		return agentManager.sendPrompt(input);
+	});
+	ipcMain.handle(ipcChannels.agentsAbort, async (_event, agentId: string) => {
+		// Session Mirror: 停止飞书流式卡片
+		if (feishuBridge) {
+			feishuBridge.stopSessionMirrorRun(agentId);
+		}
+		return agentManager.abort(agentId);
+	});
 	ipcMain.handle(ipcChannels.agentsExportHtml, (_event, agentId: string) =>
 		agentManager.exportHtml(agentId),
 	);
@@ -764,6 +987,11 @@ app.whenReady().then(async () => {
 		void settingsStore.update({ webServiceEnabled: false });
 	});
 	registerIpc();
+	registerFeishuIpc();
+
+	// 🆕 自动连接：如果已有 Bot 配置，自动启动飞书连接
+	autoConnectFeishu();
+
 	sendTelemetryHeartbeat();
 	createWindow();
 	setupTray();

--- a/src/main/pi/AgentManager.ts
+++ b/src/main/pi/AgentManager.ts
@@ -29,6 +29,8 @@ export class AgentManager {
 	private readonly toolMessageIds = new Map<string, Map<string, string>>();
 	/** 每个 agent 只保留一条自动重试状态消息，避免短暂 5xx/网络错误把会话刷屏。 */
 	private readonly retryStatusMessageIds = new Map<string, string>();
+	/** 本地事件监听器（用于 FeishuBridge 等主进程内部订阅） */
+	private readonly localEventListeners = new Set<(agentId: string, event: unknown) => void>();
 
 	constructor(
 		private readonly getProject: (id: string) => Project | undefined,
@@ -666,6 +668,12 @@ export class AgentManager {
 		this.emitState();
 	}
 
+	/** 注册本地事件监听器（供 FeishuBridge 等主进程内部模块使用） */
+	addLocalEventListener(listener: (agentId: string, event: unknown) => void): () => void {
+		this.localEventListeners.add(listener);
+		return () => { this.localEventListeners.delete(listener); };
+	}
+
 	stopAll() {
 		// 应用退出时统一清理所有 pi 子进程，避免后台 agent 残留占用模型或文件句柄。
 		for (const runtime of this.agents.values()) {
@@ -677,6 +685,10 @@ export class AgentManager {
 	}
 
 	private handlePiEvent(agentId: string, event: unknown) {
+		// 通知本地监听器（FeishuBridge 等主进程内部订阅）
+		for (const listener of this.localEventListeners) {
+			try { listener(agentId, event); } catch {}
+		}
 		this.emit(ipcChannels.agentsEvent, { agentId, event });
 
 		if (!event || typeof event !== "object") return;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -463,6 +463,8 @@ const api = {
 			ipcRenderer.invoke(ipcChannels.feishuBindingUpdate, chatId, patch) as Promise<FeishuChatBinding | undefined>,
 		onMessages: (callback: (message: FeishuChatMessage) => void) =>
 			subscribe(ipcChannels.feishuMessages, callback),
+		onBindingsChanged: (callback: (bindings: FeishuChatBinding[]) => void) =>
+			subscribe(ipcChannels.feishuBindingsChanged, callback),
 	},
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,25 +6,31 @@ import type {
 	AppInfo,
 	AppSettings,
 	AppUpdateInfo,
-	FeedbackEnvironment,
 	AvailableModel,
 	ChatMessage,
 	CodexImportReport,
 	CodexSessionSummary,
 	ClaudeImportReport,
 	ClaudeSessionSummary,
+	ConfigFileDiagnostic,
 	CreateAgentInput,
+	CreatePiSkillInput,
+	FeedbackEnvironment,
+	FeishuBotConfig,
+	FeishuBridgeStatus,
+	FeishuChatBinding,
+	FeishuChatMessage,
+	FeishuConnectInput,
+	FeishuTestResult,
 	FileTreeNode,
 	ForkMessage,
 	GitBranchInfo,
 	PiCommand,
+	PiExtensionListResult,
 	PiInstallStatus,
 	PiProxyTestResult,
-	ConfigFileDiagnostic,
-	PiExtensionListResult,
 	PiSkillListResult,
 	PiSkillSummary,
-	CreatePiSkillInput,
 	Project,
 	SendPromptInput,
 	SessionSummary,
@@ -415,6 +421,48 @@ const api = {
 			subscribe(ipcChannels.terminalData, callback),
 		onExit: (callback: (payload: TerminalExitEvent) => void) =>
 			subscribe(ipcChannels.terminalExit, callback),
+	},
+
+	// ===== 飞书桥接 =====
+	feishu: {
+		connect: (input: FeishuConnectInput) =>
+			ipcRenderer.invoke(ipcChannels.feishuConnect, input) as Promise<{
+				success: boolean;
+				message: string;
+			}>,
+		disconnect: () =>
+			ipcRenderer.invoke(ipcChannels.feishuDisconnect) as Promise<{ success: boolean }>,
+		connectByBot: (botId: string) =>
+			ipcRenderer.invoke(ipcChannels.feishuConnectByBot, botId) as Promise<{
+				success: boolean;
+				message: string;
+			}>,
+		statusRequest: () =>
+			ipcRenderer.invoke(ipcChannels.feishuStatusRequest) as Promise<FeishuBridgeStatus>,
+		onStatus: (callback: (status: FeishuBridgeStatus) => void) =>
+			subscribe(ipcChannels.feishuStatus, callback),
+		botsList: () =>
+			ipcRenderer.invoke(ipcChannels.feishuBotsList) as Promise<FeishuBotConfig[]>,
+		botAdd: (input: FeishuConnectInput) =>
+			ipcRenderer.invoke(ipcChannels.feishuBotAdd, input) as Promise<{
+				success: boolean;
+				bot?: FeishuBotConfig;
+				error?: string;
+			}>,
+		botRemove: (botId: string) =>
+			ipcRenderer.invoke(ipcChannels.feishuBotRemove, botId) as Promise<boolean>,
+		botConfig: (botId: string, patch: Partial<FeishuBotConfig>) =>
+			ipcRenderer.invoke(ipcChannels.feishuBotConfig, botId, patch) as Promise<FeishuBotConfig | undefined>,
+		testConnection: (appId: string, appSecret: string) =>
+			ipcRenderer.invoke(ipcChannels.feishuTestConnection, appId, appSecret) as Promise<FeishuTestResult>,
+		bindingsList: () =>
+			ipcRenderer.invoke(ipcChannels.feishuBindingsList) as Promise<FeishuChatBinding[]>,
+		bindingRemove: (chatId: string) =>
+			ipcRenderer.invoke(ipcChannels.feishuBindingRemove, chatId) as Promise<boolean>,
+		bindingUpdate: (chatId: string, patch: Partial<FeishuChatBinding>) =>
+			ipcRenderer.invoke(ipcChannels.feishuBindingUpdate, chatId, patch) as Promise<FeishuChatBinding | undefined>,
+		onMessages: (callback: (message: FeishuChatMessage) => void) =>
+			subscribe(ipcChannels.feishuMessages, callback),
 	},
 };
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -27,10 +27,13 @@ import {
   Pin,
   Square,
   X,
+  MessageCircle,
 } from "lucide-react";
 import { createPreviewApi } from "./previewApi";
 import { createBrowserApi } from "./browserApi";
 import { ConfigModal } from "./ConfigModal";
+import { FeishuPanel } from "./components/feishu/FeishuPanel";
+import { useFeishuBridge } from "./hooks/useFeishuBridge";
 import { TerminalDock } from "./components/terminal/TerminalDock";
 import { CloseIconButton } from "./components/ui/IconButton";
 import { getComposerEnterIntent } from "./composerBehavior";
@@ -369,6 +372,7 @@ export function App() {
   const [updateInfo, setUpdateInfo] = useState<AppUpdateInfo | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [updateChecking, setUpdateChecking] = useState(false);
+  const [feishuPanelOpen, setFeishuPanelOpen] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [windowAlwaysOnTop, setWindowAlwaysOnTop] = useState(false);
@@ -451,6 +455,9 @@ export function App() {
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const pendingAgentsRef = useRef<AgentTab[]>([]);
   const projectDragPreventClickRef = useRef(false);
+
+  // ===== 飞书桥接 =====
+  const feishu = useFeishuBridge();
 
   const activeProject = projects.find(
     (project) => project.id === activeProjectId,
@@ -3145,6 +3152,24 @@ export function App() {
             );
           })}
         </div>
+        {feishuPanelOpen && (
+          <FeishuPanel
+            status={feishu.status}
+            bots={feishu.bots}
+            bindings={feishu.bindings}
+            connecting={feishu.connecting}
+            isConnected={feishu.isConnected}
+            hasConfig={feishu.hasConfig}
+            onConnect={async (appId: string, appSecret: string, name: string, defaultUserOpenId?: string) => {
+              return await feishu.connect({ appId, appSecret, name, defaultUserOpenId });
+            }}
+            onDisconnect={feishu.disconnect}
+            onRemoveBot={feishu.removeBot}
+            onUpdateBotConfig={feishu.updateBotConfig}
+            onTest={feishu.testConnection}
+            onRemoveBinding={feishu.removeBinding}
+          />
+        )}
         {!isLanWeb && (
           <div className="toolbar-actions sidebar-bottom-actions">
             <div className="sidebar-bottom-primary-actions">
@@ -3168,6 +3193,28 @@ export function App() {
                 onClick={() => setFeedbackOpen(true)}
               >
                 <MessageSquare size={17} />
+              </button>
+              <button
+                className={`icon-button feishu-icon${feishu.isConnected ? " feishu-connected" : ""}`}
+                title={feishu.isConnected ? "飞书已连接" : "飞书 Bridge"}
+                onClick={() => setFeishuPanelOpen((prev) => !prev)}
+                style={{
+                  position: "relative",
+                }}
+              >
+                <MessageCircle size={17} />
+                {feishu.isConnected && (
+                  <span style={{
+                    position: "absolute",
+                    bottom: 1,
+                    right: 1,
+                    width: 7,
+                    height: 7,
+                    borderRadius: "50%",
+                    background: "var(--color-accent)",
+                    boxShadow: "0 0 0 2px color-mix(in srgb, var(--color-accent) 18%, transparent)",
+                  }} />
+                )}
               </button>
             </div>
             <button

--- a/src/renderer/src/ConfigModal.tsx
+++ b/src/renderer/src/ConfigModal.tsx
@@ -6,6 +6,7 @@ import { RawTab } from "./config/RawTab";
 import { SettingsTab } from "./config/SettingsTab";
 import { SkillsTab } from "./config/SkillsTab";
 import { ExtensionsTab } from "./config/ExtensionsTab";
+import { ImTab } from "./config/ImTab";
 import { CloseIconButton } from "./components/ui/IconButton";
 import { t } from "./i18n";
 import type {
@@ -802,6 +803,7 @@ function ConfigModalContent(props: ConfigModalProps) {
 		{ id: "models", label: t("config.nav.models") },
 		{ id: "auth", label: t("config.nav.auth") },
 		{ id: "settings", label: t("config.nav.settings") },
+		{ id: "im", label: "IM 连接" },
 		{ id: "raw", label: t("config.nav.raw") },
 	];
 
@@ -965,6 +967,10 @@ function ConfigModalContent(props: ConfigModalProps) {
 							onChange={setSettingsData}
 							onSave={handleSaveSettings}
 						/>
+					)}
+
+					{section === "config" && !loading && tab === "im" && (
+						<ImTab />
 					)}
 
 					{section === "skills" && !loading && (

--- a/src/renderer/src/components/feishu/FeishuConnectDialog.tsx
+++ b/src/renderer/src/components/feishu/FeishuConnectDialog.tsx
@@ -1,0 +1,367 @@
+/**
+ * FeishuConnectDialog — 飞书 Bot 连接配置弹窗
+ *
+ * 遵循 PiDeck 设计系统：CSS 变量 + ui-button / modal 体系。
+ * 两种配置方式：手动配置（App ID + Secret）和扫码安装（二维码）。
+ */
+
+import { useState, useCallback, useEffect } from "react";
+import QRCode from "qrcode";
+import type { FeishuTestResult } from "../../../../shared/types";
+
+type Props = {
+	onClose: () => void;
+	onConnect: (appId: string, appSecret: string, name: string, defaultUserOpenId?: string) => Promise<{ success: boolean; message: string }>;
+	onTest: (appId: string, appSecret: string) => Promise<FeishuTestResult>;
+	connecting: boolean;
+};
+
+type ConfigMode = "manual" | "qr";
+
+export function FeishuConnectDialog({ onClose, onConnect, onTest, connecting }: Props) {
+	const [mode, setMode] = useState<ConfigMode>("manual");
+
+	// 手动配置
+	const [appId, setAppId] = useState("");
+	const [appSecret, setAppSecret] = useState("");
+	const [botName, setBotName] = useState("");
+	const [defaultUserOpenId, setDefaultUserOpenId] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const [testResult, setTestResult] = useState<FeishuTestResult | null>(null);
+	const [testing, setTesting] = useState(false);
+	const [step, setStep] = useState<"input" | "testing" | "connecting">("input");
+
+	// 二维码
+	const [qrLink, setQrLink] = useState("");
+	const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+	const [qrGenerating, setQrGenerating] = useState(false);
+	const [showHelp, setShowHelp] = useState(false);
+
+	// 防抖生成二维码
+	const generateQr = useCallback(async (text: string) => {
+		if (!text.trim()) {
+			setQrDataUrl(null);
+			return;
+		}
+		setQrGenerating(true);
+		try {
+			const dataUrl = await QRCode.toDataURL(text.trim(), {
+				width: 280,
+				margin: 2,
+				color: { dark: "#000000", light: "#ffffff" },
+				errorCorrectionLevel: "M",
+			});
+			setQrDataUrl(dataUrl);
+		} catch {
+			setQrDataUrl(null);
+		} finally {
+			setQrGenerating(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			if (qrLink.trim()) {
+				void generateQr(qrLink);
+			} else {
+				setQrDataUrl(null);
+			}
+		}, 400);
+		return () => clearTimeout(timer);
+	}, [qrLink, generateQr]);
+
+	const handleTest = useCallback(async () => {
+		if (!appId.trim() || !appSecret.trim()) {
+			setError("请填写 App ID 和 App Secret");
+			return;
+		}
+		setTesting(true);
+		setError(null);
+		setTestResult(null);
+		try {
+			const result = await onTest(appId.trim(), appSecret.trim());
+			setTestResult(result);
+			if (result.success) setStep("testing");
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "测试失败");
+		} finally {
+			setTesting(false);
+		}
+	}, [appId, appSecret, onTest]);
+
+	const handleConnect = useCallback(async () => {
+		if (!appId.trim() || !appSecret.trim()) {
+			setError("请填写 App ID 和 App Secret");
+			return;
+		}
+		setError(null);
+		setStep("connecting");
+		const name = botName.trim() || "飞书机器人";
+		const userOpenId = defaultUserOpenId.trim() || undefined;
+		const result = await onConnect(appId.trim(), appSecret.trim(), name, userOpenId);
+		if (!result.success) {
+			setError(result.message);
+			setStep("testing");
+		}
+	}, [appId, appSecret, botName, defaultUserOpenId, onConnect]);
+
+	const isBusy = connecting || step === "connecting";
+
+	return (
+		<div className="feishu-connect-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+			<div className="feishu-connect-dialog">
+				{/* ── 头部 ── */}
+				<div className="modal-header">
+					<strong>连接飞书 Bot</strong>
+					<button onClick={onClose}>✕</button>
+				</div>
+
+				{/* ── 模式切换标签 ── */}
+				<div className="feishu-mode-tabs">
+					<button
+						className={`feishu-mode-tab${mode === "manual" ? " active" : ""}`}
+						onClick={() => setMode("manual")}
+					>
+						手动配置
+					</button>
+					<button
+						className={`feishu-mode-tab${mode === "qr" ? " active" : ""}`}
+						onClick={() => setMode("qr")}
+					>
+						扫码安装
+					</button>
+				</div>
+
+				{/* ── 内容区 ── */}
+				<div className="feishu-modal-body">
+					{mode === "manual" ? (
+						<>
+							{/* App ID */}
+							<div className="feishu-field">
+								<label>App ID</label>
+								<input
+									className="feishu-input feishu-input-mono"
+									type="text"
+									value={appId}
+									onChange={(e) => { setAppId(e.target.value); setError(null); setTestResult(null); }}
+									placeholder="cli_xxxxxxxxxxxx"
+									disabled={isBusy}
+								/>
+							</div>
+
+							{/* App Secret */}
+							<div className="feishu-field">
+								<label>App Secret</label>
+								<input
+									className="feishu-input feishu-input-mono"
+									type="password"
+									value={appSecret}
+									onChange={(e) => { setAppSecret(e.target.value); setError(null); setTestResult(null); }}
+									placeholder="••••••••••••••••"
+									disabled={isBusy}
+								/>
+							</div>
+
+							{/* Bot 名称 */}
+							<div className="feishu-field">
+								<label>
+									Bot 名称 <span className="feishu-field-optional">(可选)</span>
+								</label>
+								<input
+									className="feishu-input"
+									type="text"
+									value={botName}
+									onChange={(e) => setBotName(e.target.value)}
+									placeholder="我的飞书助手"
+									disabled={isBusy}
+								/>
+							</div>
+
+							{/* 分隔 */}
+							<hr className="feishu-divider" />
+
+							{/* Open ID */}
+							<div className="feishu-field">
+								<label>
+									你的 Open ID <span className="feishu-field-optional">(可选，用于自动拉群)</span>
+								</label>
+								<input
+									className="feishu-input feishu-input-mono"
+									type="text"
+									value={defaultUserOpenId}
+									onChange={(e) => setDefaultUserOpenId(e.target.value)}
+									placeholder="ou_xxxxxxxxxxxxxxxx"
+									disabled={isBusy}
+								/>
+								<div className="feishu-field-hint">
+									如何获取：在飞书给 Bot 发 <code>/whoami</code> 即可查看
+								</div>
+							</div>
+
+							{/* 错误提示 */}
+							{error && (
+								<div className="feishu-error-banner">{error}</div>
+							)}
+
+							{/* 测试结果 */}
+							{testResult && (
+								<div className={`feishu-test-result ${testResult.success ? "success" : "warning"}`}>
+									{testResult.success ? "✓" : "⚠"} {testResult.message}
+									{testResult.botName && ` (${testResult.botName})`}
+								</div>
+							)}
+
+							{/* 按钮 */}
+							<div className="feishu-button-row">
+								{step === "input" || step === "testing" ? (
+									<>
+										<button
+											className="ui-button ui-button-secondary"
+											onClick={handleTest}
+											disabled={testing || !appId.trim() || !appSecret.trim()}
+											style={{ flex: 1 }}
+										>
+											{testing ? "测试中…" : "测试连接"}
+										</button>
+										{step === "testing" && (
+											<button
+												className="ui-button ui-button-primary"
+												onClick={handleConnect}
+												disabled={connecting}
+												style={{ flex: 1 }}
+											>
+												{connecting ? "连接中…" : "连接"}
+											</button>
+										)}
+									</>
+								) : (
+									<div style={{ width: "100%", textAlign: "center", padding: "var(--space-3)", color: "var(--color-accent)", fontSize: "var(--font-size-caption)" }}>
+										正在连接飞书…
+									</div>
+								)}
+							</div>
+						</>
+					) : (
+						/* ── 扫码模式 ── */
+						<div className="feishu-qr-section">
+							<p className="feishu-qr-hint">
+								在飞书开放平台「应用发布」页面复制安装链接，
+								<br />
+								粘贴到下方即可生成二维码，用手机飞书扫码安装。
+							</p>
+
+							{/* Bot 安装链接 */}
+							<div className="feishu-field" style={{ textAlign: "left", marginBottom: "var(--space-4)" }}>
+								<label>Bot 安装链接</label>
+								<input
+									className="feishu-input feishu-input-mono"
+									type="text"
+									value={qrLink}
+									onChange={(e) => setQrLink(e.target.value)}
+									placeholder="https://applink.feishu.cn/client/bot/..."
+								/>
+							</div>
+
+							{/* 二维码 */}
+							<div className="feishu-qr-frame">
+								{qrGenerating ? (
+									<span style={{ color: "var(--color-text-tertiary)", fontSize: "var(--font-size-caption)" }}>
+										生成中…
+									</span>
+								) : qrDataUrl ? (
+									<img src={qrDataUrl} alt="飞书 Bot 安装二维码" />
+								) : (
+									<div className="feishu-qr-placeholder">
+										<div className="feishu-qr-placeholder-icon">📱</div>
+										<div>等待输入链接</div>
+									</div>
+								)}
+							</div>
+
+							{/* 二维码操作按钮 */}
+							{qrDataUrl && (
+								<div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "center", marginBottom: "var(--space-2)" }}>
+									<button
+										className="ui-button ui-button-sm"
+										onClick={() => navigator.clipboard.writeText(qrLink).catch(() => {})}
+									>
+										复制链接
+									</button>
+									<button
+										className="ui-button ui-button-sm"
+										onClick={() => {
+											const a = document.createElement("a");
+											a.href = qrDataUrl;
+											a.download = "feishu-bot-qr.png";
+											a.click();
+										}}
+									>
+										下载二维码
+									</button>
+								</div>
+							)}
+
+							{/* 帮助提示 */}
+							<button
+								className="feishu-help-toggle"
+								onClick={() => setShowHelp((v) => !v)}
+								style={{ textAlign: "center" }}
+							>
+								{showHelp ? "收起" : "💡 如何获取安装链接？"}
+							</button>
+							{showHelp && (
+								<div className="feishu-help-content" style={{ textAlign: "left" }}>
+									<p>1. 前往{" "}
+										<a href="https://open.feishu.cn/app" target="_blank" rel="noreferrer">
+											飞书开放平台
+										</a>{" "}
+										→ 你的应用
+									</p>
+									<p>2. 左侧菜单 → <strong>应用发布</strong></p>
+									<p>3. 在「应用可用范围」区域点击「分享应用」</p>
+									<p>4. 选择「复制链接」获取安装链接</p>
+									<p>5. 粘贴到上方输入框，生成二维码</p>
+									<p style={{ marginTop: "var(--space-1)", color: "var(--color-warning)" }}>
+										⚠ 注意：应用必须先发布并通过审核，才能生成有效的安装链接。
+									</p>
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+
+				{/* ── 底部帮助（手动模式） ── */}
+				{mode === "manual" && (
+					<div className="feishu-help-footer">
+						<button
+							className="feishu-help-toggle"
+							onClick={() => setShowHelp((v) => !v)}
+						>
+							{showHelp ? "收起帮助" : "📋 如何获取 App ID 和 App Secret？"}
+						</button>
+						{showHelp && (
+							<div className="feishu-help-content">
+								<p>1. 打开{" "}
+									<a href="https://open.feishu.cn/app" target="_blank" rel="noreferrer">
+										飞书开放平台
+									</a>
+								</p>
+								<p>2. 创建企业自建应用</p>
+								<p>3. 在「凭证与基础信息」中获取 App ID 和 App Secret</p>
+								<p>4. 在「权限管理」中开启以下权限：</p>
+								<ul>
+									<li>im:message — 获取消息</li>
+									<li>im:message:send_as_bot — 发送消息</li>
+									<li>im:chat — 获取群聊信息</li>
+									<li>im:resource — 下载文件/图片</li>
+								</ul>
+								<p>5. 在「事件订阅」中开启 im.message.receive_v1（WebSocket 长连接模式）</p>
+								<p>6. 发布应用并审核通过</p>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/src/components/feishu/FeishuConnectDialog.tsx
+++ b/src/renderer/src/components/feishu/FeishuConnectDialog.tsx
@@ -2,11 +2,10 @@
  * FeishuConnectDialog — 飞书 Bot 连接配置弹窗
  *
  * 遵循 PiDeck 设计系统：CSS 变量 + ui-button / modal 体系。
- * 两种配置方式：手动配置（App ID + Secret）和扫码安装（二维码）。
+ * 仅支持手动配置（App ID + Secret）。
  */
 
-import { useState, useCallback, useEffect } from "react";
-import QRCode from "qrcode";
+import { useState, useCallback } from "react";
 import type { FeishuTestResult } from "../../../../shared/types";
 
 type Props = {
@@ -16,12 +15,7 @@ type Props = {
 	connecting: boolean;
 };
 
-type ConfigMode = "manual" | "qr";
-
 export function FeishuConnectDialog({ onClose, onConnect, onTest, connecting }: Props) {
-	const [mode, setMode] = useState<ConfigMode>("manual");
-
-	// 手动配置
 	const [appId, setAppId] = useState("");
 	const [appSecret, setAppSecret] = useState("");
 	const [botName, setBotName] = useState("");
@@ -30,45 +24,7 @@ export function FeishuConnectDialog({ onClose, onConnect, onTest, connecting }: 
 	const [testResult, setTestResult] = useState<FeishuTestResult | null>(null);
 	const [testing, setTesting] = useState(false);
 	const [step, setStep] = useState<"input" | "testing" | "connecting">("input");
-
-	// 二维码
-	const [qrLink, setQrLink] = useState("");
-	const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
-	const [qrGenerating, setQrGenerating] = useState(false);
 	const [showHelp, setShowHelp] = useState(false);
-
-	// 防抖生成二维码
-	const generateQr = useCallback(async (text: string) => {
-		if (!text.trim()) {
-			setQrDataUrl(null);
-			return;
-		}
-		setQrGenerating(true);
-		try {
-			const dataUrl = await QRCode.toDataURL(text.trim(), {
-				width: 280,
-				margin: 2,
-				color: { dark: "#000000", light: "#ffffff" },
-				errorCorrectionLevel: "M",
-			});
-			setQrDataUrl(dataUrl);
-		} catch {
-			setQrDataUrl(null);
-		} finally {
-			setQrGenerating(false);
-		}
-	}, []);
-
-	useEffect(() => {
-		const timer = setTimeout(() => {
-			if (qrLink.trim()) {
-				void generateQr(qrLink);
-			} else {
-				setQrDataUrl(null);
-			}
-		}, 400);
-		return () => clearTimeout(timer);
-	}, [qrLink, generateQr]);
 
 	const handleTest = useCallback(async () => {
 		if (!appId.trim() || !appSecret.trim()) {
@@ -116,251 +72,143 @@ export function FeishuConnectDialog({ onClose, onConnect, onTest, connecting }: 
 					<button onClick={onClose}>✕</button>
 				</div>
 
-				{/* ── 模式切换标签 ── */}
-				<div className="feishu-mode-tabs">
-					<button
-						className={`feishu-mode-tab${mode === "manual" ? " active" : ""}`}
-						onClick={() => setMode("manual")}
-					>
-						手动配置
-					</button>
-					<button
-						className={`feishu-mode-tab${mode === "qr" ? " active" : ""}`}
-						onClick={() => setMode("qr")}
-					>
-						扫码安装
-					</button>
-				</div>
-
 				{/* ── 内容区 ── */}
 				<div className="feishu-modal-body">
-					{mode === "manual" ? (
-						<>
-							{/* App ID */}
-							<div className="feishu-field">
-								<label>App ID</label>
-								<input
-									className="feishu-input feishu-input-mono"
-									type="text"
-									value={appId}
-									onChange={(e) => { setAppId(e.target.value); setError(null); setTestResult(null); }}
-									placeholder="cli_xxxxxxxxxxxx"
-									disabled={isBusy}
-								/>
-							</div>
+					{/* App ID */}
+					<div className="feishu-field">
+						<label>App ID</label>
+						<input
+							className="feishu-input feishu-input-mono"
+							type="text"
+							value={appId}
+							onChange={(e) => { setAppId(e.target.value); setError(null); setTestResult(null); }}
+							placeholder="cli_xxxxxxxxxxxx"
+							disabled={isBusy}
+						/>
+					</div>
 
-							{/* App Secret */}
-							<div className="feishu-field">
-								<label>App Secret</label>
-								<input
-									className="feishu-input feishu-input-mono"
-									type="password"
-									value={appSecret}
-									onChange={(e) => { setAppSecret(e.target.value); setError(null); setTestResult(null); }}
-									placeholder="••••••••••••••••"
-									disabled={isBusy}
-								/>
-							</div>
+					{/* App Secret */}
+					<div className="feishu-field">
+						<label>App Secret</label>
+						<input
+							className="feishu-input feishu-input-mono"
+							type="password"
+							value={appSecret}
+							onChange={(e) => { setAppSecret(e.target.value); setError(null); setTestResult(null); }}
+							placeholder="••••••••••••••••"
+							disabled={isBusy}
+						/>
+					</div>
 
-							{/* Bot 名称 */}
-							<div className="feishu-field">
-								<label>
-									Bot 名称 <span className="feishu-field-optional">(可选)</span>
-								</label>
-								<input
-									className="feishu-input"
-									type="text"
-									value={botName}
-									onChange={(e) => setBotName(e.target.value)}
-									placeholder="我的飞书助手"
-									disabled={isBusy}
-								/>
-							</div>
+					{/* Bot 名称 */}
+					<div className="feishu-field">
+						<label>
+							Bot 名称 <span className="feishu-field-optional">(可选)</span>
+						</label>
+						<input
+							className="feishu-input"
+							type="text"
+							value={botName}
+							onChange={(e) => setBotName(e.target.value)}
+							placeholder="我的飞书助手"
+							disabled={isBusy}
+						/>
+					</div>
 
-							{/* 分隔 */}
-							<hr className="feishu-divider" />
+					{/* 分隔 */}
+					<hr className="feishu-divider" />
 
-							{/* Open ID */}
-							<div className="feishu-field">
-								<label>
-									你的 Open ID <span className="feishu-field-optional">(可选，用于自动拉群)</span>
-								</label>
-								<input
-									className="feishu-input feishu-input-mono"
-									type="text"
-									value={defaultUserOpenId}
-									onChange={(e) => setDefaultUserOpenId(e.target.value)}
-									placeholder="ou_xxxxxxxxxxxxxxxx"
-									disabled={isBusy}
-								/>
-								<div className="feishu-field-hint">
-									如何获取：在飞书给 Bot 发 <code>/whoami</code> 即可查看
-								</div>
-							</div>
+					{/* Open ID */}
+					<div className="feishu-field">
+						<label>
+							你的 Open ID <span className="feishu-field-optional">(可选，用于自动拉群)</span>
+						</label>
+						<input
+							className="feishu-input feishu-input-mono"
+							type="text"
+							value={defaultUserOpenId}
+							onChange={(e) => setDefaultUserOpenId(e.target.value)}
+							placeholder="ou_xxxxxxxxxxxxxxxx"
+							disabled={isBusy}
+						/>
+						<div className="feishu-field-hint">
+							如何获取：在飞书给 Bot 发 <code>/whoami</code> 即可查看
+						</div>
+					</div>
 
-							{/* 错误提示 */}
-							{error && (
-								<div className="feishu-error-banner">{error}</div>
-							)}
+					{/* 错误提示 */}
+					{error && (
+						<div className="feishu-error-banner">{error}</div>
+					)}
 
-							{/* 测试结果 */}
-							{testResult && (
-								<div className={`feishu-test-result ${testResult.success ? "success" : "warning"}`}>
-									{testResult.success ? "✓" : "⚠"} {testResult.message}
-									{testResult.botName && ` (${testResult.botName})`}
-								</div>
-							)}
-
-							{/* 按钮 */}
-							<div className="feishu-button-row">
-								{step === "input" || step === "testing" ? (
-									<>
-										<button
-											className="ui-button ui-button-secondary"
-											onClick={handleTest}
-											disabled={testing || !appId.trim() || !appSecret.trim()}
-											style={{ flex: 1 }}
-										>
-											{testing ? "测试中…" : "测试连接"}
-										</button>
-										{step === "testing" && (
-											<button
-												className="ui-button ui-button-primary"
-												onClick={handleConnect}
-												disabled={connecting}
-												style={{ flex: 1 }}
-											>
-												{connecting ? "连接中…" : "连接"}
-											</button>
-										)}
-									</>
-								) : (
-									<div style={{ width: "100%", textAlign: "center", padding: "var(--space-3)", color: "var(--color-accent)", fontSize: "var(--font-size-caption)" }}>
-										正在连接飞书…
-									</div>
-								)}
-							</div>
-						</>
-					) : (
-						/* ── 扫码模式 ── */
-						<div className="feishu-qr-section">
-							<p className="feishu-qr-hint">
-								在飞书开放平台「应用发布」页面复制安装链接，
-								<br />
-								粘贴到下方即可生成二维码，用手机飞书扫码安装。
-							</p>
-
-							{/* Bot 安装链接 */}
-							<div className="feishu-field" style={{ textAlign: "left", marginBottom: "var(--space-4)" }}>
-								<label>Bot 安装链接</label>
-								<input
-									className="feishu-input feishu-input-mono"
-									type="text"
-									value={qrLink}
-									onChange={(e) => setQrLink(e.target.value)}
-									placeholder="https://applink.feishu.cn/client/bot/..."
-								/>
-							</div>
-
-							{/* 二维码 */}
-							<div className="feishu-qr-frame">
-								{qrGenerating ? (
-									<span style={{ color: "var(--color-text-tertiary)", fontSize: "var(--font-size-caption)" }}>
-										生成中…
-									</span>
-								) : qrDataUrl ? (
-									<img src={qrDataUrl} alt="飞书 Bot 安装二维码" />
-								) : (
-									<div className="feishu-qr-placeholder">
-										<div className="feishu-qr-placeholder-icon">📱</div>
-										<div>等待输入链接</div>
-									</div>
-								)}
-							</div>
-
-							{/* 二维码操作按钮 */}
-							{qrDataUrl && (
-								<div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "center", marginBottom: "var(--space-2)" }}>
-									<button
-										className="ui-button ui-button-sm"
-										onClick={() => navigator.clipboard.writeText(qrLink).catch(() => {})}
-									>
-										复制链接
-									</button>
-									<button
-										className="ui-button ui-button-sm"
-										onClick={() => {
-											const a = document.createElement("a");
-											a.href = qrDataUrl;
-											a.download = "feishu-bot-qr.png";
-											a.click();
-										}}
-									>
-										下载二维码
-									</button>
-								</div>
-							)}
-
-							{/* 帮助提示 */}
-							<button
-								className="feishu-help-toggle"
-								onClick={() => setShowHelp((v) => !v)}
-								style={{ textAlign: "center" }}
-							>
-								{showHelp ? "收起" : "💡 如何获取安装链接？"}
-							</button>
-							{showHelp && (
-								<div className="feishu-help-content" style={{ textAlign: "left" }}>
-									<p>1. 前往{" "}
-										<a href="https://open.feishu.cn/app" target="_blank" rel="noreferrer">
-											飞书开放平台
-										</a>{" "}
-										→ 你的应用
-									</p>
-									<p>2. 左侧菜单 → <strong>应用发布</strong></p>
-									<p>3. 在「应用可用范围」区域点击「分享应用」</p>
-									<p>4. 选择「复制链接」获取安装链接</p>
-									<p>5. 粘贴到上方输入框，生成二维码</p>
-									<p style={{ marginTop: "var(--space-1)", color: "var(--color-warning)" }}>
-										⚠ 注意：应用必须先发布并通过审核，才能生成有效的安装链接。
-									</p>
-								</div>
-							)}
+					{/* 测试结果 */}
+					{testResult && (
+						<div className={`feishu-test-result ${testResult.success ? "success" : "warning"}`}>
+							{testResult.success ? "✓" : "⚠"} {testResult.message}
+							{testResult.botName && ` (${testResult.botName})`}
 						</div>
 					)}
-				</div>
 
-				{/* ── 底部帮助（手动模式） ── */}
-				{mode === "manual" && (
-					<div className="feishu-help-footer">
-						<button
-							className="feishu-help-toggle"
-							onClick={() => setShowHelp((v) => !v)}
-						>
-							{showHelp ? "收起帮助" : "📋 如何获取 App ID 和 App Secret？"}
-						</button>
-						{showHelp && (
-							<div className="feishu-help-content">
-								<p>1. 打开{" "}
-									<a href="https://open.feishu.cn/app" target="_blank" rel="noreferrer">
-										飞书开放平台
-									</a>
-								</p>
-								<p>2. 创建企业自建应用</p>
-								<p>3. 在「凭证与基础信息」中获取 App ID 和 App Secret</p>
-								<p>4. 在「权限管理」中开启以下权限：</p>
-								<ul>
-									<li>im:message — 获取消息</li>
-									<li>im:message:send_as_bot — 发送消息</li>
-									<li>im:chat — 获取群聊信息</li>
-									<li>im:resource — 下载文件/图片</li>
-								</ul>
-								<p>5. 在「事件订阅」中开启 im.message.receive_v1（WebSocket 长连接模式）</p>
-								<p>6. 发布应用并审核通过</p>
+					{/* 按钮 */}
+					<div className="feishu-button-row">
+						{step === "input" || step === "testing" ? (
+							<>
+								<button
+									className="ui-button ui-button-secondary"
+									onClick={handleTest}
+									disabled={testing || !appId.trim() || !appSecret.trim()}
+									style={{ flex: 1 }}
+								>
+									{testing ? "测试中…" : "测试连接"}
+								</button>
+								{step === "testing" && (
+									<button
+										className="ui-button ui-button-primary"
+										onClick={handleConnect}
+										disabled={connecting}
+										style={{ flex: 1 }}
+									>
+										{connecting ? "连接中…" : "连接"}
+									</button>
+								)}
+							</>
+						) : (
+							<div style={{ width: "100%", textAlign: "center", padding: "var(--space-3)", color: "var(--color-accent)", fontSize: "var(--font-size-caption)" }}>
+								正在连接飞书…
 							</div>
 						)}
 					</div>
-				)}
+				</div>
+
+				{/* ── 底部帮助 ── */}
+				<div className="feishu-help-footer">
+					<button
+						className="feishu-help-toggle"
+						onClick={() => setShowHelp((v) => !v)}
+					>
+						{showHelp ? "收起帮助" : "📋 如何获取 App ID 和 App Secret？"}
+					</button>
+					{showHelp && (
+						<div className="feishu-help-content">
+							<p>1. 打开{" "}
+								<a href="https://open.feishu.cn/app" target="_blank" rel="noreferrer">
+									飞书开放平台
+								</a>
+							</p>
+							<p>2. 创建企业自建应用</p>
+							<p>3. 在「凭证与基础信息」中获取 App ID 和 App Secret</p>
+							<p>4. 在「权限管理」中开启以下权限：</p>
+							<ul>
+								<li>im:message — 获取消息</li>
+								<li>im:message:send_as_bot — 发送消息</li>
+								<li>im:chat — 获取群聊信息</li>
+								<li>im:resource — 下载文件/图片</li>
+							</ul>
+							<p>5. 在「事件订阅」中开启 im.message.receive_v1（WebSocket 长连接模式）</p>
+							<p>6. 发布应用并审核通过</p>
+						</div>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/renderer/src/components/feishu/FeishuPanel.tsx
+++ b/src/renderer/src/components/feishu/FeishuPanel.tsx
@@ -1,0 +1,254 @@
+/**
+ * FeishuPanel — 侧边栏飞书面板
+ *
+ * 遵循 PiDeck 设计系统：CSS 变量 + ui-button / icon-button 体系。
+ * 显示连接状态、Bot 信息、聊天绑定列表，提供连接/断开/管理操作。
+ */
+
+import { useState } from "react";
+import { FeishuConnectDialog } from "./FeishuConnectDialog";
+import type {
+	FeishuBridgeStatus,
+	FeishuChatBinding,
+	FeishuBotConfig,
+	FeishuTestResult,
+} from "../../../../shared/types";
+
+type Props = {
+	status: FeishuBridgeStatus;
+	bots: FeishuBotConfig[];
+	bindings: FeishuChatBinding[];
+	connecting: boolean;
+	isConnected: boolean;
+	hasConfig: boolean;
+	onConnect: (appId: string, appSecret: string, name: string, defaultUserOpenId?: string) => Promise<{ success: boolean; message: string }>;
+	onDisconnect: () => void;
+	onRemoveBot: (botId: string) => Promise<boolean>;
+	onUpdateBotConfig: (botId: string, patch: Partial<FeishuBotConfig>) => Promise<FeishuBotConfig | undefined>;
+	onTest: (appId: string, appSecret: string) => Promise<FeishuTestResult>;
+	onRemoveBinding: (chatId: string) => Promise<boolean>;
+};
+
+const STATUS_LABEL: Record<string, string> = {
+	connected: "已连接",
+	connecting: "连接中",
+	disconnected: "未连接",
+	error: "错误",
+};
+
+export function FeishuPanel({
+	status,
+	bots,
+	bindings,
+	connecting,
+	isConnected,
+	hasConfig,
+	onConnect,
+	onDisconnect,
+	onRemoveBot,
+	onUpdateBotConfig,
+	onTest,
+	onRemoveBinding,
+}: Props) {
+	const [showConfig, setShowConfig] = useState(false);
+	const [showBots, setShowBots] = useState(false);
+	const [showBindings, setShowBindings] = useState(false);
+	const [editingBotId, setEditingBotId] = useState<string | null>(null);
+	const [editOpenId, setEditOpenId] = useState("");
+
+	const statusClass = status.status;
+
+	const handleDeleteBot = async (botId: string) => {
+		if (!window.confirm("确定要删除该 Bot 配置吗？")) return;
+		await onRemoveBot(botId);
+	};
+
+	return (
+		<div className="feishu-panel">
+			{/* ── 状态指示器 ── */}
+			<div className="feishu-panel-header">
+				<span className={`feishu-status-dot ${statusClass}`} />
+				<span className="feishu-panel-title">飞书 Bridge</span>
+				<span
+					className="feishu-panel-status"
+					style={{
+						color:
+							statusClass === "connected"
+								? "var(--color-accent)"
+								: statusClass === "connecting"
+									? "var(--color-warning)"
+									: statusClass === "error"
+										? "var(--color-danger)"
+										: "var(--color-text-tertiary)",
+					}}
+				>
+					{STATUS_LABEL[statusClass] || statusClass}
+				</span>
+			</div>
+
+			{/* ── 错误消息 ── */}
+			{status.errorMessage && (
+				<div className="feishu-error-banner">{status.errorMessage}</div>
+			)}
+
+			{/* ── Bot 列表 ── */}
+			{bots.length > 0 && (
+				<div>
+					<button
+						className="feishu-section-toggle"
+						onClick={() => setShowBots((prev) => !prev)}
+					>
+						{showBots ? "▾" : "▸"} 已配置 Bot ({bots.length})
+					</button>
+					{showBots &&
+						bots.map((bot) => (
+							<div key={bot.id} className="feishu-bot-item" style={{ marginTop: 4 }}>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+									<div style={{ minWidth: 0 }}>
+										<div className="feishu-bot-name">{bot.name}</div>
+										<div className="feishu-bot-meta">
+											App: <span>{bot.appId.slice(0, 12)}…</span>
+										</div>
+										{bot.defaultUserOpenId && (
+											<div className="feishu-bot-meta" style={{ marginTop: 2 }}>
+												Open ID: <span>{bot.defaultUserOpenId.slice(0, 16)}…</span>
+											</div>
+										)}
+									</div>
+									<div className="feishu-bot-actions">
+										<button
+											className="icon-button"
+											title="编辑 Open ID"
+											onClick={() => {
+												setEditingBotId(editingBotId === bot.id ? null : bot.id);
+												setEditOpenId(bot.defaultUserOpenId || "");
+											}}
+											style={{ width: 26, height: 26, fontSize: 13 }}
+										>
+											{editingBotId === bot.id ? "✕" : "✎"}
+										</button>
+										<button
+											className="icon-button"
+											title="删除 Bot"
+											onClick={() => handleDeleteBot(bot.id)}
+											style={{ width: 26, height: 26, color: "var(--color-danger)", fontSize: 14 }}
+										>
+											🗑
+										</button>
+									</div>
+								</div>
+								{/* Open ID 编辑 */}
+								{editingBotId === bot.id && (
+									<div className="feishu-openid-edit">
+										<input
+											type="text"
+											value={editOpenId}
+											onChange={(e) => setEditOpenId(e.target.value)}
+											placeholder="ou_xxxxxxxxxxxxxxxx"
+										/>
+										<button
+											className="ui-button ui-button-sm ui-button-primary"
+											style={{ fontSize: "var(--font-size-micro)", height: "var(--control-height-xs)", padding: "0 8px" }}
+											onClick={async () => {
+												await onUpdateBotConfig(bot.id, { defaultUserOpenId: editOpenId.trim() || undefined });
+												setEditingBotId(null);
+											}}
+										>
+											保存
+										</button>
+									</div>
+								)}
+							</div>
+						))}
+				</div>
+			)}
+
+			{/* ── 绑定概览 ── */}
+			{bindings.length > 0 && (
+				<div>
+					<button
+						className="feishu-section-toggle"
+						onClick={() => setShowBindings((prev) => !prev)}
+					>
+						{showBindings ? "▾" : "▸"} 活跃聊天 ({bindings.length})
+					</button>
+					{showBindings &&
+						bindings.map((b) => (
+							<div key={b.chatId} className="feishu-binding-item" style={{ marginTop: 2 }}>
+								<div className="feishu-binding-info">
+									<div className="feishu-binding-name">
+										{b.chatType === "p2p" ? "💬" : "👥"} {b.groupName || b.chatId.slice(0, 8)}
+									</div>
+									<div className="feishu-binding-session">
+										会话: {b.sessionId.slice(0, 8)}
+									</div>
+								</div>
+								<button
+									className="icon-button"
+									title="解除绑定"
+									onClick={() => onRemoveBinding(b.chatId)}
+									style={{ width: 24, height: 24, fontSize: 12, color: "var(--color-text-tertiary)" }}
+								>
+									✕
+								</button>
+							</div>
+						))}
+				</div>
+			)}
+
+			{/* ── 无 Bot 时的空状态 ── */}
+			{bots.length === 0 && !isConnected && (
+				<div className="feishu-empty">
+					连接飞书 Bot，在飞书中与 Pi 对话
+				</div>
+			)}
+
+			{/* ── 操作按钮 ── */}
+			<div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-1)" }}>
+				{!isConnected ? (
+					<>
+						<button
+							className="ui-button ui-button-sm ui-button-primary"
+							onClick={() => setShowConfig(true)}
+							disabled={connecting}
+							style={{ flex: 1 }}
+						>
+							{hasConfig ? "连接" : "配置 Bot"}
+						</button>
+						{hasConfig && (
+							<button
+								className="ui-button ui-button-sm"
+								onClick={() => setShowConfig(true)}
+								style={{ minWidth: 32, padding: "0 8px" }}
+							>
+								⚙
+							</button>
+						)}
+					</>
+				) : (
+					<button
+						className="ui-button ui-button-sm ui-button-secondary"
+						onClick={onDisconnect}
+						style={{ flex: 1 }}
+					>
+						断开连接
+					</button>
+				)}
+			</div>
+
+			{/* ── 配置弹窗 ── */}
+			{showConfig && (
+				<FeishuConnectDialog
+					onClose={() => setShowConfig(false)}
+					onConnect={async (appId, appSecret, name, defaultUserOpenId) => {
+						const result = await onConnect(appId, appSecret, name, defaultUserOpenId);
+						if (result.success) setShowConfig(false);
+						return result;
+					}}
+					onTest={onTest}
+					connecting={connecting}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/renderer/src/config/ImTab.tsx
+++ b/src/renderer/src/config/ImTab.tsx
@@ -5,7 +5,6 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
-import QRCode from "qrcode";
 import type {
 	FeishuBotConfig,
 	FeishuBridgeStatus,
@@ -48,46 +47,7 @@ export function ImTab(_props: Props) {
 	const [connectionMessage, setConnectionMessage] = useState<string | null>(null);
 	const [expandedBotId, setExpandedBotId] = useState<string | null>(null);
 
-	// 二维码状态
-	const [qrLink, setQrLink] = useState("");
-	const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
-	const [qrGenerating, setQrGenerating] = useState(false);
-
 	const api = (window as unknown as { piDesktop?: { feishu?: FeishuApiRaw } }).piDesktop?.feishu;
-
-	// 生成二维码
-	const generateQr = useCallback(async (text: string) => {
-		if (!text.trim()) {
-			setQrDataUrl(null);
-			return;
-		}
-		setQrGenerating(true);
-		try {
-			const dataUrl = await QRCode.toDataURL(text.trim(), {
-				width: 200,
-				margin: 2,
-				color: { dark: "#000000", light: "#ffffff" },
-				errorCorrectionLevel: "M",
-			});
-			setQrDataUrl(dataUrl);
-		} catch {
-			setQrDataUrl(null);
-		} finally {
-			setQrGenerating(false);
-		}
-	}, []);
-
-	// 防抖生成二维码
-	useEffect(() => {
-		const timer = setTimeout(() => {
-			if (qrLink.trim()) {
-				void generateQr(qrLink);
-			} else {
-				setQrDataUrl(null);
-			}
-		}, 400);
-		return () => clearTimeout(timer);
-	}, [qrLink, generateQr]);
 
 	const loadData = useCallback(async () => {
 		if (!api) { setLoading(false); return; }
@@ -485,69 +445,7 @@ export function ImTab(_props: Props) {
 				)}
 			</div>
 
-			{/* 二维码生成 */}
-			<div>
-				<h3 style={{ margin: "0 0 12px 0", fontSize: 15, color: "var(--text-primary, #e0e0e0)" }}>
-					📱 生成安装二维码
-				</h3>
-				<div style={{
-					display: "flex",
-					gap: 16,
-					alignItems: "flex-start",
-					flexWrap: "wrap",
-				}}>
-					<div style={{ flex: "1 1 260px" }}>
-						<p style={{ fontSize: 12, color: "#888", marginBottom: 8 }}>
-							粘贴飞书应用的安装链接，生成二维码供他人扫码安装 Bot。
-						</p>
-						<input
-							type="text"
-							value={qrLink}
-							onChange={(e) => setQrLink(e.target.value)}
-							placeholder="https://applink.feishu.cn/client/bot/..."
-							style={{
-								width: "100%",
-								padding: "6px 10px",
-								borderRadius: 4,
-								border: "1px solid var(--border-color, #333)",
-								background: "var(--bg-primary, #0d0d1a)",
-								color: "var(--text-primary, #e0e0e0)",
-								fontSize: 13,
-								boxSizing: "border-box",
-							}}
-						/>
-						<div style={{ fontSize: 11, color: "#888", marginTop: 6 }}>
-							💡 在飞书开放平台「应用发布」→「分享应用」中复制安装链接。
-						</div>
-					</div>
-					<div style={{
-						width: 150,
-						height: 150,
-						border: "2px dashed var(--border-color, #444)",
-						borderRadius: 8,
-						display: "flex",
-						alignItems: "center",
-						justifyContent: "center",
-						background: "#fff",
-						flexShrink: 0,
-						overflow: "hidden",
-					}}>
-						{qrGenerating ? (
-							<span style={{ color: "#888", fontSize: 12 }}>生成中...</span>
-						) : qrDataUrl ? (
-							<img
-								src={qrDataUrl}
-								alt="飞书安装二维码"
-								style={{ width: 138, height: 138 }}
-							/>
-						) : (
-							<div style={{ textAlign: "center", color: "#ccc" }}>
-								<div style={{ fontSize: 28 }}>📱</div>
-							</div>
-						)}
-					</div>
-				</div>
-			</div>
+
 
 			{/* 帮助信息 */}
 			<details style={{ fontSize: 12, color: "#888" }}>

--- a/src/renderer/src/config/ImTab.tsx
+++ b/src/renderer/src/config/ImTab.tsx
@@ -1,0 +1,573 @@
+/**
+ * ImTab — IM 连接配置选项卡
+ *
+ * 在设置弹窗中集中管理飞书 Bot 配置，含二维码生成。
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import QRCode from "qrcode";
+import type {
+	FeishuBotConfig,
+	FeishuBridgeStatus,
+	FeishuChatBinding,
+	FeishuTestResult,
+} from "../../../shared/types";
+
+type Props = {
+	onSave?: () => void;
+};
+
+type FeishuApiRaw = {
+	botsList?: () => Promise<FeishuBotConfig[]>;
+	statusRequest?: () => Promise<FeishuBridgeStatus>;
+	bindingsList?: () => Promise<FeishuChatBinding[]>;
+	onStatus?: (cb: (s: FeishuBridgeStatus) => void) => () => void;
+	connect?: (input: { appId: string; appSecret: string; name: string }) => Promise<{ success: boolean; message: string }>;
+	connectByBot?: (botId: string) => Promise<{ success: boolean; message: string }>;
+	disconnect?: () => Promise<unknown>;
+	botAdd?: (input: { appId: string; appSecret: string; name?: string }) => Promise<{ success: boolean; bot?: FeishuBotConfig; error?: string }>;
+	botRemove?: (botId: string) => Promise<boolean>;
+	testConnection?: (appId: string, appSecret: string) => Promise<FeishuTestResult>;
+	bindingRemove?: (chatId: string) => Promise<boolean>;
+};
+
+export function ImTab(_props: Props) {
+	const [bots, setBots] = useState<FeishuBotConfig[]>([]);
+	const [status, setStatus] = useState<FeishuBridgeStatus>({ status: "disconnected", activeBindings: 0 });
+	const [bindings, setBindings] = useState<FeishuChatBinding[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [showAddForm, setShowAddForm] = useState(false);
+	const [appId, setAppId] = useState("");
+	const [appSecret, setAppSecret] = useState("");
+	const [botName, setBotName] = useState("");
+	const [adding, setAdding] = useState(false);
+	const [testResult, setTestResult] = useState<FeishuTestResult | null>(null);
+	const [testing, setTesting] = useState(false);
+	const [connecting, setConnecting] = useState(false);
+	const [connectionMessage, setConnectionMessage] = useState<string | null>(null);
+	const [expandedBotId, setExpandedBotId] = useState<string | null>(null);
+
+	// 二维码状态
+	const [qrLink, setQrLink] = useState("");
+	const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+	const [qrGenerating, setQrGenerating] = useState(false);
+
+	const api = (window as unknown as { piDesktop?: { feishu?: FeishuApiRaw } }).piDesktop?.feishu;
+
+	// 生成二维码
+	const generateQr = useCallback(async (text: string) => {
+		if (!text.trim()) {
+			setQrDataUrl(null);
+			return;
+		}
+		setQrGenerating(true);
+		try {
+			const dataUrl = await QRCode.toDataURL(text.trim(), {
+				width: 200,
+				margin: 2,
+				color: { dark: "#000000", light: "#ffffff" },
+				errorCorrectionLevel: "M",
+			});
+			setQrDataUrl(dataUrl);
+		} catch {
+			setQrDataUrl(null);
+		} finally {
+			setQrGenerating(false);
+		}
+	}, []);
+
+	// 防抖生成二维码
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			if (qrLink.trim()) {
+				void generateQr(qrLink);
+			} else {
+				setQrDataUrl(null);
+			}
+		}, 400);
+		return () => clearTimeout(timer);
+	}, [qrLink, generateQr]);
+
+	const loadData = useCallback(async () => {
+		if (!api) { setLoading(false); return; }
+		setLoading(true);
+		setError(null);
+		try {
+			const [botsList, statusRes, bindingsList] = await Promise.all([
+				api.botsList?.(),
+				api.statusRequest?.(),
+				api.bindingsList?.(),
+			]);
+			setBots(botsList ?? []);
+			setStatus(statusRes ?? { status: "disconnected", activeBindings: 0 });
+			setBindings(bindingsList ?? []);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : String(e));
+		} finally {
+			setLoading(false);
+		}
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+	useEffect(() => {
+		void loadData();
+	}, [loadData]);
+
+	useEffect(() => {
+		if (!api) return;
+		return api.onStatus?.(setStatus);
+	}, [api]);
+
+	const handleTest = useCallback(async () => {
+		if (!api || !appId.trim() || !appSecret.trim()) return;
+		setTesting(true);
+		setTestResult(null);
+		try {
+			const result = await api.testConnection!(appId.trim(), appSecret.trim());
+			setTestResult(result);
+		} catch (e) {
+			setTestResult({ success: false, message: e instanceof Error ? e.message : String(e) });
+		} finally {
+			setTesting(false);
+		}
+	}, [api, appId, appSecret]);
+
+	const handleAddBot = useCallback(async () => {
+		if (!api || !appId.trim() || !appSecret.trim()) return;
+		setAdding(true);
+		try {
+			const result = await api.botAdd!({
+				appId: appId.trim(),
+				appSecret: appSecret.trim(),
+				name: botName.trim() || "飞书机器人",
+			});
+			if (result.success) {
+				setAppId("");
+				setAppSecret("");
+				setBotName("");
+				setShowAddForm(false);
+				setTestResult(null);
+				await loadData();
+			} else {
+				setError(result.error ?? "添加失败");
+			}
+		} catch (e) {
+			setError(e instanceof Error ? e.message : String(e));
+		} finally {
+			setAdding(false);
+		}
+	}, [api, appId, appSecret, botName, loadData]);
+
+	const handleConnect = useCallback(async () => {
+		if (!api || bots.length === 0) return;
+		setConnecting(true);
+		setConnectionMessage(null);
+		try {
+			const bot = bots[0]!;
+			const result = await api.connectByBot!(bot.id);
+			setConnectionMessage(result.message);
+			if (result.success) await loadData();
+		} catch (e) {
+			setConnectionMessage(e instanceof Error ? e.message : String(e));
+		} finally {
+			setConnecting(false);
+		}
+	}, [api, bots, loadData]);
+
+	const handleDisconnect = useCallback(async () => {
+		if (!api) return;
+		await api.disconnect!();
+		await loadData();
+		setConnectionMessage("已断开");
+	}, [api, loadData]);
+
+	const handleRemoveBot = useCallback(async (botId: string) => {
+		if (!api) return;
+		if (!window.confirm("确定要删除该 Bot 配置吗？")) return;
+		await api.botRemove!(botId);
+		await loadData();
+	}, [api, loadData]);
+
+	const handleRemoveBinding = useCallback(async (chatId: string) => {
+		if (!api) return;
+		await api.bindingRemove!(chatId);
+		await loadData();
+	}, [api, loadData]);
+
+	const isConnected = status.status === "connected";
+
+	const statusColors: Record<string, string> = {
+		connected: "#00c864",
+		connecting: "#ffa726",
+		disconnected: "#888",
+		error: "#ff4d4d",
+	};
+
+	const statusLabels: Record<string, string> = {
+		connected: "已连接",
+		connecting: "连接中",
+		disconnected: "未连接",
+		error: "错误",
+	};
+
+	if (loading) {
+		return <div style={{ padding: 40, textAlign: "center", color: "#888" }}>加载中...</div>;
+	}
+
+	return (
+		<div style={{ display: "flex", flexDirection: "column", gap: 20, padding: "8px 0" }}>
+			{/* 连接状态 */}
+			<div style={{
+				display: "flex",
+				alignItems: "center",
+				gap: 12,
+				padding: "12px 16px",
+				background: "var(--bg-secondary, #1a1a2e)",
+				borderRadius: 8,
+			}}>
+				<span style={{
+					width: 10,
+					height: 10,
+					borderRadius: "50%",
+					background: statusColors[status.status] || "#888",
+					display: "inline-block",
+					flexShrink: 0,
+				}} />
+				<div style={{ flex: 1 }}>
+					<div style={{ fontWeight: 600, color: "var(--text-primary, #e0e0e0)" }}>
+						飞书连接状态: {statusLabels[status.status] || status.status}
+					</div>
+					{status.errorMessage && (
+						<div style={{ color: "#ff4d4d", fontSize: 12, marginTop: 2 }}>
+							{status.errorMessage}
+						</div>
+					)}
+				</div>
+				<div style={{ display: "flex", gap: 8 }}>
+					{isConnected ? (
+						<button className="config-btn" onClick={handleDisconnect} style={{ fontSize: 12 }}>
+							⏹ 断开
+						</button>
+					) : (
+						<button
+							className="config-btn primary"
+							onClick={handleConnect}
+							disabled={connecting || bots.length === 0}
+							style={{ fontSize: 12 }}
+						>
+							{connecting ? "连接中..." : "🔗 连接"}
+						</button>
+					)}
+				</div>
+			</div>
+
+			{connectionMessage && (
+				<div style={{
+					padding: "8px 12px",
+					borderRadius: 6,
+					background: connectionMessage.includes("成功") ? "rgba(0, 200, 100, 0.1)" : "rgba(255, 150, 50, 0.1)",
+					color: connectionMessage.includes("成功") ? "#00c864" : "#ff9632",
+					fontSize: 13,
+				}}>
+					{connectionMessage}
+				</div>
+			)}
+
+			{error && (
+				<div style={{
+					padding: "8px 12px",
+					borderRadius: 6,
+					background: "rgba(255, 77, 77, 0.1)",
+					color: "#ff4d4d",
+					fontSize: 13,
+				}}>
+					{error}
+					<button onClick={() => setError(null)} style={{ marginLeft: 8, background: "none", border: "none", color: "#ff4d4d", cursor: "pointer" }}>✕</button>
+				</div>
+			)}
+
+			{/* Bot 管理 */}
+			<div>
+				<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+					<h3 style={{ margin: 0, fontSize: 15, color: "var(--text-primary, #e0e0e0)" }}>
+						🤖 Bot 配置 ({bots.length})
+					</h3>
+					<button
+						className="config-btn primary"
+						onClick={() => { setShowAddForm((v) => !v); setTestResult(null); setAppId(""); setAppSecret(""); setBotName(""); }}
+						style={{ fontSize: 12 }}
+					>
+						{showAddForm ? "取消" : "+ 添加 Bot"}
+					</button>
+				</div>
+
+				{showAddForm && (
+					<div style={{
+						padding: 16,
+						background: "var(--bg-secondary, #1a1a2e)",
+						borderRadius: 8,
+						marginBottom: 12,
+						display: "flex",
+						flexDirection: "column",
+						gap: 12,
+					}}>
+						<div>
+							<label style={{ fontSize: 12, fontWeight: 600, display: "block", marginBottom: 4, color: "var(--text-primary, #e0e0e0)" }}>
+								App ID
+							</label>
+							<input
+								type="text"
+								value={appId}
+								onChange={(e) => { setAppId(e.target.value); setTestResult(null); }}
+								placeholder="cli_xxxxxxxxxxxx"
+								style={{ width: "100%", padding: "6px 10px", borderRadius: 4, border: "1px solid var(--border-color, #333)", background: "var(--bg-primary, #0d0d1a)", color: "var(--text-primary, #e0e0e0)", fontSize: 13 }}
+							/>
+						</div>
+						<div>
+							<label style={{ fontSize: 12, fontWeight: 600, display: "block", marginBottom: 4, color: "var(--text-primary, #e0e0e0)" }}>
+								App Secret
+							</label>
+							<input
+								type="password"
+								value={appSecret}
+								onChange={(e) => { setAppSecret(e.target.value); setTestResult(null); }}
+								placeholder="••••••••••••••••"
+								style={{ width: "100%", padding: "6px 10px", borderRadius: 4, border: "1px solid var(--border-color, #333)", background: "var(--bg-primary, #0d0d1a)", color: "var(--text-primary, #e0e0e0)", fontSize: 13 }}
+							/>
+						</div>
+						<div>
+							<label style={{ fontSize: 12, fontWeight: 600, display: "block", marginBottom: 4, color: "var(--text-primary, #e0e0e0)" }}>
+								Bot 名称 <span style={{ fontWeight: 400, color: "#888" }}>(可选)</span>
+							</label>
+							<input
+								type="text"
+								value={botName}
+								onChange={(e) => setBotName(e.target.value)}
+								placeholder="我的飞书助手"
+								style={{ width: "100%", padding: "6px 10px", borderRadius: 4, border: "1px solid var(--border-color, #333)", background: "var(--bg-primary, #0d0d1a)", color: "var(--text-primary, #e0e0e0)", fontSize: 13 }}
+							/>
+						</div>
+
+						{testResult && (
+							<div style={{
+								padding: "8px 12px",
+								borderRadius: 4,
+								background: testResult.success ? "rgba(0, 200, 100, 0.1)" : "rgba(255, 150, 50, 0.1)",
+								color: testResult.success ? "#00c864" : "#ff9632",
+								fontSize: 13,
+							}}>
+								{testResult.success ? "✅ " : "⚠️ "}{testResult.message}
+							</div>
+						)}
+
+						<div style={{ display: "flex", gap: 8 }}>
+							<button
+								className="config-btn"
+								onClick={handleTest}
+								disabled={testing || !appId.trim() || !appSecret.trim()}
+								style={{ fontSize: 12 }}
+							>
+								{testing ? "测试中..." : "🔍 测试连接"}
+							</button>
+							<button
+								className="config-btn primary"
+								onClick={handleAddBot}
+								disabled={adding || !appId.trim() || !appSecret.trim()}
+								style={{ fontSize: 12 }}
+							>
+								{adding ? "添加中..." : "✅ 保存"}
+							</button>
+						</div>
+
+						<div style={{ fontSize: 11, color: "#888", lineHeight: 1.6 }}>
+							<p style={{ margin: "4px 0" }}>
+								💡 在 <a href="https://open.feishu.cn/app" target="_blank" style={{ color: "#4fc3f7" }}>飞书开放平台</a> 创建企业自建应用，获取 App ID 和 App Secret。
+							</p>
+						</div>
+					</div>
+				)}
+
+				{bots.length === 0 && !showAddForm && (
+					<div style={{ padding: 24, textAlign: "center", color: "#888", fontSize: 13 }}>
+						暂无 Bot 配置，点击上方按钮添加。
+					</div>
+				)}
+				{bots.map((bot) => (
+					<div key={bot.id} style={{
+						padding: "12px 14px",
+						background: "var(--bg-secondary, #1a1a2e)",
+						borderRadius: 8,
+						marginBottom: 8,
+					}}>
+						<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+							<div>
+								<div style={{ fontWeight: 600, color: "var(--text-primary, #e0e0e0)", fontSize: 14 }}>
+									{bot.name}
+								</div>
+								<div style={{ color: "#888", fontSize: 12 }}>
+									App ID: {bot.appId.slice(0, 14)}...
+								</div>
+							</div>
+							<div style={{ display: "flex", gap: 6 }}>
+								<button
+									className="config-btn"
+									onClick={() => setExpandedBotId(expandedBotId === bot.id ? null : bot.id)}
+									style={{ fontSize: 11 }}
+								>
+									{expandedBotId === bot.id ? "收起" : "详情"}
+								</button>
+								<button
+									className="config-btn"
+									onClick={() => handleRemoveBot(bot.id)}
+									style={{ fontSize: 11, color: "#ff4d4d" }}
+								>
+									🗑
+								</button>
+							</div>
+						</div>
+						{expandedBotId === bot.id && (
+							<div style={{ marginTop: 10, padding: "10px 0", borderTop: "1px solid var(--border-color, #333)", fontSize: 12, color: "#999" }}>
+								<div>Bot ID: {bot.id}</div>
+								<div>状态: {bot.enabled ? "✅ 启用" : "❌ 禁用"}</div>
+								{bot.defaultWorkspaceId && <div>默认工作区: {bot.defaultWorkspaceId}</div>}
+								{bot.defaultModelId && <div>默认模型: {bot.defaultModelId}</div>}
+							</div>
+						)}
+					</div>
+				))}
+			</div>
+
+			{/* 聊天绑定 */}
+			<div>
+				<h3 style={{ margin: "0 0 12px 0", fontSize: 15, color: "var(--text-primary, #e0e0e0)" }}>
+					💬 活跃聊天绑定 ({bindings.length})
+				</h3>
+				{bindings.length === 0 ? (
+					<div style={{ padding: 16, textAlign: "center", color: "#888", fontSize: 13 }}>
+						暂无活跃绑定。连接飞书后发送消息即可自动创建绑定。
+					</div>
+				) : (
+					bindings.map((binding) => (
+						<div key={binding.chatId} style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "space-between",
+							padding: "8px 12px",
+							background: "var(--bg-secondary, #1a1a2e)",
+							borderRadius: 6,
+							marginBottom: 4,
+							fontSize: 12,
+						}}>
+							<div>
+								<span style={{ color: "var(--text-primary, #e0e0e0)" }}>
+									{binding.chatType === "p2p" ? "💬" : "👥"} {binding.groupName || binding.chatId.slice(0, 10)}
+								</span>
+								<div style={{ color: "#888", fontSize: 10 }}>
+									会话: {binding.sessionId.slice(0, 8)} | {new Date(binding.createdAt).toLocaleString()}
+								</div>
+							</div>
+							<button
+								onClick={() => handleRemoveBinding(binding.chatId)}
+								style={{
+									background: "none",
+									border: "none",
+									color: "#ff4d4d",
+									cursor: "pointer",
+									fontSize: 14,
+									padding: "2px 6px",
+								}}
+								title="解除绑定"
+							>
+								✕
+							</button>
+						</div>
+					))
+				)}
+			</div>
+
+			{/* 二维码生成 */}
+			<div>
+				<h3 style={{ margin: "0 0 12px 0", fontSize: 15, color: "var(--text-primary, #e0e0e0)" }}>
+					📱 生成安装二维码
+				</h3>
+				<div style={{
+					display: "flex",
+					gap: 16,
+					alignItems: "flex-start",
+					flexWrap: "wrap",
+				}}>
+					<div style={{ flex: "1 1 260px" }}>
+						<p style={{ fontSize: 12, color: "#888", marginBottom: 8 }}>
+							粘贴飞书应用的安装链接，生成二维码供他人扫码安装 Bot。
+						</p>
+						<input
+							type="text"
+							value={qrLink}
+							onChange={(e) => setQrLink(e.target.value)}
+							placeholder="https://applink.feishu.cn/client/bot/..."
+							style={{
+								width: "100%",
+								padding: "6px 10px",
+								borderRadius: 4,
+								border: "1px solid var(--border-color, #333)",
+								background: "var(--bg-primary, #0d0d1a)",
+								color: "var(--text-primary, #e0e0e0)",
+								fontSize: 13,
+								boxSizing: "border-box",
+							}}
+						/>
+						<div style={{ fontSize: 11, color: "#888", marginTop: 6 }}>
+							💡 在飞书开放平台「应用发布」→「分享应用」中复制安装链接。
+						</div>
+					</div>
+					<div style={{
+						width: 150,
+						height: 150,
+						border: "2px dashed var(--border-color, #444)",
+						borderRadius: 8,
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						background: "#fff",
+						flexShrink: 0,
+						overflow: "hidden",
+					}}>
+						{qrGenerating ? (
+							<span style={{ color: "#888", fontSize: 12 }}>生成中...</span>
+						) : qrDataUrl ? (
+							<img
+								src={qrDataUrl}
+								alt="飞书安装二维码"
+								style={{ width: 138, height: 138 }}
+							/>
+						) : (
+							<div style={{ textAlign: "center", color: "#ccc" }}>
+								<div style={{ fontSize: 28 }}>📱</div>
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{/* 帮助信息 */}
+			<details style={{ fontSize: 12, color: "#888" }}>
+				<summary style={{ cursor: "pointer", marginBottom: 8 }}>📋 配置指南</summary>
+				<div style={{ lineHeight: 1.8, paddingLeft: 16 }}>
+					<p>1. 打开 <a href="https://open.feishu.cn/app" target="_blank" style={{ color: "#4fc3f7" }}>飞书开放平台</a></p>
+					<p>2. 创建「企业自建应用」</p>
+					<p>3. 在 <strong>凭证与基础信息</strong> 中获取 App ID 和 App Secret</p>
+					<p>4. 在 <strong>权限管理</strong> 中开启：</p>
+					<ul style={{ margin: "4px 0", paddingLeft: 20 }}>
+						<li>im:message — 获取消息</li>
+						<li>im:message:send_as_bot — 发送消息</li>
+						<li>im:chat — 获取群聊信息</li>
+						<li>im:resource — 下载文件/图片</li>
+					</ul>
+					<p>5. 在 <strong>事件订阅</strong> 中开启 im.message.receive_v1（WebSocket 长连接模式）</p>
+					<p>6. 创建应用版本并发布</p>
+					<p style={{ marginTop: 8 }}>详细文档：<a href="https://open.feishu.cn/document/home/index" target="_blank" style={{ color: "#4fc3f7" }}>飞书开放平台文档</a></p>
+				</div>
+			</details>
+		</div>
+	);
+}

--- a/src/renderer/src/config/configTypes.ts
+++ b/src/renderer/src/config/configTypes.ts
@@ -1,4 +1,4 @@
-export type ConfigTab = "models" | "auth" | "settings" | "raw";
+export type ConfigTab = "models" | "auth" | "settings" | "im" | "raw";
 
 // ── 匹配 pi 实际文件格式的类型 ────────────────────────
 

--- a/src/renderer/src/hooks/useFeishuBridge.ts
+++ b/src/renderer/src/hooks/useFeishuBridge.ts
@@ -29,6 +29,7 @@ type PiDesktopFeishuApi = {
 	bindingRemove: (chatId: string) => Promise<boolean>;
 	bindingUpdate: (chatId: string, patch: Partial<FeishuChatBinding>) => Promise<FeishuChatBinding | undefined>;
 	onMessages: (callback: (message: FeishuChatMessage) => void) => () => void;
+	onBindingsChanged: (callback: (bindings: FeishuChatBinding[]) => void) => () => void;
 };
 
 function getApi(): PiDesktopFeishuApi | undefined {
@@ -77,6 +78,14 @@ export function useFeishuBridge() {
 		if (!api) return;
 		return api.onMessages((msg) => {
 			setMessages((prev) => [...prev.slice(-99), msg]);
+		});
+	}, [api]);
+
+	// 绑定列表变更推送
+	useEffect(() => {
+		if (!api) return;
+		return api.onBindingsChanged((bi) => {
+			setBindings(bi);
 		});
 	}, [api]);
 

--- a/src/renderer/src/hooks/useFeishuBridge.ts
+++ b/src/renderer/src/hooks/useFeishuBridge.ts
@@ -1,0 +1,190 @@
+/**
+ * useFeishuBridge — 飞书桥接状态 Hook
+ *
+ * 封装 IPC 调用 + 状态订阅，供前端组件使用。
+ * 通过 window.piDesktop.feishu.* API 与主进程通信。
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import type {
+	FeishuBotConfig,
+	FeishuBridgeStatus,
+	FeishuChatBinding,
+	FeishuChatMessage,
+	FeishuConnectInput,
+	FeishuTestResult,
+} from "../../../shared/types";
+
+type PiDesktopFeishuApi = {
+	connect: (input: FeishuConnectInput) => Promise<{ success: boolean; message: string }>;
+	disconnect: () => Promise<{ success: boolean }>;
+	statusRequest: () => Promise<FeishuBridgeStatus>;
+	onStatus: (callback: (status: FeishuBridgeStatus) => void) => () => void;
+	botsList: () => Promise<FeishuBotConfig[]>;
+	botAdd: (input: FeishuConnectInput) => Promise<{ success: boolean; bot?: FeishuBotConfig; error?: string }>;
+	botRemove: (botId: string) => Promise<boolean>;
+	botConfig: (botId: string, patch: Partial<FeishuBotConfig>) => Promise<FeishuBotConfig | undefined>;
+	testConnection: (appId: string, appSecret: string) => Promise<FeishuTestResult>;
+	bindingsList: () => Promise<FeishuChatBinding[]>;
+	bindingRemove: (chatId: string) => Promise<boolean>;
+	bindingUpdate: (chatId: string, patch: Partial<FeishuChatBinding>) => Promise<FeishuChatBinding | undefined>;
+	onMessages: (callback: (message: FeishuChatMessage) => void) => () => void;
+};
+
+function getApi(): PiDesktopFeishuApi | undefined {
+	return (window as unknown as { piDesktop?: { feishu?: PiDesktopFeishuApi } }).piDesktop?.feishu;
+}
+
+export function useFeishuBridge() {
+	const [status, setStatus] = useState<FeishuBridgeStatus>({ status: "disconnected", activeBindings: 0 });
+	const [bots, setBots] = useState<FeishuBotConfig[]>([]);
+	const [bindings, setBindings] = useState<FeishuChatBinding[]>([]);
+	const [messages, setMessages] = useState<FeishuChatMessage[]>([]);
+	const [connecting, setConnecting] = useState(false);
+	const [testing, setTesting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const api = getApi();
+
+	// 初始状态加载
+	useEffect(() => {
+		if (!api) return;
+
+		void (async () => {
+			try {
+				const [s, b, bi] = await Promise.all([
+					api.statusRequest(),
+					api.botsList(),
+					api.bindingsList(),
+				]);
+				setStatus(s);
+				setBots(b);
+				setBindings(bi);
+			} catch (e) {
+				console.error("飞书状态加载失败:", e);
+			}
+		})();
+	}, [api]);
+
+	// 状态推送订阅
+	useEffect(() => {
+		if (!api) return;
+		return api.onStatus(setStatus);
+	}, [api]);
+
+	// 消息推送订阅
+	useEffect(() => {
+		if (!api) return;
+		return api.onMessages((msg) => {
+			setMessages((prev) => [...prev.slice(-99), msg]);
+		});
+	}, [api]);
+
+	const connect = useCallback(async (input: FeishuConnectInput) => {
+		if (!api) return { success: false, message: "API 未就绪" };
+		setConnecting(true);
+		setError(null);
+		try {
+			const result = await api.connect(input);
+			if (result.success) {
+				const [b, bi] = await Promise.all([api.botsList(), api.bindingsList()]);
+				setBots(b);
+				setBindings(bi);
+			} else {
+				setError(result.message);
+			}
+			return result;
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			setError(msg);
+			return { success: false, message: msg };
+		} finally {
+			setConnecting(false);
+		}
+	}, [api]);
+
+	const disconnect = useCallback(async () => {
+		if (!api) return;
+		await api.disconnect();
+		setBindings([]);
+	}, [api]);
+
+	const addBot = useCallback(async (input: FeishuConnectInput) => {
+		if (!api) return { success: false, error: "API 未就绪" };
+		const result = await api.botAdd(input);
+		if (result.success) {
+			setBots((prev) => [...prev, result.bot!]);
+		}
+		return result;
+	}, [api]);
+
+	const removeBot = useCallback(async (botId: string) => {
+		if (!api) return false;
+		const ok = await api.botRemove(botId);
+		if (ok) {
+			setBots((prev) => prev.filter((b) => b.id !== botId));
+		}
+		return ok;
+	}, [api]);
+
+	const updateBotConfig = useCallback(async (botId: string, patch: Partial<FeishuBotConfig>) => {
+		if (!api) return undefined;
+		const updated = await api.botConfig(botId, patch);
+		if (updated) {
+			setBots((prev) => prev.map((b) => (b.id === botId ? updated : b)));
+		}
+		return updated;
+	}, [api]);
+
+	const testConnection = useCallback(async (appId: string, appSecret: string) => {
+		if (!api) return { success: false, message: "API 未就绪" };
+		setTesting(true);
+		try {
+			return await api.testConnection(appId, appSecret);
+		} finally {
+			setTesting(false);
+		}
+	}, [api]);
+
+	const removeBinding = useCallback(async (chatId: string) => {
+		if (!api) return false;
+		const ok = await api.bindingRemove(chatId);
+		if (ok) {
+			setBindings((prev) => prev.filter((b) => b.chatId !== chatId));
+		}
+		return ok;
+	}, [api]);
+
+	const refreshBindings = useCallback(async () => {
+		if (!api) return;
+		const bi = await api.bindingsList();
+		setBindings(bi);
+	}, [api]);
+
+	// 判断当前状态
+	const isConnected = status.status === "connected";
+	const isConnecting = status.status === "connecting";
+	const hasConfig = bots.length > 0;
+
+	return {
+		status,
+		bots,
+		bindings,
+		messages,
+		connecting,
+		testing,
+		error,
+		isConnected,
+		isConnecting,
+		hasConfig,
+		connect,
+		disconnect,
+		addBot,
+		removeBot,
+		updateBotConfig,
+		testConnection,
+		removeBinding,
+		refreshBindings,
+		clearError: () => setError(null),
+	};
+}

--- a/src/renderer/src/previewApi.ts
+++ b/src/renderer/src/previewApi.ts
@@ -496,6 +496,7 @@ export function createPreviewApi(): PiDesktopApi {
 			bindingRemove: async () => false,
 			bindingUpdate: async () => undefined,
 			onMessages: () => () => {},
+			onBindingsChanged: () => () => {},
 		},
 	};
 }

--- a/src/renderer/src/previewApi.ts
+++ b/src/renderer/src/previewApi.ts
@@ -481,5 +481,21 @@ export function createPreviewApi(): PiDesktopApi {
 				};
 			},
 		},
+		feishu: {
+			connect: async () => ({ success: true, message: "预览模式" }),
+			disconnect: async () => ({ success: true }),
+			connectByBot: async () => ({ success: false, message: "预览模式不支持" }),
+			statusRequest: async () => ({ status: "disconnected" as const, activeBindings: 0 }),
+			onStatus: () => () => {},
+			botsList: async () => [],
+			botAdd: async () => ({ success: false, error: "预览模式不支持" }),
+			botRemove: async () => false,
+			botConfig: async () => undefined,
+			testConnection: async () => ({ success: false, message: "预览模式不支持" }),
+			bindingsList: async () => [],
+			bindingRemove: async () => false,
+			bindingUpdate: async () => undefined,
+			onMessages: () => () => {},
+		},
 	};
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -8174,3 +8174,419 @@ body.is-composer-resizing .composer-resize-handle::after {
 :root[data-theme="dark"] .setting-switch-row strong {
 	color: var(--color-text-primary);
 }
+
+/* ── 飞书面板（侧边栏内嵌） ───────────────────── */
+.feishu-panel {
+	padding: var(--space-3);
+	font-size: var(--font-size-control);
+	color: var(--color-text-secondary);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2);
+}
+
+.feishu-panel-header {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+}
+
+.feishu-panel-header .feishu-status-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: var(--radius-pill);
+	flex-shrink: 0;
+	transition: background-color 0.3s ease;
+}
+.feishu-panel-header .feishu-status-dot.connected {
+	background: var(--color-accent);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 14%, transparent);
+}
+.feishu-panel-header .feishu-status-dot.connecting {
+	background: var(--color-warning);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-warning) 14%, transparent);
+	animation: feishu-pulse 1.3s ease-in-out infinite;
+}
+.feishu-panel-header .feishu-status-dot.disconnected {
+	background: var(--color-text-tertiary);
+}
+.feishu-panel-header .feishu-status-dot.error {
+	background: var(--color-danger);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-danger) 14%, transparent);
+}
+@keyframes feishu-pulse {
+	0%, 100% { transform: scale(1); opacity: 1; }
+	50% { transform: scale(1.25); opacity: 0.55; }
+}
+
+.feishu-panel-header .feishu-panel-title {
+	font-weight: 600;
+	font-size: var(--font-size-control);
+	color: var(--color-text-primary);
+	font-family: var(--font-family-brand);
+	font-style: italic;
+	letter-spacing: 0.01em;
+}
+
+.feishu-panel-header .feishu-panel-status {
+	margin-left: auto;
+	font-size: var(--font-size-micro);
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+}
+
+.feishu-error-banner {
+	padding: var(--space-1) var(--space-2);
+	border-radius: var(--radius-sm);
+	background: var(--color-danger-soft);
+	color: var(--color-danger);
+	font-size: var(--font-size-micro);
+	line-height: var(--line-height-caption);
+	word-break: break-all;
+}
+
+/* Bot 列表项 */
+.feishu-bot-item {
+	padding: var(--space-2);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: var(--radius-md);
+	background: var(--color-bg-panel);
+	font-size: var(--font-size-caption);
+	line-height: var(--line-height-caption);
+}
+.feishu-bot-item .feishu-bot-name {
+	color: var(--color-text-primary);
+	font-weight: 600;
+	font-size: var(--font-size-control);
+}
+.feishu-bot-item .feishu-bot-meta {
+	color: var(--color-text-tertiary);
+	font-size: var(--font-size-micro);
+}
+.feishu-bot-item .feishu-bot-meta span {
+	font-family: var(--font-family-mono);
+}
+.feishu-bot-item .feishu-bot-actions {
+	display: flex;
+	gap: var(--space-1);
+	align-items: center;
+}
+
+/* Open ID 编辑行 */
+.feishu-openid-edit {
+	display: flex;
+	gap: var(--space-1);
+	align-items: center;
+	margin-top: var(--space-1);
+}
+.feishu-openid-edit input {
+	flex: 1;
+	min-width: 0;
+	height: var(--control-height-xs);
+	padding: 0 var(--space-2);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: var(--radius-sm);
+	background: var(--color-bg-muted);
+	color: var(--color-text-primary);
+	font-size: var(--font-size-micro);
+	font-family: var(--font-family-mono);
+	box-sizing: border-box;
+}
+.feishu-openid-edit input:focus {
+	outline: none;
+	border-color: var(--color-accent);
+	box-shadow: var(--focus-ring);
+}
+
+/* 绑定列表项 */
+.feishu-binding-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: var(--space-1) var(--space-2);
+	border-radius: var(--radius-sm);
+	background: var(--color-bg-panel);
+	font-size: var(--font-size-micro);
+	line-height: var(--line-height-micro);
+}
+.feishu-binding-item .feishu-binding-info {
+	min-width: 0;
+}
+.feishu-binding-item .feishu-binding-name {
+	color: var(--color-text-primary);
+	font-weight: 500;
+}
+.feishu-binding-item .feishu-binding-session {
+	color: var(--color-text-tertiary);
+}
+
+/* 可折叠区块标题 */
+.feishu-section-toggle {
+	width: 100%;
+	border: 0;
+	background: none;
+	color: var(--color-text-secondary);
+	font-size: var(--font-size-caption);
+	font-weight: 500;
+	text-align: left;
+	padding: var(--space-1) 0;
+	cursor: pointer;
+	transition: color 0.15s ease;
+	font-family: var(--font-family-base);
+}
+.feishu-section-toggle:hover {
+	color: var(--color-accent);
+}
+
+/* 空状态 */
+.feishu-empty {
+	text-align: center;
+	padding: var(--space-3) 0;
+	color: var(--color-text-tertiary);
+	font-size: var(--font-size-caption);
+	line-height: var(--line-height-caption);
+}
+
+/* ── 飞书连接弹窗 ─────────────────────────────── */
+.feishu-connect-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 120;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--overlay-backdrop);
+	animation: feishu-fade-in 0.15s ease;
+}
+@keyframes feishu-fade-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+.feishu-connect-dialog {
+	width: min(540px, calc(100vw - 48px));
+	max-height: calc(100vh - 80px);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: var(--radius-lg);
+	background: var(--color-bg-panel);
+	box-shadow: var(--shadow-modal);
+	animation: feishu-slide-up 0.18s ease-out;
+}
+@keyframes feishu-slide-up {
+	from { opacity: 0; transform: translateY(12px); }
+	to { opacity: 1; transform: translateY(0); }
+}
+
+.feishu-connect-dialog .feishu-modal-body {
+	flex: 1;
+	overflow-y: auto;
+	padding: var(--space-5) var(--space-5) var(--space-4);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-4);
+}
+
+/* 模式切换标签 */
+.feishu-mode-tabs {
+	display: flex;
+	border-bottom: 1px solid var(--color-border-subtle);
+	margin-bottom: 0;
+}
+.feishu-mode-tab {
+	flex: 1;
+	padding: 11px 0 10px;
+	border: 0;
+	background: none;
+	font-size: var(--font-size-body);
+	font-weight: 500;
+	color: var(--color-text-tertiary);
+	border-bottom: 2px solid transparent;
+	cursor: pointer;
+	transition: color 0.18s ease, border-color 0.18s ease;
+	font-family: var(--font-family-base);
+}
+.feishu-mode-tab:hover {
+	color: var(--color-text-secondary);
+}
+.feishu-mode-tab.active {
+	color: var(--color-accent);
+	border-bottom-color: var(--color-accent);
+	font-weight: 600;
+}
+
+/* 表单字段 */
+.feishu-field {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-1);
+}
+.feishu-field label {
+	font-size: var(--font-size-caption);
+	font-weight: 600;
+	color: var(--color-text-primary);
+}
+.feishu-field label .feishu-field-optional {
+	font-weight: 400;
+	color: var(--color-text-tertiary);
+}
+.feishu-field .feishu-field-hint {
+	font-size: var(--font-size-micro);
+	color: var(--color-text-tertiary);
+	line-height: var(--line-height-caption);
+}
+.feishu-field .feishu-field-hint code {
+	font-family: var(--font-family-mono);
+	font-size: var(--font-size-micro);
+	background: var(--color-bg-muted);
+	padding: 1px 5px;
+	border-radius: var(--radius-xs);
+}
+
+/* 输入框 */
+.feishu-input {
+	width: 100%;
+	height: var(--control-height-md);
+	padding: 0 var(--space-3);
+	border: 1px solid var(--color-border-subtle);
+	border-radius: var(--radius-md);
+	background: var(--color-bg-muted);
+	color: var(--color-text-primary);
+	font-size: var(--font-size-control);
+	box-sizing: border-box;
+	transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.feishu-input:focus {
+	outline: none;
+	border-color: var(--color-accent);
+	box-shadow: var(--focus-ring);
+}
+.feishu-input::placeholder {
+	color: var(--color-text-tertiary);
+}
+.feishu-input:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.feishu-input-mono {
+	font-family: var(--font-family-mono);
+	font-size: var(--font-size-caption);
+}
+
+/* 分隔线 */
+.feishu-divider {
+	height: 0;
+	border: 0;
+	border-top: 1px solid var(--color-border-subtle);
+	margin: var(--space-1) 0;
+}
+
+/* 按钮行 */
+.feishu-button-row {
+	display: flex;
+	gap: var(--space-2);
+	margin-top: var(--space-2);
+}
+
+/* 测试结果提示 */
+.feishu-test-result {
+	padding: var(--space-2) var(--space-3);
+	border-radius: var(--radius-md);
+	font-size: var(--font-size-caption);
+	line-height: var(--line-height-caption);
+}
+.feishu-test-result.success {
+	background: var(--color-accent-soft);
+	color: var(--color-accent);
+}
+.feishu-test-result.warning {
+	background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+	color: var(--color-warning);
+}
+
+/* 二维码区域 */
+.feishu-qr-section {
+	text-align: center;
+}
+.feishu-qr-section .feishu-qr-hint {
+	font-size: var(--font-size-caption);
+	color: var(--color-text-secondary);
+	line-height: var(--line-height-body);
+	margin: 0 0 var(--space-4);
+}
+.feishu-qr-frame {
+	width: 280px;
+	height: 280px;
+	margin: 0 auto var(--space-3);
+	border: 2px dashed var(--color-border-strong);
+	border-radius: var(--radius-lg);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--color-bg-muted);
+	overflow: hidden;
+}
+.feishu-qr-frame img {
+	width: 264px;
+	height: 264px;
+	border-radius: var(--radius-sm);
+}
+.feishu-qr-placeholder {
+	text-align: center;
+	color: var(--color-text-tertiary);
+	font-size: var(--font-size-caption);
+	line-height: var(--line-height-caption);
+}
+.feishu-qr-placeholder .feishu-qr-placeholder-icon {
+	font-size: 40px;
+	margin-bottom: var(--space-1);
+}
+
+/* 帮助区域 */
+.feishu-help-toggle {
+	width: 100%;
+	border: 0;
+	background: none;
+	color: var(--color-text-tertiary);
+	font-size: var(--font-size-caption);
+	padding: var(--space-2) var(--space-3);
+	cursor: pointer;
+	text-align: left;
+	transition: color 0.15s ease;
+	font-family: var(--font-family-base);
+}
+.feishu-help-toggle:hover {
+	color: var(--color-text-secondary);
+}
+.feishu-help-content {
+	padding: 0 var(--space-3) var(--space-3);
+	font-size: var(--font-size-caption);
+	color: var(--color-text-secondary);
+	line-height: 1.8;
+}
+.feishu-help-content p {
+	margin: 0 0 var(--space-1);
+}
+.feishu-help-content ul {
+	padding-left: 20px;
+	margin: var(--space-1) 0;
+}
+.feishu-help-content a {
+	color: var(--color-accent);
+	text-decoration: none;
+}
+.feishu-help-content a:hover {
+	text-decoration: underline;
+}
+
+.feishu-help-footer {
+	border-top: 1px solid var(--color-border-subtle);
+}
+
+/* 侧边栏飞书按钮 */
+.feishu-icon.feishu-connected {
+	color: var(--color-accent);
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -97,4 +97,23 @@ export const ipcChannels = {
 	terminalClose: "terminal:close",
 	terminalData: "terminal:data",
 	terminalExit: "terminal:exit",
+
+	// ===== 飞书桥接 =====
+	feishuConnect: "feishu:connect",
+	feishuDisconnect: "feishu:disconnect",
+	feishuStatus: "feishu:status",
+	feishuStatusRequest: "feishu:status-request",
+	feishuBotsList: "feishu:bots-list",
+	feishuBotAdd: "feishu:bot-add",
+	feishuBotRemove: "feishu:bot-remove",
+	feishuBotConfig: "feishu:bot-config",
+	feishuTestConnection: "feishu:test-connection",
+	feishuBindingsList: "feishu:bindings-list",
+	feishuBindingRemove: "feishu:binding-remove",
+	feishuBindingUpdate: "feishu:binding-update",
+	feishuMessages: "feishu:messages",
+	feishuQrCode: "feishu:qr-code",
+	feishuConnectByBot: "feishu:connect-by-bot",
+	/** Pi 创建会话时触发飞书自动拉群 */
+	feishuAutoGroup: "feishu:auto-group",
 } as const;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -111,6 +111,7 @@ export const ipcChannels = {
 	feishuBindingsList: "feishu:bindings-list",
 	feishuBindingRemove: "feishu:binding-remove",
 	feishuBindingUpdate: "feishu:binding-update",
+	feishuBindingsChanged: "feishu:bindings-changed",
 	feishuMessages: "feishu:messages",
 	feishuQrCode: "feishu:qr-code",
 	feishuConnectByBot: "feishu:connect-by-bot",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -380,3 +380,69 @@ export type ThinkingUpdate = {
 	thinking: string;
 };
 
+// ===== 飞书桥接类型 =====
+
+export type FeishuBotConfig = {
+	id: string;
+	name: string;
+	enabled: boolean;
+	appId: string;
+	appSecret: string; // 加密存储
+	defaultWorkspaceId?: string;
+	defaultChannelId?: string;
+	defaultModelId?: string;
+	requireMention?: boolean;
+	/** 用户自己的 open_id（用于自动拉群时加入 user_id_list）。在飞书中给 Bot 发 /whoami 即可获取 */
+	defaultUserOpenId?: string;
+};
+
+export type FeishuBridgeStatus = {
+	status: "disconnected" | "connecting" | "connected" | "error";
+	activeBindings: number;
+	connectedAt?: number;
+	errorMessage?: string;
+	botOpenId?: string;
+	botName?: string;
+};
+
+export type FeishuChatBinding = {
+	chatId: string;
+	botId: string;
+	userId: string;
+	sessionId: string;
+	workspaceId: string;
+	channelId?: string;
+	modelId?: string;
+	source: "feishu" | "session-mirror";
+	chatType: "p2p" | "group";
+	groupName?: string;
+	createdAt: number;
+};
+
+export type FeishuChatMessage = {
+	chatId: string;
+	messageId: string;
+	senderOpenId: string;
+	senderName?: string;
+	chatType: "p2p" | "group";
+	groupName?: string;
+	messageType: "text" | "image" | "post" | "file";
+	text: string;
+	imageKeys: string[];
+	fileKeys: string[];
+	timestamp: number;
+};
+
+export type FeishuConnectInput = {
+	appId: string;
+	appSecret: string;
+	name?: string;
+	defaultUserOpenId?: string;
+};
+
+export type FeishuTestResult = {
+	success: boolean;
+	message: string;
+	botName?: string;
+};
+

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -410,6 +410,7 @@ export type FeishuChatBinding = {
 	botId: string;
 	userId: string;
 	sessionId: string;
+	sessionPath?: string;
 	workspaceId: string;
 	channelId?: string;
 	modelId?: string;


### PR DESCRIPTION
## Summary
## 概述                                                                                          
                                                                                                    
   为 PiDeck 集成飞书/Lark 远程控制能力，用户可在飞书 App 中与 Pi Agent 对话，支持流式卡片实时展示  
 Agent 处理过程。                                                                                   
                                                                                                    
   ## 参考来源                                                                                      
                                                                                                    
   本功能的架构和实现大量参考了以下优秀项目：                                                       
                                                                                                    
   - **[Proma](https://github.com/proma-ai/Proma)** — 流式卡片协议（CardKit）、任务状态机           
 （RunState）、消息处理管线设计                                                                     
   - **[pi-feishu-lark](https://github.com/AX1202/pi-feishu-lark)** — 飞书扩展的完整实现，包括      
 WSClient 连接、智能消息模式（text/post/interactive）、会话管理、GatewayLock 等                     
                                                                                                    
   ## 新增功能                                                                                      
                                                                                                    
   - 🔗 **飞书 WebSocket 长连接**：基于 `@larksuiteoapi/node-sdk` 的 WSClient + EventDispatcher     
   - ⚡ **闪电确认**：收到消息后 ~200ms 回复 "⚡ 已收到"，消除用户等待感                            
   - 📊 **流式活动轨迹卡片**：Agent 每步操作（启动/工具调用/思考/输出/压缩/重试）实时可见，带时间戳 
 和状态图标                                                                                         
   - 🔄 **并行启动**：CardStream 创建与 Agent 推理并行执行，互不阻塞                                
   - 🎯 **智能消息模式**：根据内容特征自动选择 text/post/interactive，正确渲染代码块和表格          
   - 🤖 **Session Mirror 自动拉群**：Pi 侧创建会话 → 飞书自动创建私人群聊                           
   - 📱 **双向消息同步**：飞书 ↔ Pi 实时互通                                                        
   - 💬 **命令系统**：`/help /new /stop /status /whoami /refresh`                                   
   - 🔁 **断线自动重连**：指数退避（5s→60s，最多 10 次）                                            
   - 🛡️ **三重消息去重**：event_id + message_id + 内容指纹（5s TTL）                                
                                                                                                    
   ## 新增文件                                                                                      
                                                                                                    
   | 文件 | 说明 |                                                                                  
   |------|------|                                                                                  
   | `src/main/feishu/FeishuBridge.ts` | 桥接主类（~1200 行），消息处理、Agent 调度、绑定管理 |     
   | `src/main/feishu/CardStream.ts` | 流式卡片通信协议（im.v1.message.patch + 200ms 节流） |       
   | `src/main/feishu/CardRunState.ts` | 纯函数状态机，Agent 事件 → 结构化 RunState |               
   | `src/main/feishu/CardRenderer.ts` | RunState → 飞书卡片 JSON 渲染 |                            
   | `src/main/feishu/rich-text.ts` | Markdown → 飞书消息智能转换 |                                 
   | `src/main/feishu/FeishuConfig.ts` | 多 Bot 配置 CRUD + 绑定持久化 |                            
   | `src/main/feishu/types.ts` | 内部类型定义 |                                                    
   | `src/renderer/src/components/feishu/` | 飞书 UI（侧边栏面板 + Bot 配置弹窗） |                 
   | `src/renderer/src/config/ImTab.tsx` | 设置面板 "IM 连接" Tab |                                 
   | `docs/飞书远程控制-维护手册.md` | 完整维护文档（架构/注入点/故障排查） |                       
                                                                                                    
   ## 修改文件要点                                                                                  
                                                                                                    
   - **AgentManager.ts** — 新增 `addLocalEventListener()`，供 FeishuBridge 监听 Agent 事件          
   - **index.ts** — 注册全部飞书 IPC 处理器 + autoConnectFeishu + Session Mirror 触发器             
   - **ipc.ts** — 新增 14 个飞书相关 IPC 通道                                                       
   - **types.ts** — 新增 `FeishuBotConfig`、`FeishuBridgeStatus`、`ImageContent` 等共享类型         
                                                                                                    
   ## 技术亮点                                                                                      
                                                                                                    
   1. **纯函数状态机**：`reduceFromPiEvent(state, event) → newState`，便于测试和维护                
   2. **流式卡片节流**：200ms 合并间隔，终态强制 flush，最大重试 2 次                               
   3. **降级兜底**：CardStream patch 失败后自动降级为文本消息发送                                   
   4. **绑定恢复**：重启后通过 sessionPath 自动恢复飞书会话映射                                     
   5. **四级群聊匹配**：sessionId → sessionPath → 孤立群复用 → 新建群                               
                                                                                                    
   ## 需要配置                                                                                      
                                                                                                    
   - 飞书开放平台创建应用 + 获取 App ID/Secret                                                      
   - 权限：`im:message`、`im:message:send_as_bot`、`im:chat`、`im:resource`                         
   - 事件订阅：`im.message.receive_v1` 
<!-- Describe what changed and why. -->

## Checklist

- [ ] I ran `npm run typecheck`.
- [ ] I ran `npm run build`.
- [ ] I added comments for non-obvious logic or state transitions.
- [ ] I updated documentation if behavior changed.

## Screenshots

<!-- Add screenshots or recordings for UI changes. -->
