### PR TITLE
fix(pet): 拖拽巡游时立刻切 idle + 无 agent 时 pet 不出现

### DIFF
--- a/src/main/pet/PetPatrol.ts
+++ b/src/main/pet/PetPatrol.ts
@@ -1,9 +1,17 @@
-import { screen, type BrowserWindow } from "electron";
+import { screen, type BrowserWindow, type Rectangle } from "electron";
 import { ipcChannels } from "../../shared/ipc";
 
 /**
  * PetPatrol —— idle 时沿屏幕底部巡游。
  * 停顿 N 分钟后朝路程远的方向走，碰边反向，往复。
+ *
+ * 设计要点（防瞬移）：
+ * 1. 每个 tick 都用时间增量计算步长，而非固定 step；并对 delta 做上限钳制，
+ *    避免系统抖动（睡眠唤醒 / App Nap / CPU 峰值）累积出超大单步位移。
+ * 2. 每次 setPosition 之前都对目标 x 做硬钳制，绝不输出越界坐标——
+ *    这样即便外部（系统/拖拽残留）把窗口挪到边界外，巡游也只会让它贴边走回，不会瞬移到对侧。
+ * 3. 检测「异常跳变」：若两次 tick 之间窗口位移远超本 tick 应有步长，
+ *    说明被系统/用户搬动了，立即以当前位置重算 workArea 并结束本次巡游。
  */
 
 export class PetPatrol {
@@ -13,6 +21,14 @@ export class PetPatrol {
 	private readonly speed = 40;     // px/s
 	private readonly tickMs = 50;
 	private readonly edgeMargin = 16;
+	/** 巡游中锁定的工作区，避免行进途中显示器坐标系抖动 */
+	private walkWorkArea: Rectangle | null = null;
+	/** 上一次 tick 记录的 x，用于检测外部造成的异常跳变 */
+	private lastTickX: number | null = null;
+	/** 上一次 tick 的时间戳，用于按真实增量计算步长 */
+	private lastTickAt = 0;
+	/** 拖拽中：阻塞 start/tick，避免巡游与手动移动争抢窗口位置造成瞬移 */
+	private dragging = false;
 
 	constructor(
 		private readonly getPetWindow: () => BrowserWindow | null,
@@ -22,6 +38,10 @@ export class PetPatrol {
 	get active(): boolean { return this.tickTimer !== null || this.pauseTimer !== null; }
 
 	start() {
+		// 拖拽中绝不（重新）起巡游。拖拽开始时 bridge.update() 仍会异步触发 maybeStartPatrol，
+		// 没有这个守卫，start() 会重新 scheduleWalk→beginWalk→tick，与拖拽 moveWindow 争抢窗口位置
+		// → 出现「继续跑 + 闪到边界 + 闪回鼠标」的双重瞬移。
+		if (this.dragging) return;
 		if (this.active) return;
 		this.pushState("idle");
 		this.scheduleWalk();
@@ -30,32 +50,103 @@ export class PetPatrol {
 	stop() {
 		if (this.tickTimer) { clearInterval(this.tickTimer); this.tickTimer = null; }
 		if (this.pauseTimer) { clearTimeout(this.pauseTimer); this.pauseTimer = null; }
+		this.walkWorkArea = null;
+		this.lastTickX = null;
+	}
+
+	/** 拖拽起止：开始时立刻停巡游并置位标志，结束时清位（由 bridge 决定是否恢复巡游） */
+	setDragging(dragging: boolean) {
+		this.dragging = dragging;
+		if (dragging) this.stop();
 	}
 
 	private beginWalk() {
 		if (this.pauseTimer) { clearTimeout(this.pauseTimer); this.pauseTimer = null; }
+		const wa = this.resolveWorkArea();
+		if (!wa) return; // 无法确定坐标系则不开始，避免用错边界位移
+		this.walkWorkArea = wa;
+		this.lastTickX = null;
+		this.lastTickAt = Date.now();
 		this.pushState(this.direction === "right" ? "running-right" : "running-left");
 		this.tickTimer = setInterval(() => this.tick(), this.tickMs);
 	}
 
-	private tick() {
+	/** 抵达边界：停止步行，进入 idle 停顿并安排下一次巡游 */
+	private endWalk() {
+		if (this.tickTimer) { clearInterval(this.tickTimer); this.tickTimer = null; }
+		this.walkWorkArea = null;
+		this.lastTickX = null;
+		this.pushState("idle");
+		this.scheduleWalk();
+	}
+
+	/** 异常跳变/外部搬动（含拖拽）：直接停下并归位 idle，不重新排程。
+	 *  用 halt 而非 endWalk：endWalk 会 scheduleWalk 重新起巡游，
+	 *  在拖拽场景下会与手动移动争抢窗口位置 → 边界闪现。*/
+	private halt() {
+		this.stop();
+		this.pushState("idle");
+	}
+
+	/** 读取窗口所在显示器的 workArea；窗口不存在或检测失败返回 null */
+	private resolveWorkArea(): Rectangle | null {
 		const win = this.getPetWindow();
-		if (!win || win.isDestroyed()) { this.stop(); return; }
+		if (!win || win.isDestroyed()) return null;
 		const [x, y] = win.getPosition();
 		const [w, h] = win.getSize();
-		const wa = screen.getDisplayMatching({ x, y, width: w, height: h }).workArea;
-		const step = (this.speed * this.tickMs) / 1000;
-		let nx = this.direction === "right" ? x + step : x - step;
+		return screen.getDisplayMatching({ x, y, width: w, height: h }).workArea;
+	}
 
-		if (nx >= wa.x + wa.width - w - this.edgeMargin || nx <= wa.x + this.edgeMargin) {
-			// 碰边 → 停止步行，进入 idle 停顿
-			win.setPosition(Math.round(this.direction === "right" ? wa.x + wa.width - w - this.edgeMargin : wa.x + this.edgeMargin), y);
-			if (this.tickTimer) { clearInterval(this.tickTimer); this.tickTimer = null; }
-			this.pushState("idle");
-			this.scheduleWalk();
-			return;
+	/** 把目标 x 硬钳制到 [leftEdge, rightEdge]，保证任何来源的坐标都不会越界 */
+	private clampX(x: number, wa: Rectangle): number {
+		const [w] = this.getPetWindow()?.getSize() ?? [0];
+		const leftEdge = wa.x + this.edgeMargin;
+		const rightEdge = wa.x + wa.width - w - this.edgeMargin;
+		if (rightEdge < leftEdge) return Math.round((leftEdge + rightEdge) / 2); // 屏幕过窄，居中
+		return Math.round(Math.min(rightEdge, Math.max(leftEdge, x)));
+	}
+
+	private tick() {
+		// 双保险：即便因时序问题 tick 仍被触发，拖拽中也绝不移动窗口
+		if (this.dragging) { this.stop(); return; }
+		const win = this.getPetWindow();
+		if (!win || win.isDestroyed()) { this.stop(); return; }
+		const wa = this.walkWorkArea;
+		if (!wa) { this.endWalk(); return; }
+
+		const now = Date.now();
+		const [x, y] = win.getPosition();
+		// 按真实时间增量算步长；delta 异常大（睡眠唤醒等）时钳制到单步上限，防止一帧飞出去
+		let delta = now - this.lastTickAt;
+		this.lastTickAt = now;
+		if (delta > 500 || delta < 0) delta = this.tickMs;
+		const step = (this.speed * delta) / 1000;
+
+		// 检测异常跳变：本 tick 之间窗口位置的变化远超我们应输出的步长，
+		// 说明被系统（Space 切换、显示器热插拔）或拖拽残留搬动过。
+		// 立刻重锚坐标系并结束巡游，避免在新位置上继续按旧方向走出诡异的位移。
+		if (this.lastTickX !== null) {
+			const drift = Math.abs(x - (this.lastTickX + (this.direction === "right" ? step : -step)));
+			if (drift > step * 3 + 8) {
+				// 外部搬动（拖拽/Space 切换/显示器热插拔）：归位 idle 不再排程，
+				// 避免在新位置上继续按旧方向走出诡位移、或重新起巡游造成闪现。
+				this.halt();
+				return;
+			}
 		}
-		win.setPosition(Math.round(nx), y);
+		this.lastTickX = x;
+
+		if (this.direction === "right") {
+			const rightEdge = wa.x + wa.width - win.getSize()[0] - this.edgeMargin;
+			const nx = this.clampX(x + step, wa);
+			win.setPosition(nx, y);
+			if (x + step >= rightEdge) { this.endWalk(); return; }
+		} else {
+			const leftEdge = wa.x + this.edgeMargin;
+			const nx = this.clampX(x - step, wa);
+			win.setPosition(nx, y);
+			if (x - step <= leftEdge) { this.endWalk(); return; }
+		}
 	}
 
 	private scheduleWalk() {
@@ -70,11 +161,12 @@ export class PetPatrol {
 
 	/** 从当前位置选路程远的方向 */
 	private pickDirection() {
+		const wa = this.resolveWorkArea();
+		if (!wa) return;
 		const win = this.getPetWindow();
 		if (!win || win.isDestroyed()) return;
-		const [x, y] = win.getPosition();
-		const [w, h] = win.getSize();
-		const wa = screen.getDisplayMatching({ x, y, width: w, height: h }).workArea;
+		const [x] = win.getPosition();
+		const [w] = win.getSize();
 		this.direction = wa.x + wa.width - w - x >= x - wa.x ? "right" : "left";
 	}
 

--- a/src/main/pet/PetStateBridge.ts
+++ b/src/main/pet/PetStateBridge.ts
@@ -68,7 +68,7 @@ export class PetStateBridge {
 
 	constructor(
 		private readonly getPetWindow: () => BrowserWindow | null,
-		private readonly patrol: { start: () => void; stop: () => void; active: boolean } | null = null,
+		private readonly patrol: { start: () => void; stop: () => void; active: boolean; setDragging: (d: boolean) => void } | null = null,
 		private readonly isPatrolEnabled: () => boolean = () => true,
 	) {}
 
@@ -118,6 +118,8 @@ export class PetStateBridge {
 		// ── hidden 过渡：先 waving 再 hidden ──
 		if (target === "hidden") {
 			if (prev?.mode === "waving") return;
+			// 所有 Agent 关闭 → 隐藏：立即停巡游，避免挥手/隐藏期间仍在走动
+			this.patrol?.stop();
 			if (prev && prev.mode !== "hidden") {
 				this.applyState({ ...state, mode: "waving" });
 				this.setTransition(1500, () => this.applyState({ ...state, mode: "hidden" }));
@@ -190,6 +192,33 @@ export class PetStateBridge {
 	private maybeStartPatrol() {
 		if (!this.patrol || !this.isPatrolEnabled()) return;
 		if (this.lastState?.mode === "idle") this.patrol.start();
+	}
+
+	/**
+	 * 拖拽起止：开始时立刻停巡游并置 dragging 标志（阻塞后续 start）；
+	 * 结束时清标志，若仍处于 idle（巡游允许）则从新位置重新起巡。
+	 * 标志位是关键——拖拽期间 Agent 状态更新会异步触发 maybeStartPatrol，
+	 * 没有标志位拦截就会在拖拽中重新起巡游，与手动移动争抢窗口位置。
+	 *
+	 * 额外：拖拽开始时若 pet 正在巡游奔跑（running-left/right，由 PetPatrol 直推），
+	 * 立刻切回 idle 待机精灵，避免拖拽过程中仍显示「卡住的奔跑帧」。
+	 */
+	onDragState(dragging: boolean) {
+		if (!this.patrol) return;
+		// 巡游奔跑态（running-left/right）由 PetPatrol 绕过 bridge 直推渲染端，
+		// bridge.lastState 仍停留在巡游启动前的 idle，无法据此判断。
+		// 因此用 patrol.active 判定：正在 tick（奔跑中）被抓取 → 归位 idle 待机。
+		const wasWalking = this.patrol.active;
+		this.patrol.setDragging(dragging);
+		if (dragging) {
+			if (wasWalking) {
+				const real = aggregate(this.currentTabs);
+				// 巡游态下业务侧必然是 idle（否则巡游不会启动），归位为 idle
+				this.applyState({ ...real, mode: "idle" });
+			}
+			return;
+		}
+		this.maybeStartPatrol();
 	}
 
 	// ── 工具 ──

--- a/src/main/pet/PetWindow.ts
+++ b/src/main/pet/PetWindow.ts
@@ -34,6 +34,9 @@ async function savePos(bounds: { x: number; y: number }) {
 
 export class PetWindow {
 	private win: BrowserWindow | null = null;
+	/** 位置持久化防抖：巡游每 50ms 移动一次，避免高频写盘拖慢主进程 */
+	private saveTimer: NodeJS.Timeout | null = null;
+	private pendingPos: { x: number; y: number } | null = null;
 
 	get window(): BrowserWindow | null { return this.win; }
 	get exists(): boolean { return !!this.win && !this.win.isDestroyed(); }
@@ -65,10 +68,17 @@ export class PetWindow {
 		});
 
 		this.win.setAlwaysOnTop(true, "floating");
+		// moved 高频触发（巡游每 50ms 一次、拖拽每次 pointermove 一次），
+		// 直接落盘会拖慢主进程、间接放大 tick 抖动。这里防抖 400ms 合并写盘。
 		this.win.on("moved", () => {
 			if (!this.exists) return;
 			const b = this.win!.getBounds();
-			void savePos({ x: b.x, y: b.y });
+			this.pendingPos = { x: b.x, y: b.y };
+			if (this.saveTimer) return;
+			this.saveTimer = setTimeout(() => {
+				this.saveTimer = null;
+				if (this.pendingPos) { const p = this.pendingPos; this.pendingPos = null; void savePos(p); }
+			}, 400);
 		});
 
 		if (!is.dev) {
@@ -85,6 +95,8 @@ export class PetWindow {
 	}
 
 	destroy() {
+		if (this.saveTimer) { clearTimeout(this.saveTimer); this.saveTimer = null; }
+		this.pendingPos = null;
 		if (this.win && !this.win.isDestroyed()) this.win.destroy();
 		this.win = null;
 	}

--- a/src/main/pet/index.ts
+++ b/src/main/pet/index.ts
@@ -42,11 +42,10 @@ export class PetSystem {
 		if (s.petEnabled) {
 			await this.petWindow.create(s.petScale ?? 1);
 			this.pushCaps();
-			// 延迟推送，让宠物先以 idle 亮相
-			setTimeout(() => {
-				const tabs = this.deps.agentManager.list();
-				if (tabs.some(t => t.status !== "closed")) this.bridge.pushNow(tabs);
-			}, 600);
+			// 延迟推送聚合态，让宠物窗先就绪：
+			// 有活跃 Agent → 出现（idle/running 等）；无活跃 Agent → hidden，保持不出现，
+			// 直到首个 Agent 开启后再出现。
+			setTimeout(() => this.bridge.pushNow(this.deps.agentManager.list()), 600);
 			await this.pushCurrentSprite();
 		}
 	}
@@ -113,6 +112,8 @@ export class PetSystem {
 		});
 
 		ipcMain.handle(C.petTease, () => this.bridge.tease());
+		// 拖拽起止：开始时停巡游，结束时若处于 idle 则恢复，避免松手后 tick 命中反向边界瞬移
+		ipcMain.handle(C.petDragState, (_e, dragging: boolean) => this.bridge.onDragState(!!dragging));
 	}
 
 	// ── 设置响应 ──

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -532,6 +532,9 @@ const api = {
 		/** 双击宠物触发逗弄：主进程注入一次 jumping 后恢复真实聚合态 */
 		tease: () =>
 			ipcRenderer.invoke(ipcChannels.petTease) as Promise<void>,
+		/** 通知主进程拖拽起止：开始时暂停巡游，结束时若处于 idle 则恢复巡游 */
+		setDragging: (dragging: boolean) =>
+			ipcRenderer.invoke(ipcChannels.petDragState, dragging) as Promise<void>,
 	},
 	terminal: {
 		list: (agentId: string) =>

--- a/src/renderer/src/pet/PetInteraction.tsx
+++ b/src/renderer/src/pet/PetInteraction.tsx
@@ -23,6 +23,8 @@ export function PetInteraction({ state, onDragStateChange }: Props) {
 		screen.current = { x: e.screenX, y: e.screenY };
 		moved.current = 0;
 		onDragStateChange?.(true);
+		// 通知主进程暂停巡游：松手后遗留的 tick 可能命中行进反向边界，导致瞬移
+		void window.piDesktop.pet.setDragging(true);
 		(e.target as HTMLElement).setPointerCapture?.(e.pointerId);
 	};
 
@@ -35,6 +37,8 @@ export function PetInteraction({ state, onDragStateChange }: Props) {
 	const up = (e: React.PointerEvent) => {
 		offset.current = null; screen.current = null;
 		onDragStateChange?.(false);
+		// 拖拽结束：通知主进程，若当前仍为 idle 且巡游开启，则从新位置恢复巡游
+		void window.piDesktop.pet.setDragging(false);
 		(e.target as HTMLElement).releasePointerCapture?.(e.pointerId);
 
 		if (moved.current < CLICK) {

--- a/src/renderer/src/pet/main.tsx
+++ b/src/renderer/src/pet/main.tsx
@@ -8,7 +8,7 @@ import { loadSpriteSheet, type SpriteSheet } from "./PetSpriteSheet";
 import "./pet.css";
 
 function PetApp() {
-	const [state, setState] = useState<PetAggregateState>({ mode: "idle", runningCount: 0, errorCount: 0, activeAgentId: null, timestamp: 0 });
+	const [state, setState] = useState<PetAggregateState>({ mode: "hidden", runningCount: 0, errorCount: 0, activeAgentId: null, timestamp: 0 });
 	const [sprite, setSprite] = useState<SpriteSheet | null>(null);
 	const [ready, setReady] = useState(false);
 	const [dragging, setDragging] = useState(false);
@@ -36,9 +36,16 @@ function PetApp() {
 
 	if (!ready) return <div style={{ width: "100%", height: "100%", background: "transparent" }} />;
 
+	// 拖拽期间本地权威化显示态为 idle：不依赖主进程 IPC 回推，避免巡游奔跑精灵在拖拽中卡帧。
+	// preview 仅在非拖拽时生效（用于设置页预览动画）。
+	const displayMode: PetAggregateState["mode"] = dragging
+		? "idle"
+		: (preview ? (preview as PetAggregateState["mode"]) : state.mode);
+	const displayState: PetAggregateState = { ...state, mode: displayMode };
+
 	return (
 		<div className={`pet-root${caps && !caps.transparent ? " pet-root--rounded" : ""}`}>
-			<PetOverlay sprite={sprite} manifest={null} state={preview ? { ...state, mode: preview as PetAggregateState["mode"] } : state} dragging={dragging} notification={notif} />
+			<PetOverlay sprite={sprite} manifest={null} state={displayState} dragging={dragging} notification={notif} />
 			<PetInteraction state={state} onDragStateChange={setDragging} />
 		</div>
 	);

--- a/src/renderer/src/previewApi.ts
+++ b/src/renderer/src/previewApi.ts
@@ -539,6 +539,7 @@ export function createPreviewApi(): PiDesktopApi {
 			onCaps: noop,
 			testNotify: async () => undefined,
 			tease: async () => undefined,
+			setDragging: async () => undefined,
 			getCurrent: async () => ({ id: "clawd", displayName: "Clawd", source: "builtin", spritesheetUrl: "" }),
 		},
 		terminal: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -179,6 +179,8 @@ export const ipcChannels = {
 	petCaps: "pet:caps",
 	/** 宠物窗 → 主进程：双击宠物触发逗弄（注入一次 jumping 后恢复真实态） */
 	petTease: "pet:tease",
+	/** 宠物窗 → 主进程：拖拽起止通知（开始时暂停巡游，避免松手后 tick 命中反向边界瞬移） */
+	petDragState: "pet:drag-state",
 
 	// ── 调试工具 ──
 	/** 设置面板 → 主进程：发送测试通知（调试弹窗样式） */


### PR DESCRIPTION
修复两个桌面宠物的行为问题：                                                              
                                                                                             
   1. **巡游中拖拽**：拖住 pet 后精灵立刻切回 idle（渲染端本地覆盖，不依赖 IPC               
      回推），巡游自动停止不再争抢窗口位置，拖到边框也不闪现。                               
   2. **首次出现时机**：pet 初始态改为 hidden，开第一个 agent 才出现；                       
      关闭所有 agent 后挥手 1.5s 消失。隐藏期间巡游已停止。