### PR TITLE
fix: 主进程流式消息节流合并 + 工具结果截断，修复大会话渲染进程白屏

### DIFF
--- a/src/main/pi/AgentManager.ts
+++ b/src/main/pi/AgentManager.ts
@@ -37,6 +37,17 @@ export class AgentManager {
 	private readonly creatingSessionAgents = new Map<string, Promise<AgentTab>>();
 	/** 记录每个 agent 当前执行的工具名称，无工具时为 null */
 	private readonly toolExecutingByAgent = new Map<string, string | null>();
+	/** 流式消息 emit 节流状态。 */
+	private readonly messageFlushTimers = new Map<string, NodeJS.Timeout>();
+	private readonly pendingMessageAgents = new Set<string>();
+	/** 流式 emit 合并窗口（毫秒）。50ms 兼顾流畅度与传输量，肉眼几乎无延迟。 */
+	private static readonly MESSAGE_FLUSH_INTERVAL_MS = 50;
+	/**
+	 * 工具结果文本截断阈值（字符数）。工具结果（如 bash 输出、文件读取）可能达数十 KB，
+	 * 若完整存入 ChatMessage.meta 并随流式 emit 反复全量传输，会显著放大 IPC payload
+	 * 并推高渲染进程内存，是大会话白屏的重要诱因。超长结果保留首尾各一部分，中间省略。
+	 */
+	private static readonly MAX_TOOL_RESULT_CHARS = 8000;
 	/** 本地事件监听器（用于 FeishuBridge 等主进程内部订阅） */
 	private readonly localEventListeners = new Set<(agentId: string, event: unknown) => void>();
 	/** 状态变更监听器（用于 PetStateBridge 等主进程内部模块订阅 AgentTab[] 聚合状态） */
@@ -77,7 +88,7 @@ export class AgentManager {
 		const messages = this.convertAgentMessages(agentId, trimmed);
 		this.messages.set(agentId, messages);
 		this.refreshAutoTitle(agentId);
-		this.emit(ipcChannels.agentsMessage, { agentId, messages });
+		this.scheduleMessageEmit(agentId, true);
 		return messages;
 	}
 
@@ -1115,6 +1126,8 @@ export class AgentManager {
 		) {
 			this.upsertAssistantMessage(agentId, typed.message);
 			this.activeAssistantMessageIds.delete(agentId);
+			// message_end 是本轮回答的最终状态，立即 flush 确保完整消息及时可见
+			this.flushMessageEmit(agentId);
 		}
 
 		if (typed.type === "tool_execution_start") {
@@ -1140,6 +1153,8 @@ export class AgentManager {
 				typed,
 				typed.isError ? "error" : "done",
 			);
+			// 工具执行结束是终态，立即 flush 把最终结果推给渲染进程，避免节流窗口内用户看不到完成状态。
+			this.flushMessageEmit(agentId);
 			// 清除工具执行状态
 			this.toolExecutingByAgent.set(agentId, null);
 			// 工具调用完成后保持 agent 状态为 running，等待后续的 agent_end 事件
@@ -1215,11 +1230,15 @@ export class AgentManager {
 				this.streamingThinking.set(agentId, finalThinking);
 			}
 			this.upsertAssistantMessage(agentId, partialMessage);
+			// thinking_end 是阶段性终态，立即 flush 让思考块完整落盘显示。
+			this.flushMessageEmit(agentId);
 			return;
 		}
 
 		if (eventType === "message_end" || eventType === "done" || eventType === "error") {
 			this.upsertAssistantMessage(agentId, partialMessage);
+			// message_end/done/error 是本轮回答的最终状态，立即 flush 确保完整消息及时可见。
+			this.flushMessageEmit(agentId);
 			this.activeAssistantMessageIds.delete(agentId);
 		}
 	}
@@ -1277,7 +1296,9 @@ export class AgentManager {
 		}
 
 		this.messages.set(agentId, list);
-		this.emit(ipcChannels.agentsMessage, { agentId, messages: list });
+		// upsertAssistantMessage 被 text_delta/thinking_delta 高频调用，走节流合并；
+		// message_end/thinking_end 等终态调用方会在调用后显式 flush，保证最终状态及时。
+		this.scheduleMessageEmit(agentId);
 	}
 
 	private upsertToolMessage(
@@ -1341,10 +1362,7 @@ export class AgentManager {
 								: message,
 						);
 						this.messages.set(agentId, nextList);
-						this.emit(ipcChannels.agentsMessage, {
-							agentId,
-							messages: nextList,
-						});
+						this.scheduleMessageEmit(agentId, true);
 					})
 					.catch(() => {
 						// 文件不存在或被删除，跳过
@@ -1381,8 +1399,8 @@ export class AgentManager {
 			status,
 			toolName,
 			toolCallId,
-			args,
-			result,
+			args: this.truncateForDetail(this.safeJson(args)),
+			result: this.truncateForDetail(this.extractToolResultText(result) || this.safeJson(result)),
 			isError,
 			detailText,
 			originalContent,
@@ -1404,7 +1422,7 @@ export class AgentManager {
 		}
 
 		this.messages.set(agentId, list);
-		this.emit(ipcChannels.agentsMessage, { agentId, messages: list });
+		this.scheduleMessageEmit(agentId);
 	}
 
 	private addMessage(
@@ -1426,7 +1444,7 @@ export class AgentManager {
 		});
 		this.messages.set(agentId, list);
 		if (role === "user" || role === "assistant") this.refreshAutoTitle(agentId);
-		this.emit(ipcChannels.agentsMessage, { agentId, messages: list });
+		this.scheduleMessageEmit(agentId, true);
 	}
 
 	private refreshAutoTitle(agentId: string) {
@@ -1519,7 +1537,7 @@ export class AgentManager {
 		message.meta = { status, attempt, maxAttempts, delayMs, errorMessage: reason };
 
 		this.messages.set(agentId, list);
-		this.emit(ipcChannels.agentsMessage, { agentId, messages: list });
+		this.scheduleMessageEmit(agentId, true);
 	}
 
 	private convertAgentMessages(
@@ -1601,8 +1619,8 @@ export class AgentManager {
 								status: isError ? "error" : "done",
 								toolName,
 								toolCallId,
-								args: historicalCall?.args,
-								result,
+								args: this.truncateForDetail(this.safeJson(historicalCall?.args)),
+								result: this.truncateForDetail(this.extractToolResultText(result) || this.safeJson(result)),
 								isError,
 								detailText,
 								...(originalContent && /write|edit|create|patch/i.test(toolName)
@@ -1680,14 +1698,18 @@ export class AgentManager {
 		isError: boolean,
 	) {
 		const details = this.extractToolDetails(result);
+		// args/结果/details 都先序列化再截断，避免单条工具详情撑大 ChatMessage.meta。
+		const argsText = args ? this.truncateForDetail(this.safeJson(args)) : "";
+		const resultText = result
+			? this.truncateForDetail(this.extractToolResultText(result) || this.safeJson(result))
+			: "";
+		const detailsText = details ? this.truncateForDetail(this.safeJson(details)) : "";
 		const sections = [
 			`工具：${toolName ?? "tool"}`,
 			`状态：${isError ? "失败" : "完成"}`,
-			args ? `参数：\n${this.safeJson(args)}` : "",
-			result
-				? `结果：\n${this.extractToolResultText(result) || this.safeJson(result)}`
-				: "",
-			details ? `详情：\n${this.safeJson(details)}` : "",
+			args ? `参数：\n${argsText}` : "",
+			result ? `结果：\n${resultText}` : "",
+			details ? `详情：\n${detailsText}` : "",
 		].filter(Boolean);
 		return sections.join("\n\n");
 	}
@@ -1696,6 +1718,22 @@ export class AgentManager {
 		if (!result || typeof result !== "object") return undefined;
 		return (result as any).details;
 	}
+
+	/** 对超长工具文本做首尾截断，保留头部和尾部以兼顾开头信息和错误堆栈。 */
+	private truncateForDetail(text: unknown): string {
+		// safeJson/extractToolResultText 在某些输入下可能返回 undefined（如 JSON.stringify(undefined)），
+		// 必须在此归一化为字符串，否则后续 .length 访问会抛 TypeError 导致主进程未捕获异常弹窗。
+		const str = typeof text === "string" ? text : text == null ? "" : String(text);
+		if (str.length <= AgentManager.MAX_TOOL_RESULT_CHARS) return str;
+		const keep = Math.floor(AgentManager.MAX_TOOL_RESULT_CHARS / 2);
+		const omitted = str.length - keep * 2;
+		return (
+			`${str.slice(0, keep)}\n` +
+			`…（已省略中间 ${omitted} 字符，完整内容共 ${str.length} 字符）\n` +
+			str.slice(-keep)
+		);
+	}
+
 
 
 	private extractToolResultText(result: unknown) {
@@ -1801,6 +1839,36 @@ export class AgentManager {
 	/** 清理 ANSI 转义码，模型思考内容中常见终端颜色序列 */
 	private stripAnsi(text: string): string {
 		return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+	}
+
+	/**
+	 * 安排一次消息 emit。流式高频事件走节流合并（同一 agent 50ms 内多次调用只 emit 一次最新数组）；
+	 * immediate=true 时跳过节流立即 flush，用于 message_end/tool_execution_end 等终态事件，确保最终状态不丢。
+	 */
+	private scheduleMessageEmit(agentId: string, immediate = false) {
+		if (immediate) {
+			this.flushMessageEmit(agentId);
+			return;
+		}
+		if (this.pendingMessageAgents.has(agentId)) return;
+		this.pendingMessageAgents.add(agentId);
+		const timer = setTimeout(() => this.flushMessageEmit(agentId), AgentManager.MESSAGE_FLUSH_INTERVAL_MS);
+		// 节流定时器不应阻止进程退出
+		timer.unref?.();
+		this.messageFlushTimers.set(agentId, timer);
+	}
+
+	private flushMessageEmit(agentId: string) {
+		const timer = this.messageFlushTimers.get(agentId);
+		if (timer) {
+			clearTimeout(timer);
+			this.messageFlushTimers.delete(agentId);
+		}
+		this.pendingMessageAgents.delete(agentId);
+		this.emit(ipcChannels.agentsMessage, {
+			agentId,
+			messages: this.messages.get(agentId) ?? [],
+		});
 	}
 
 	private emitThinking(agentId: string, thinking: string) {


### PR DESCRIPTION
## Summary

有时候的某些session行进过程中会卡卡的然后程序白屏。搞了这个节流后就不白屏了。消融实验验证过有效。

## Checklist

- [√ ] I ran `npm run typecheck`.
- [√ ] I ran `npm run build`.
- [x] I added comments for non-obvious logic or state transitions.
- [ ] I updated documentation if behavior changed.

## Screenshots

no ui changed
