### PR TITLE
fix: 终端乱码 - 注入 UTF-8 locale 到 node-pty 环境变量

### DIFF
--- a/src/main/terminal/TerminalSessionManager.ts
+++ b/src/main/terminal/TerminalSessionManager.ts
@@ -210,12 +210,18 @@ export class TerminalSessionManager {
 		let lastError: unknown;
 		for (const candidate of candidates) {
 			try {
+				// macOS GUI 应用（Electron）不继承登录 shell 的环境变量，
+				// LANG/LC_CTYPE 可能为空或 C，导致 shell 内 UTF-8 输出乱码。
+				// 显式注入 UTF-8 locale，让 shell 知道应以 UTF-8 解释字节流。
+				const env = { ...process.env };
+				if (!env.LANG) env.LANG = "en_US.UTF-8";
+				if (!env.LC_ALL) env.LC_ALL = "en_US.UTF-8";
 				const terminal = pty.spawn(candidate.command, candidate.args, {
 					name: "xterm-256color",
 					cols: 80,
 					rows: 24,
 					cwd,
-					env: process.env,
+					env,
 				});
 				return { shell: candidate.shell, pty: terminal };
 			} catch (error) {


### PR DESCRIPTION
终端在部分 macOS 环境下显示乱码，原因是 node-pty 创建子进程时未设置 UTF-8 环境变量。

修复：在 node-pty 的 spawn 选项中注入 LANG 和 LC_ALL 环境变量，强制 UTF-8 编码。