### PR TITLE
fix: hide internal pi-subagent sessions from history

### DIFF
--- a/src/main/sessions/SessionScanner.ts
+++ b/src/main/sessions/SessionScanner.ts
@@ -165,6 +165,17 @@ export class SessionScanner {
     return files;
   }
 
+  private parentSessionFileForSubagentPath(filePath: string) {
+    // pi-subagents persists resumable runs as <parent-stem>/<run-id>/run-N/session.jsonl.
+    // Match the full layout so unrelated nested Pi sessions remain visible.
+    if (basename(filePath).toLowerCase() !== "session.jsonl") return undefined;
+    const runDirectory = dirname(filePath);
+    if (!/^run-\d+$/i.test(basename(runDirectory))) return undefined;
+    const runRoot = dirname(runDirectory);
+    const parentSessionRoot = dirname(runRoot);
+    return join(dirname(parentSessionRoot), `${basename(parentSessionRoot)}.jsonl`);
+  }
+
   private async readSummary(filePath: string): Promise<SessionSummary | null> {
     const [raw, info] = await Promise.all([readFile(filePath, "utf8"), stat(filePath)]);
     const lines = raw.split(/\r?\n/).filter(Boolean);
@@ -184,9 +195,22 @@ export class SessionScanner {
     let codexAgentRole: string | undefined;
     let codexAgentNickname: string | undefined;
     let codexSourcePath: string | undefined;
+    let latestSessionInfoName: string | undefined;
+    let forkParentSession: string | undefined;
+    let hasSubagentChildMarker = false;
 
     for (const line of lines) {
       const entry = JSON.parse(line) as any;
+      if (entry.type === "session_info") {
+        // Forked sessions may contain an older copied name; only the latest marker is authoritative.
+        latestSessionInfoName = this.optionalString(entry.name ?? entry.data?.name);
+      }
+      if (entry.type === "session") {
+        forkParentSession ||= this.optionalString(entry.parentSession ?? entry.header?.parentSession);
+      }
+      if (entry.type === "custom" && entry.customType === "pi-subagents.child-session") {
+        hasSubagentChildMarker = true;
+      }
       // 扫描前几行的非消息条目，检测导入来源标记
       if (source === "pi") {
         if (entry.type === "codex_import") {
@@ -214,6 +238,18 @@ export class SessionScanner {
         if (text && message.role === "assistant" && !firstAssistantText) firstAssistantText = text;
       }
     }
+
+    // New pi-subagents runs carry an explicit marker. The path/fork checks retain compatibility
+    // with older runs, but require the generated child name so ordinary nested sessions survive.
+    const hasLegacySubagentName = latestSessionInfoName?.startsWith("subagent-") === true;
+    const hasLegacyOwnedPath = Boolean(this.parentSessionFileForSubagentPath(filePath));
+    if (
+      source === "pi"
+      && (
+        hasSubagentChildMarker
+        || (hasLegacySubagentName && (hasLegacyOwnedPath || Boolean(forkParentSession)))
+      )
+    ) return null;
 
     if (source === "codex" && codexSourcePath && !codexParentThreadId) {
       const fallbackInfo = this.readCodexThreadInfo(codexSourcePath);

--- a/tests/sessionScannerSubagents.test.mjs
+++ b/tests/sessionScannerSubagents.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+import ts from "typescript";
+import vm from "node:vm";
+
+const require = createRequire(import.meta.url);
+
+function loadCodexMetaModule() {
+	const source = readFileSync("src/shared/codexSessionMeta.ts", "utf8");
+	const { outputText } = ts.transpileModule(source, {
+		compilerOptions: {
+			module: ts.ModuleKind.CommonJS,
+			target: ts.ScriptTarget.ES2022,
+		},
+	});
+	const sandbox = { exports: {} };
+	vm.runInNewContext(outputText, sandbox, { filename: "codexSessionMeta.ts" });
+	return sandbox.exports;
+}
+
+function loadSessionScanner(homePath) {
+	const source = readFileSync("src/main/sessions/SessionScanner.ts", "utf8");
+	const { outputText } = ts.transpileModule(source, {
+		compilerOptions: {
+			module: ts.ModuleKind.CommonJS,
+			target: ts.ScriptTarget.ES2022,
+		},
+	});
+	const codexMeta = loadCodexMetaModule();
+	const sandbox = {
+		exports: {},
+		require: (id) => {
+			if (id === "electron") return { app: { getPath: () => homePath } };
+			if (id === "../../shared/codexSessionMeta") return codexMeta;
+			return require(id);
+		},
+	};
+	vm.runInNewContext(outputText, sandbox, { filename: "SessionScanner.ts" });
+	return sandbox.exports;
+}
+
+function writeSession(filePath, entries) {
+	mkdirSync(dirname(filePath), { recursive: true });
+	writeFileSync(filePath, `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`, "utf8");
+}
+
+function session(name, cwd) {
+	return [
+		{ type: "session_info", name, cwd },
+		{ type: "message", message: { role: "user", content: "hello" } },
+	];
+}
+
+test("hides persisted pi-subagents runs without deleting them or unrelated nested sessions", async () => {
+	const home = mkdtempSync(join(tmpdir(), "pideck-subagent-scanner-"));
+	try {
+		const projectPath = "C:\\repo\\project";
+		const piDir = join(home, ".pi", "agent", "sessions", "--C--repo-project--");
+		const parentFile = join(piDir, "parent.jsonl");
+		const workerFile = join(piDir, "parent", "run-abc", "run-0", "session.jsonl");
+		const reviewerFile = join(piDir, "parent", "run-abc", "run-1", "session.jsonl");
+		const nestedUserFile = join(piDir, "manual", "notes.jsonl");
+		const lookalikeFile = join(piDir, "manual", "arbitrary", "run-0", "session.jsonl");
+
+		writeSession(parentFile, session("Parent", projectPath));
+		writeSession(join(piDir, "ordinary.jsonl"), session("Ordinary", projectPath));
+		writeSession(join(piDir, "subagent-looking-name.jsonl"), session("subagent-worker-manual-0", projectPath));
+		// This sibling makes lookalikeFile collide with the legacy ownership layout.
+		writeSession(join(piDir, "manual.jsonl"), session("Manual owner", projectPath));
+		writeSession(nestedUserFile, session("Nested user session", projectPath));
+		writeSession(lookalikeFile, session("Path lookalike", projectPath));
+		// Explicit metadata covers new runs even when intercom naming is unavailable.
+		writeSession(workerFile, [
+			...session("Worker without generated name", projectPath),
+			{ type: "custom", customType: "pi-subagents.child-session", data: { schemaVersion: 1 } },
+		]);
+		// Generated naming plus the standard path retains compatibility with old runs.
+		writeSession(reviewerFile, session("subagent-reviewer-run-abc-1", projectPath));
+
+		const { SessionScanner } = loadSessionScanner(home);
+		const summaries = await new SessionScanner().list(projectPath);
+		const visiblePaths = new Set(summaries.map(summary => summary.filePath));
+
+		assert.equal(visiblePaths.has(parentFile), true);
+		assert.equal(visiblePaths.has(nestedUserFile), true);
+		assert.equal(visiblePaths.has(lookalikeFile), true);
+		assert.equal(visiblePaths.has(workerFile), false);
+		assert.equal(visiblePaths.has(reviewerFile), false);
+		assert.equal(summaries.some(summary => summary.name === "subagent-worker-manual-0"), true);
+		assert.equal(existsSync(workerFile), true);
+		assert.equal(existsSync(reviewerFile), true);
+	} finally {
+		rmSync(home, { recursive: true, force: true });
+	}
+});
+
+test("handles orphan, fork, rename and imported-session compatibility without false positives", async () => {
+	const home = mkdtempSync(join(tmpdir(), "pideck-orphan-subagent-scanner-"));
+	try {
+		const projectPath = "/repo/project";
+		const piDir = join(home, ".pi", "agent", "sessions", "--repo-project--");
+		const orphanFile = join(piDir, "deleted-parent", "orphan-run", "run-0", "session.jsonl");
+		const renamedChildFile = join(piDir, "renamed-parent", "manual-run", "run-0", "session.jsonl");
+		const legacyForkFile = join(piDir, "legacy-fork.jsonl");
+		const manualForkFile = join(piDir, "manual-fork.jsonl");
+		const markedCustomFile = join(piDir, "custom-child-location.jsonl");
+		const importedFile = join(piDir, "codex-parent", "import-run", "run-0", "session.jsonl");
+
+		writeSession(orphanFile, session("subagent-worker-orphan-run-0", projectPath));
+		// PiDeck rename prepends sessionName; the original generated session_info remains authoritative.
+		writeSession(renamedChildFile, [
+			{ sessionName: "Renamed child", cwd: projectPath },
+			...session("subagent-worker-old-run-0", projectPath),
+		]);
+		writeSession(legacyForkFile, [
+			{ type: "session", id: "legacy-child", parentSession: "parent-session.jsonl", cwd: projectPath },
+			...session("subagent-worker-fork-run-0", projectPath),
+		]);
+		writeSession(manualForkFile, [
+			{ type: "session", id: "manual-child", parentSession: "parent-session.jsonl", cwd: projectPath },
+			{ type: "session_info", name: "subagent-worker-copied-parent-0", cwd: projectPath },
+			...session("Manual user fork", projectPath),
+		]);
+		writeSession(markedCustomFile, [
+			...session("Custom-location child", projectPath),
+			{ type: "custom", customType: "pi-subagents.child-session", data: { schemaVersion: 1 } },
+		]);
+		writeSession(join(piDir, "codex-parent.jsonl"), session("Codex owner", projectPath));
+		writeSession(importedFile, [
+			...session("subagent-reviewer-import-run-0", projectPath),
+			{ type: "custom", customType: "pi-subagents.child-session", data: { schemaVersion: 1 } },
+			{ type: "codex_import", version: 1, codexSessionId: "codex-child", sourcePath: join(home, "missing.jsonl") },
+		]);
+
+		const { SessionScanner } = loadSessionScanner(home);
+		const summaries = await new SessionScanner().list(projectPath);
+		const visiblePaths = new Set(summaries.map(summary => summary.filePath));
+
+		assert.equal(visiblePaths.has(orphanFile), false);
+		assert.equal(visiblePaths.has(renamedChildFile), false);
+		assert.equal(visiblePaths.has(legacyForkFile), false);
+		assert.equal(visiblePaths.has(manualForkFile), true);
+		assert.equal(visiblePaths.has(markedCustomFile), false);
+		assert.equal(visiblePaths.has(importedFile), true);
+	} finally {
+		rmSync(home, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## What changed

- Skip native Pi sessions carrying the explicit `pi-subagents.child-session` marker.
- Keep compatibility with existing pi-subagents runs by recognizing their generated `subagent-*` name together with either the persisted `run-N/session.jsonl` layout or a fork parent header.
- Preserve ordinary nested Pi sessions and imported Codex subagent sessions.
- Add regression coverage for legacy runs, orphaned runs, renamed sessions, forked sessions, explicit markers, path lookalikes, and Codex imports.

## Why

PiDeck recursively scans every JSONL file under `~/.pi/agent/sessions`. pi-subagents stores internal worker and reviewer session files below the parent session directory (and may create forked JSONL sessions), so those implementation-detail sessions were indexed as normal history and flooded the project sidebar.

The scanner now filters those entries while building summaries. It does not delete, move, or rewrite any session file, so pi-subagents resume and diagnostic behavior is unchanged.

## Validation

- `node --test tests/sessionScannerSubagents.test.mjs tests/sessionScannerCodexFallback.test.mjs tests/agentListDisplay.test.mjs` — 4 passed
- `npm run typecheck` — passed
- Rebased onto the current `main` before validation
