### PR TITLE
feat(agent): 同步 Pi session_info_changed 到侧边栏标题

### DIFF
--- a/src/main/pi/AgentManager.ts
+++ b/src/main/pi/AgentManager.ts
@@ -2016,6 +2016,20 @@ export class AgentManager {
 		const typed = event as Record<string, any>;
 		const runtime = this.agents.get(agentId);
 
+		// 扩展/RPC 调用 setSessionName 后 Pi 会发 session_info_changed；
+		// 同步到 tab.title，使侧边栏与手动 rename 路径看到同一标题。
+		// 忽略空 name，避免把已有标题抹掉。
+		if (typed.type === "session_info_changed" && runtime) {
+			const name =
+				typeof typed.name === "string"
+					? typed.name.replace(/\s+/g, " ").trim()
+					: "";
+			if (name && name !== runtime.tab.title) {
+				runtime.tab.title = name;
+				this.emitState();
+			}
+		}
+
 		if (typed.type === "agent_start" && runtime) {
 			runtime.tab.status = "running";
 			this.activeAssistantMessageIds.delete(agentId);


### PR DESCRIPTION
## Summary

Pi 在 `setSessionName`（含扩展调用、RPC 重命名）后会发出 `session_info_changed` 事件，但 PiDeck 原先忽略该事件，侧边栏 Agent 标题不会实时更新。

本 PR 在 `AgentManager.handlePiEvent` 中桥接该事件：收到非空 `name` 时更新 `tab.title` 并 `emitState()`，使扩展自动命名与手动重命名一样即时反映到 UI。

## 行为边界

- 只处理非空 `name`，避免空事件抹掉现有标题
- 与当前标题相同时不重复 `emitState`
- 不影响 PiDeck 本地 `refreshAutoTitle`（仍只改内存、不写 Pi session）
- 用户手动 rename 路径保持原逻辑；事件回调幂等

## Checklist

- [x] I ran `npm run typecheck`.
- [x] I ran `npm run build`.
- [x] I added comments for non-obvious logic or state transitions.
- [x] I updated documentation if behavior changed.

## Screenshots

无 UI 结构变更；侧边栏标题在扩展改名后实时刷新。

<img width="1275" height="602" alt="图片" src="https://github.com/user-attachments/assets/849fa8e8-a0fa-4374-9e32-e87e61c201f0" />
