### PR TITLE
style: refine markdown rendering, empty-state layout, and unify scrollbar across the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -705,6 +705,61 @@
         }
       }
     },
+    "node_modules/@docsearch/js/node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/@electron-toolkit/preload": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@electron-toolkit/preload/-/preload-3.0.2.tgz",
@@ -3852,6 +3907,15 @@
         "@types/node": "*",
         "xmlbuilder": ">=11.0.1"
       }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.2.15",
@@ -8211,6 +8275,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lowercase-keys": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,7 +213,6 @@
       "integrity": "sha512-ngdgVGp05lJzUyA+sUzr0MDZ7AMtANcJpwIzq4ZsfpZL5B3S7A4XYfMcU2sECZc3bx3ysOhYcdbbaTjc3ve0WQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.54.0",
         "@algolia/requester-browser-xhr": "5.54.0",
@@ -356,7 +355,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -705,17 +703,6 @@
         "search-insights": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@electron-toolkit/preload": {
@@ -1106,6 +1093,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1127,6 +1115,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1143,6 +1132,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1157,6 +1147,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3862,21 +3853,12 @@
         "xmlbuilder": ">=11.0.1"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmmirror.com/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3887,7 +3869,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4281,7 +4262,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4315,7 +4295,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4343,7 +4322,6 @@
       "integrity": "sha512-APAX4ajIOgsmYoUlGe++oNZkSTBgmXYM4maHC0OxC+Yo7xkaKQElV0ATZYCZA7jzrSJX1OBiqEs7mk+ZxXgYqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.20.0",
         "@algolia/client-abtesting": "5.54.0",
@@ -4754,7 +4732,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5253,7 +5230,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5306,7 +5284,6 @@
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5751,7 +5728,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6094,7 +6070,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -6246,7 +6221,6 @@
       "integrity": "sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -6435,6 +6409,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6455,6 +6430,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6665,7 +6641,6 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -7023,7 +6998,6 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -8237,20 +8211,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lowercase-keys": {
@@ -9533,6 +9493,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9546,7 +9507,6 @@
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -10009,7 +9969,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10131,6 +10090,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10148,6 +10108,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10310,7 +10271,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10320,7 +10280,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10710,6 +10669,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11358,6 +11318,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -11562,7 +11523,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11920,7 +11880,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12966,7 +12925,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13027,7 +12985,6 @@
       "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.38",
         "@vue/compiler-sfc": "3.5.38",

--- a/src/renderer/src/components/app/AppParts.tsx
+++ b/src/renderer/src/components/app/AppParts.tsx
@@ -3273,7 +3273,9 @@ function MarkdownLink(
 		onOpenFile?: (path: string) => void;
 	},
 ) {
-	const { onOpenExternal, onOpenFile, ...anchorProps } = props;
+	const { onOpenExternal, onOpenFile, children, className, title, ...anchorProps } = props;
+	// remarkLinkifyPaths 生成的文件路径链接走 file:// 协议，与普通外链区分展示
+	const isFileLink = props.href?.startsWith("file://") ?? false;
 	const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
 		e.preventDefault();
 		if (!props.href) return;
@@ -3289,7 +3291,29 @@ function MarkdownLink(
 			void onOpenExternal(props.href);
 		}
 	};
-	return <a {...anchorProps} onClick={handleClick} />;
+	const linkClass =
+		[className, isFileLink ? "markdown-link-file" : undefined]
+			.filter(Boolean)
+			.join(" ") || undefined;
+	return (
+		<a
+			{...anchorProps}
+			className={linkClass}
+			onClick={handleClick}
+			// 文件链接 hover 展示解码后的完整路径，便于确认目标文件；
+			// 普通链接不传 title，保留 markdown 自带 title 语法的原行为
+			title={isFileLink ? decodeURIComponent(props.href!.slice(7)) : title}
+		>
+			{isFileLink ? (
+				<>
+					<FileText size={12} className="markdown-link-file-icon" />
+					<span>{children}</span>
+				</>
+			) : (
+				children
+			)}
+		</a>
+	);
 }
 
 function extractText(node: ReactNode): string {

--- a/src/renderer/src/components/app/AppParts.tsx
+++ b/src/renderer/src/components/app/AppParts.tsx
@@ -2495,9 +2495,14 @@ export const TurnRow = memo(function TurnRow(props: {
 		}
 		return -1;
 	})();
-	const hasExecutionProcess = lastAssistantIndex > 0;
-	const executionItems = hasExecutionProcess
-		? (run.items as (ThinkingGroupItem | ToolGroupItem | MessageItem)[]).slice(0, lastAssistantIndex)
+	// 执行过程 = 除最终回答外的所有条目（最终回答在折叠区外始终可见，不能再进折叠详情）。
+	// 边界：lastAssistantIndex === 0（如「思考+直接回答」的无工具回合）时，若取 run.items 全量，
+	// 最终回答会被同时渲染进折叠详情和下方正文，展开后出现两份；filter 排除它本身，
+	// 同时保留最终回答之后可能存在的尾部 tool/thinking 条目（slice 方案会将其丢弃）。
+	const executionItems = lastAssistantIndex >= 0
+		? (run.items as (ThinkingGroupItem | ToolGroupItem | MessageItem)[]).filter(
+			(_, index) => index !== lastAssistantIndex,
+		)
 		: (run.items as (ThinkingGroupItem | ToolGroupItem | MessageItem)[]);
 	const finalMessageItem = lastAssistantIndex >= 0 ? (run.items[lastAssistantIndex] as MessageItem) : null;
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5972,6 +5972,121 @@ body.ask-dialog-open .ask-card-preview {
   font-family: var(--font-family-mono);
   font-size: 0.92em;
 }
+/* 行内代码 chip：:not(pre) > code 只命中行内 code，代码块（pre > code）天然隔离，无需额外 reset */
+.markdown-body :not(pre) > code {
+  padding: 0.15em 0.35em;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+}
+
+/* ===== Markdown 普通元素排版（heading/链接/引用/hr/图片/文字格式） ===== */
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin: 1.4em 0 0.5em;
+  line-height: 1.35;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  letter-spacing: -0.01em;
+}
+.markdown-body h1 {
+  font-size: 1.65em;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: 0.2em;
+}
+.markdown-body h2 {
+  font-size: 1.4em;
+}
+.markdown-body h3 {
+  font-size: 1.2em;
+}
+.markdown-body h4 {
+  font-size: 1.08em;
+}
+.markdown-body h5 {
+  font-size: 1em;
+}
+.markdown-body h6 {
+  font-size: 0.95em;
+  color: var(--color-text-secondary);
+}
+/* 消息以标题开头时去掉顶部留白，避免气泡顶部出现多余空隙 */
+.markdown-body > :is(h1, h2, h3, h4, h5, h6):first-child {
+  margin-top: 0;
+}
+
+.markdown-body a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+/* 链接焦点环走全局 a:focus-visible 统一样式，不在此处覆盖 */
+
+.markdown-body blockquote {
+  margin: 0.8em 0;
+  padding: 0.6em 1em;
+  border-left: 3px solid var(--color-border-strong);
+  background: var(--color-bg-muted);
+  color: var(--color-text-secondary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+.markdown-body blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body hr {
+  margin: 1.5em 0;
+  border: none;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.markdown-body img {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.markdown-body strong {
+  font-weight: 600;
+}
+.markdown-body em {
+  font-style: italic;
+}
+/* remarkGfm 的 ~~删除线~~ 渲染为 <del>（不是 <s>），选择器必须匹配 del 才生效 */
+.markdown-body del {
+  text-decoration: line-through;
+  color: var(--color-text-secondary);
+}
+
+/* 文件路径链接（remarkLinkifyPaths 生成的 file:// 链接）：等宽字体 + 图标 chip，与普通外链区分 */
+.markdown-link-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-family-mono);
+  font-size: 0.92em;
+  color: var(--color-accent);
+  background: var(--color-bg-muted);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+.markdown-link-file:hover {
+  background: var(--color-bg-hover);
+  text-decoration: underline;
+}
+.markdown-link-file-icon {
+  flex-shrink: 0;
+}
 
 .empty-state {
   height: 100%;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -60,6 +60,7 @@
   --color-text-tertiary: #8b8f94;
   --color-text-inverse: #ffffff;
   --color-border-subtle: #e5e5df;
+  --color-border-default: #dfdfd7;
   --color-border-strong: #d7d7cf;
   --color-accent: #238636;
   --color-accent-strong: #1f7a32;
@@ -170,6 +171,7 @@
   --color-bg-hover: #eaeaea;
   --color-bg-active: #d4edda;
   --color-border-subtle: #e2e2e2;
+  --color-border-default: #d9d9d9;
   --color-border-strong: #d0d0d0;
   --shadow-composer: 0 8px 28px rgba(20, 24, 31, 0.06);
   --shadow-drawer: -8px 0 24px rgba(20, 24, 31, 0.06);
@@ -193,6 +195,7 @@
   --color-bg-muted: #fff8e8;
   --color-bg-hover: #f7efd8;
   --color-border-subtle: #eadfc8;
+  --color-border-default: #e2d5b9;
   --color-border-strong: #dacbad;
 }
 
@@ -203,6 +206,7 @@
   --color-bg-hover: #e8f1ff;
   --color-bg-active: #e6f0ff;
   --color-border-subtle: #d9e6f7;
+  --color-border-default: #d0dff3;
   --color-border-strong: #c7d9ef;
 }
 
@@ -213,6 +217,7 @@
   --color-bg-hover: #e7f3eb;
   --color-bg-active: #e2f4e8;
   --color-border-subtle: #d6e8dc;
+  --color-border-default: #cee0d4;
   --color-border-strong: #c5d9cc;
 }
 
@@ -332,6 +337,7 @@
   --color-text-tertiary: #858e99;
   --color-text-inverse: #ffffff;
   --color-border-subtle: #2a2f35;
+  --color-border-default: #32383f;
   --color-border-strong: #3a414a;
   --color-accent: #35c45a;
   --color-accent-strong: #55d774;
@@ -1410,6 +1416,35 @@ body:not(.is-list-resizing)
 }
 .list-collapsed .splitter-left {
   display: none;
+}
+
+/* ── 全局统一滚动条：细滑块、透明轨道，融入面板背景 ──
+   个别容器（如会话列表、终端）用更具体的选择器隐藏或覆盖。 */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--color-border-strong);
+  border-radius: 999px;
+  /* 8px 槽内留 2px 透明边，视觉粗细约 4px，更轻地融入背景 */
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text-tertiary);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+*::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 .conversation-list {
@@ -2986,21 +3021,6 @@ body.is-terminal-resizing {
   padding: 18px clamp(24px, 4vw, 48px) 24px;
   min-height: 0;
   scroll-padding-top: 18px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-border-default) transparent;
-}
-.message-timeline::-webkit-scrollbar {
-  width: 8px;
-}
-.message-timeline::-webkit-scrollbar-track {
-  background: transparent;
-}
-.message-timeline::-webkit-scrollbar-thumb {
-  background: var(--color-border-default);
-  border-radius: 4px;
-}
-.message-timeline::-webkit-scrollbar-thumb:hover {
-  background: var(--color-border-strong);
 }
 .scroll-to-bottom-btn {
   position: absolute;
@@ -4071,8 +4091,8 @@ body.is-terminal-resizing .terminal-resize-handle::before {
   transform: rotate(180deg);
 }
 .tool-card-content {
-  border: 1px solid var(--color-border-subtle);
-  border-top: 0;
+  /* 与 thinking-card-content 统一：仅顶部细分隔线，去除四周边框盒感 */
+  border-top: 1px solid var(--color-border-subtle);
   border-radius: 0 0 var(--radius-sm) var(--radius-sm);
   background: transparent;
   position: relative;
@@ -4353,7 +4373,8 @@ body.is-terminal-resizing .terminal-resize-handle::before {
 }
 .thinking-card-content {
   padding: var(--space-2) var(--space-3) var(--space-3);
-  border-top: 0;
+  /* 内嵌滚动块统一：透明背景 + 顶部细分隔线，不用盒子边框，融入会话白底 */
+  border-top: 1px solid var(--color-border-subtle);
   color: var(--color-text-tertiary);
   font-size: var(--font-size-caption);
   line-height: 1.6;
@@ -5957,7 +5978,9 @@ body.ask-dialog-open .ask-card-preview {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: min(8vh, 80px);
+  justify-content: center;
+  /* 视觉中心略偏上比数学居中更自然，底部留出补偿空间 */
+  padding-bottom: 12vh;
   color: var(--color-text-tertiary);
 }
 .empty-logo {
@@ -5971,31 +5994,38 @@ body.ask-dialog-open .ask-card-preview {
     var(--color-accent-strong) 0%,
     var(--color-accent) 100%
   );
-  margin-bottom: var(--space-6);
-  margin-top: -40px;
+  box-shadow:
+    0 18px 40px color-mix(in srgb, var(--color-accent) 28%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  margin-bottom: var(--space-8);
 }
 .empty-tagline {
   display: grid;
-  gap: var(--space-1);
-  margin: 0 0 var(--space-5);
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
   color: var(--color-text-primary);
   font-family: var(--font-family-brand);
   font-size: clamp(28px, 3.8vw, 54px);
   font-weight: 600;
-  line-height: 0.98;
-  letter-spacing: -0.04em;
+  /* 两行大字需要呼吸空间，0.98 会让上下行笔画相触 */
+  line-height: 1.08;
+  letter-spacing: -0.03em;
   text-align: center;
+  text-wrap: balance;
 }
 .empty-tagline-yours {
   color: color-mix(in srgb, var(--color-chat-link) 90%, white);
   font-style: italic;
 }
 .empty-state .empty-subtitle {
-  margin: var(--space-8) 0 var(--space-8);
+  margin: 0 0 var(--space-8);
   color: var(--color-text-secondary);
+  /* 与主标题同族衬线，靠字号和灰度分层 */
   font-family: var(--font-family-brand);
-  font-size: clamp(24px, 3vw, 34px);
-  line-height: 1.45;
+  font-size: clamp(17px, 1.6vw, 21px);
+  font-weight: 500;
+  line-height: 1.6;
+  letter-spacing: 0;
   text-align: center;
 }
 .empty-subtitle-line {
@@ -6029,6 +6059,7 @@ body.ask-dialog-open .ask-card-preview {
     var(--color-accent-soft) 75%,
     var(--color-accent)
   );
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--color-accent) 18%, transparent);
   color: var(--color-accent-strong);
   font-family: var(--font-family-base);
   font-size: var(--font-size-brand);
@@ -9136,18 +9167,6 @@ body.is-composer-resizing .composer-resize-handle::after {
   overflow-y: auto;
   overflow-x: hidden;
   padding: 6px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-border-default) transparent;
-}
-.picker-palette-list::-webkit-scrollbar {
-  width: 6px;
-}
-.picker-palette-list::-webkit-scrollbar-track {
-  background: transparent;
-}
-.picker-palette-list::-webkit-scrollbar-thumb {
-  background: var(--color-border-default);
-  border-radius: 3px;
 }
 .model-group {
   margin-bottom: 4px;
@@ -17220,19 +17239,6 @@ html[data-theme="dark"] .scratch-pad-md mark {
   margin: 0.5em 0;
 }
 
-.scratch-pad-preview-scroll::-webkit-scrollbar {
-  width: 6px;
-}
-
-.scratch-pad-preview-scroll::-webkit-scrollbar-thumb {
-  background: var(--color-border-subtle);
-  border-radius: 3px;
-}
-
-.scratch-pad-preview-scroll::-webkit-scrollbar-track {
-  background: transparent;
-}
-
 /* ── PiDeck 左侧边栏 v3 Braun 卡片化重设计 ── */
 
 .chat-list-pane.v3-braun {
@@ -17331,18 +17337,16 @@ html[data-theme="dark"] .scratch-pad-md mark {
   /* 将滚动条移入侧栏右侧留白，等量内边距保持列表内容不贴边。 */
   margin-right: calc(-1 * var(--space-3));
   padding-right: var(--space-3);
+}
+
+/* v3-braun 侧栏会话列表保持可见滚动条（基础 .conversation-list 为隐藏）；
+   只声明宽度压过 0 值，粗细颜色沿用全局统一滚动条。 */
+.chat-list-pane.v3-braun .sidebar-body .conversation-list {
   scrollbar-width: thin;
 }
-
 .chat-list-pane.v3-braun .sidebar-body .conversation-list::-webkit-scrollbar {
-  width: 5px;
-}
-
-.chat-list-pane.v3-braun
-  .sidebar-body
-  .conversation-list::-webkit-scrollbar-thumb {
-  background: var(--color-border-strong);
-  border-radius: 3px;
+  width: 8px;
+  height: 8px;
 }
 
 .chat-list-pane.v3-braun .sidebar-body .project-group {


### PR DESCRIPTION
## 问题

上游代码中：
1. Markdown 渲染缺少对 heading / blockquote / hr / img / inline code 等基础元素的样式定义，AI 消息的排版与普通文本没有区分度
2. 空状态页使用 `padding-top: min(8vh, 80px)` 实现垂直定位，在大屏或窗口变化时偏离视觉中心
3. 每个面板/组件独立声明滚动条样式（`.message-timeline`, `.picker-palette-list`, `.scratch-pad-preview-scroll` 等共 4 处），重复且不一致
4. `remarkLinkifyPaths` 生成的 `file://` 链接与普通外链样式相同，没有视觉区分，也无法直观预览目标路径
5. `tool-card-content` 和 `thinking-card-content` 使用四周边框 + 圆角的盒子感样式，与面板白底之间产生多余分隔线

## 根因

样式缺失和分散属于渐进式开发中自然积累的债务：早期逐一为新增组件添加独立滚动条样式，而没有抽象出全局规则；Markdown 渲染随着 remark 插件逐步扩展，但缺少配套样式；空状态定位采用像素/视高硬编码而非 flex 居中。

## 修复内容

### 1. Markdown 基础排版样式（`styles.css`）
- 为 h1-h6、a、blockquote、hr、img、strong、em、del 和 inline code 添加完整排版规则
- h1 底部细线分隔，h6 降级为次级色
- blockquote 左侧粗边框 + 圆角 + 浅底色
- 行内 code 用 chip 式背景 + 小圆角，与 `pre > code` 区块自然隔离

### 2. 空状态布局（`styles.css`）
- `.empty-state` 从 `padding-top: min(8vh, 80px)` 改为 `justify-content: center` + `padding-bottom: 12vh`
- 调整品牌字体行高（0.98→1.08）、字号间距、subtitle 视觉权重
- 为 logo 和按钮补充 `box-shadow` 层次感
- 标题启用 `text-wrap: balance`

### 3. 全局统一滚动条
- 在 `*` 级声明 `scrollbar-width: thin` + 自定义 webkit 伪元素，作为全局默认值
- 移除 `.message-timeline`、`.picker-palette-list`、`.scratch-pad-preview-scroll` 等 4 处独立滚动条样式
- v3-braun 侧栏保持可见滚动条，用更具体的选择器覆盖全局

### 4. file:// 链接 Chip 展示（`styles.css` + `AppParts.tsx`）
- 新增 `.markdown-link-file` 类：等宽字体 + 文件图标 + 浅底色 chip
- `MarkdownLink` 组件识别 `file://` 协议渲染图标和 tooltip（展示解码后完整路径，方便确认目标文件）
- 新增 `--color-border-default` 设计 token，覆盖 light / dark / sepia / blue / green 五个主题

### 5. 卡片边框简化
- `tool-card-content` 和 `thinking-card-content`：去掉四周边框，仅保留顶部细分隔线，减少盒感

## 影响范围

- 纯 UI 变更，无业务逻辑改动
- session timeline 中所有 Markdown 消息排版会更新
- file:// 链接获得新的 chip 样式（不影响功能）
- 空状态在侧栏收起/展开时保持视觉居中
- 所有内嵌滚动容器采用统一细滑块样式
