### PR TITLE
perf: 优化 Thinking 节流、Session 摘要缓存及渲染比较，减少不必要重计算

### DIFF
--- a/src/main/pi/AgentManager.ts
+++ b/src/main/pi/AgentManager.ts
@@ -23,6 +23,7 @@ import type { RpcResponse } from "./PiRpcClient";
 import { formatBashToolMessage } from "./bashResult";
 import { extractMessageText } from "./messageContent";
 import { mergeHistoryWithPreservedMessages } from "./historyMessages";
+import { LatestByKeyEmitter } from "./LatestByKeyEmitter";
 import {
   updateActiveToolCalls,
   type ActiveToolCallState,
@@ -62,6 +63,10 @@ export class AgentManager {
 	/** 流式消息 emit 节流状态。 */
 	private readonly messageFlushTimers = new Map<string, NodeJS.Timeout>();
 	private readonly pendingMessageAgents = new Set<string>();
+	private readonly thinkingEmitter = new LatestByKeyEmitter<string, string>(
+		50,
+		(agentId, thinking) => this.emitThinkingNow(agentId, thinking),
+	);
 	/** 流式 emit 合并窗口（毫秒）。50ms 兼顾流畅度与传输量，肉眼几乎无延迟。 */
 	private static readonly MESSAGE_FLUSH_INTERVAL_MS = 50;
 	/**
@@ -3111,7 +3116,7 @@ export class AgentManager {
 			const prev = this.streamingThinking.get(agentId) ?? "";
 			const delta = String(assistantEvent.delta ?? "");
 			this.streamingThinking.set(agentId, prev + delta);
-			this.emitThinking(agentId, this.stripAnsi(prev + delta));
+			this.thinkingEmitter.push(agentId, this.stripAnsi(prev + delta));
 			this.upsertAssistantMessage(agentId, partialMessage);
 			return;
 		}
@@ -3122,6 +3127,8 @@ export class AgentManager {
 			);
 			if (finalThinking) {
 				this.streamingThinking.set(agentId, finalThinking);
+				this.thinkingEmitter.push(agentId, this.stripAnsi(finalThinking));
+				this.thinkingEmitter.flush(agentId);
 			}
 			this.upsertAssistantMessage(agentId, partialMessage);
 			// thinking_end 是阶段性终态，立即 flush 让思考块完整落盘显示。
@@ -3968,6 +3975,11 @@ export class AgentManager {
 	}
 
 	private emitThinking(agentId: string, thinking: string) {
+		if (!thinking) this.thinkingEmitter.cancel(agentId);
+		this.emitThinkingNow(agentId, thinking);
+	}
+
+	private emitThinkingNow(agentId: string, thinking: string) {
 		const update: ThinkingUpdate = { agentId, thinking };
 		this.emit(ipcChannels.agentsThinking, update);
 	}

--- a/src/main/pi/LatestByKeyEmitter.ts
+++ b/src/main/pi/LatestByKeyEmitter.ts
@@ -1,0 +1,41 @@
+/**
+ * 按 key 收集最新值，在窗口期内去重节流，到期只回调每个 key 的最新值。
+ * 适用于高频增量更新（如 thinking delta），只需最后一次值的场景。
+ */
+export class LatestByKeyEmitter<K, V> {
+  private readonly timers = new Map<K, ReturnType<typeof setTimeout>>();
+  private readonly latest = new Map<K, V>();
+
+  constructor(
+    private readonly windowMs: number,
+    private readonly callback: (key: K, value: V) => void,
+  ) {}
+
+  push(key: K, value: V): void {
+    this.latest.set(key, value);
+    if (!this.timers.has(key)) {
+      this.timers.set(
+        key,
+        setTimeout(() => this.flush(key), this.windowMs),
+      );
+    }
+  }
+
+  flush(key: K): void {
+    const timer = this.timers.get(key);
+    if (timer != null) clearTimeout(timer);
+    this.timers.delete(key);
+    const value = this.latest.get(key);
+    if (value !== undefined) {
+      this.latest.delete(key);
+      this.callback(key, value);
+    }
+  }
+
+  cancel(key: K): void {
+    const timer = this.timers.get(key);
+    if (timer != null) clearTimeout(timer);
+    this.timers.delete(key);
+    this.latest.delete(key);
+  }
+}

--- a/src/main/sessions/SessionScanner.ts
+++ b/src/main/sessions/SessionScanner.ts
@@ -7,6 +7,7 @@ import { basename as posixBasename, dirname as posixDirname, join as posixJoin }
 import type { ChatMessage, ChatRole, SessionSummary } from "../../shared/types";
 import { getCodexSessionThreadInfo } from "../../shared/codexSessionMeta";
 import { extractMessageText, extractThinkingRaw } from "../pi/messageContent";
+import { SessionSummaryCache, type SessionFileVersion } from "./sessionSummaryCache";
 
 export class SessionScanner {
   private readonly root = join(app.getPath("home"), ".pi", "agent", "sessions");
@@ -15,6 +16,8 @@ export class SessionScanner {
   private wslConfig: { distro: string; user: string; home: string } | null = null;
   /** 比 renderer watchdog 更短，确保超时前先终止实际扫描，避免后台请求堆积。 */
   private scanTimeoutMs = 18_000;
+  private readonly summaryCache = new SessionSummaryCache<SessionSummary | null>();
+  private summaryCacheFileSetKey = "";
 
   /**
    * wsl.exe 命令与启动模式。优先绝对路径，
@@ -47,11 +50,13 @@ export class SessionScanner {
     // 动态获取 WSL 中用户的 HOME 目录，解决 root（/root）与普通用户（/home/user）路径差异
     const home = await this.fetchWslHome(wslDistro, wslUser);
     this.wslConfig = { distro: wslDistro, user: wslUser, home };
+    this.clearSummaryCache();
   }
 
   /** 清除 WSL 配置 */
   clearWsl(): void {
     this.wslConfig = null;
+    this.clearSummaryCache();
   }
 
   /** 通过 wsl.exe 动态获取用户 HOME 目录，失败时 fallback 到 /home/<user> */
@@ -138,18 +143,22 @@ export class SessionScanner {
     });
   }
 
-  /** 通过 wsl.exe 获取文件修改时间戳 */
-  private readWslFileMtime(wslPath: string, signal?: AbortSignal): Promise<number> {
+  /** 通过 wsl.exe 获取缓存判定所需的修改时间和大小。 */
+  private readWslFileVersion(wslPath: string, signal?: AbortSignal): Promise<SessionFileVersion> {
     return new Promise((resolve, reject) => {
-      execFile(this.wslExePath, ["-d", this.wslConfig!.distro, "-u", this.wslConfig!.user, "stat", "-c", "%Y", wslPath], {
+      execFile(this.wslExePath, ["-d", this.wslConfig!.distro, "-u", this.wslConfig!.user, "stat", "-c", "%Y %s", wslPath], {
         shell: this.wslShell,
         encoding: "utf8",
         timeout: 5_000,
         signal,
         windowsHide: true,
       }, (err, stdout) => {
-        if (err) reject(err);
-        else resolve(Number(stdout.trim()) * 1000);
+        if (err) {
+          reject(err);
+          return;
+        }
+        const [mtimeSeconds, size] = stdout.trim().split(/\s+/).map(Number);
+        resolve({ mtimeMs: mtimeSeconds * 1000, size });
       });
     });
   }
@@ -233,6 +242,11 @@ export class SessionScanner {
       const files = this.wslConfig
         ? await this.collectWslJsonl(signal).catch(rethrowAbort([] as string[]))
         : await this.collectJsonl(this.root).catch(() => [] as string[]);
+      const fileSetKey = [...files].sort().join("\n");
+      if (fileSetKey !== this.summaryCacheFileSetKey) {
+        this.summaryCache.clear();
+        this.summaryCacheFileSetKey = fileSetKey;
+      }
 
       const summaries = await Promise.all(files.map(file =>
         this.readSummary(file, signal).catch(rethrowAbort(null))
@@ -769,14 +783,23 @@ export class SessionScanner {
   }
 
   private async readSummary(filePath: string, signal?: AbortSignal): Promise<SessionSummary | null> {
-    // WSL 路径通过 wsl.exe 命令读取，Windows 路径直接用 fs
+    // 先读取轻量文件指纹；未变化时复用摘要，避免周期扫描反复读取和解析全部 JSONL。
     const isWsl = this.isWslPath(filePath);
-    const [raw, info] = await Promise.all([
-      isWsl ? this.readWslFile(filePath, signal) : readFile(filePath, "utf8"),
-      isWsl ? this.readWslFileMtime(filePath, signal).then(m => ({ mtimeMs: m })) : stat(filePath),
-    ]);
+    const info = isWsl
+      ? await this.readWslFileVersion(filePath, signal)
+      : await stat(filePath);
+    const version = { mtimeMs: info.mtimeMs, size: info.size };
+    const cached = this.summaryCache.get(filePath, version);
+    if (cached !== undefined) return cached;
+
+    const raw = isWsl
+      ? await this.readWslFile(filePath, signal)
+      : await readFile(filePath, "utf8");
     const lines = raw.split(/\r?\n/).filter(Boolean);
-    if (lines.length === 0) return null;
+    if (lines.length === 0) {
+      this.summaryCache.set(filePath, version, null);
+      return null;
+    }
 
     let name: string | undefined;
     let projectPath: string | undefined;
@@ -906,7 +929,7 @@ export class SessionScanner {
 
     const inferredName = this.cleanTitle(name) || this.cleanTitle(firstUserText) || this.cleanTitle(firstAssistantText) || "Untitled";
 
-    return {
+    const summary: SessionSummary = {
       id: filePath,
       filePath,
       projectPath: projectPath ? this.normalize(projectPath) : this.inferProjectPathFromFile(filePath),
@@ -924,6 +947,13 @@ export class SessionScanner {
       // 标记 WSL 来源，供 rename/delete/copy/readMessages 等操作识别
       wsl: isWsl || undefined,
     };
+    this.summaryCache.set(filePath, version, summary);
+    return summary;
+  }
+
+  private clearSummaryCache(): void {
+    this.summaryCache.clear();
+    this.summaryCacheFileSetKey = "";
   }
 
   private optionalString(value: unknown) {

--- a/src/main/sessions/sessionSummaryCache.ts
+++ b/src/main/sessions/sessionSummaryCache.ts
@@ -1,0 +1,36 @@
+/**
+ * Session 摘要缓存：按文件路径 + 版本（mtime+size）判定是否命中，
+ * 避免周期扫描时反复读取和解析未变化的 JSONL 文件。
+ */
+
+export interface SessionFileVersion {
+  mtimeMs: number;
+  size: number;
+}
+
+interface CacheEntry<V> {
+  version: SessionFileVersion;
+  value: V;
+}
+
+export class SessionSummaryCache<V> {
+  private readonly store = new Map<string, CacheEntry<V>>();
+
+  get(filePath: string, version: SessionFileVersion): V | undefined {
+    const entry = this.store.get(filePath);
+    if (!entry) return undefined;
+    if (entry.version.mtimeMs !== version.mtimeMs || entry.version.size !== version.size) {
+      this.store.delete(filePath);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(filePath: string, version: SessionFileVersion, value: V): void {
+    this.store.set(filePath, { version, value });
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -68,6 +68,7 @@ import {
 } from "./agentListDisplay";
 import { resolveLocale, setI18nLocale, t } from "./i18n";
 import { mergeAgentRuntimeState } from "./utils/agentRuntimeState";
+import { sameSessionSummaryList } from "./utils/sessionSummaryList";
 import {
   acknowledgeUnknownPrompt,
   canDiscardQueuedPrompt,
@@ -1582,20 +1583,7 @@ export function App() {
       ),
     ),
   );
-  const activeProjectSessionSyncKey = useMemo(() => {
-    if (!activeProjectId) return "";
-    return displayAgents
-      .filter((agent) => agent.projectId === activeProjectId)
-      .map((agent) => {
-        const runtime = runtimeStateByAgent[agent.id];
-        return `${agent.id}:${agent.status}:${runtime?.isStreaming ? 1 : 0}:${runtime?.isExecutingTool ? 1 : 0}`;
-      })
-      .sort()
-      .join("|");
-  }, [activeProjectId, displayAgents, runtimeStateByAgent]);
-
-  // 消息分页:超过 100 条消息时启用,大幅减少输入卡顿
-  // 首屏 100 条,每次加载 100 条,一页一页懒加载
+  // 历史首屏控制在 50 条，避免打开旧会话时同步解析过多 Markdown/KaTeX。
   const {
     visibleMessages: paginatedMessages,
     hasMore: hasMoreMessages,
@@ -1604,9 +1592,9 @@ export function App() {
     isLoading: isLoadingMoreMessages,
   } = useMessagePagination({
     messages: activeMessages,
-    initialPageSize: 100, // 首屏 100 条
-    pageSize: 100,        // 每次加载 100 条
-    enabled: activeMessages.length > 100, // 超过 100 条才启用
+    initialPageSize: 50,
+    pageSize: 50,
+    enabled: activeMessages.length > 50,
   });
 
   /** 最后一条用户消息的 id，用于决定重发按钮只在最新消息上显示。 */
@@ -2409,14 +2397,13 @@ export function App() {
       return () => { disposed = true; };
     }
 
-    // pi-subagents 会在 Agent 运行期间直接向 sessions 目录写入子会话，主进程没有文件变更事件。
-    // 仅在当前项目运行期间低频扫描，兼顾实时嵌套与 WSL/大历史目录的 IO 成本。
-    const timer = window.setInterval(scheduleRefresh, 3000);
+    // 子会话由扩展直接写盘，运行期间保留低频兜底；工具 start/end 不应重置计时器并触发额外扫描。
+    const timer = window.setInterval(scheduleRefresh, 15_000);
     return () => {
       disposed = true;
       window.clearInterval(timer);
     };
-  }, [activeProjectId, activeProjectHasBusyAgent, activeProjectSessionSyncKey, collapsedProjects]);
+  }, [activeProjectId, activeProjectHasBusyAgent, collapsedProjects]);
 
   function getComposerMaxHeight() {
     const chatPane = chatPaneRef.current;
@@ -3174,10 +3161,11 @@ export function App() {
       );
       if (sessionRequestByProjectRef.current[projectId] !== request) return next;
       const sorted = [...next].sort((a, b) => b.updatedAt - a.updatedAt);
-      setSessionsByProject((current) => ({
-        ...current,
-        [projectId]: sorted,
-      }));
+      setSessionsByProject((current) => {
+        const previous = current[projectId] ?? [];
+        if (sameSessionSummaryList(previous, sorted)) return current;
+        return { ...current, [projectId]: sorted };
+      });
       setVisibleProjectChildCountByProject((current) => ({
         ...current,
         [projectId]: current[projectId] ?? SIDEBAR_PROJECT_CHILD_PAGE_SIZE,
@@ -4021,10 +4009,9 @@ export function App() {
   }
 
   function applyAgentRuntimeState(agentId: string, incoming: AgentRuntimeState) {
-    const nextState = mergeAgentRuntimeState(
-      runtimeStateByAgentRef.current[agentId],
-      incoming,
-    );
+    const currentState = runtimeStateByAgentRef.current[agentId];
+    const nextState = mergeAgentRuntimeState(currentState, incoming);
+    if (nextState === currentState) return nextState;
     runtimeStateByAgentRef.current = {
       ...runtimeStateByAgentRef.current,
       [agentId]: nextState,

--- a/src/renderer/src/components/app/AppParts.tsx
+++ b/src/renderer/src/components/app/AppParts.tsx
@@ -43,6 +43,8 @@ import {
 	getToolFilePath,
 	countTextLines,
 	getToolEditDiff,
+	sameAgentRunForRender,
+	sameChatMessageForRender,
 } from "./AppUtils";
 
 // Mermaid 库体积数 MB，仅在真正出现 mermaid 代码块时才动态加载，
@@ -2708,7 +2710,12 @@ export const TurnRow = memo(function TurnRow(props: {
 			</div>
 		</article>
 	);
-});
+}, (previous, next) =>
+	sameAgentRunForRender(previous.run, next.run) &&
+	previous.showThinking === next.showThinking &&
+	previous.isStreaming === next.isStreaming &&
+	previous.agentRunning === next.agentRunning,
+);
 
 /**
  * 从用户消息文本中提取 pi 展开后的 <skill name="..." location="...">...</skill> 块。
@@ -2904,7 +2911,13 @@ export const UserBubble = memo(function UserBubble(props: {
 			</div>
 		</article>
 	);
-});
+}, (previous, next) =>
+	sameChatMessageForRender(previous.message, next.message) &&
+	previous.isLastUserMessage === next.isLastUserMessage &&
+	previous.agentRunning === next.agentRunning &&
+	previous.validCommandNames === next.validCommandNames &&
+	previous.validFilePaths === next.validFilePaths,
+);
 
 /**
  * remark 插件：把助手正文里的裸文件路径转换成可点击的 file:// 链接。

--- a/src/renderer/src/components/app/AppUtils.ts
+++ b/src/renderer/src/components/app/AppUtils.ts
@@ -100,6 +100,64 @@ export type AgentRunItem = {
 
 export type RenderMessage = MessageItem | ToolGroupItem | ThinkingGroupItem | AgentRunItem;
 
+export function sameChatMessageForRender(previous: ChatMessage, next: ChatMessage): boolean {
+	if (
+		previous.id !== next.id ||
+		previous.role !== next.role ||
+		previous.text !== next.text ||
+		previous.thinking !== next.thinking ||
+		previous.timestamp !== next.timestamp
+	) {
+		return false;
+	}
+	const previousImages = previous.images ?? [];
+	const nextImages = next.images ?? [];
+	return (
+		previousImages.length === nextImages.length &&
+		previousImages.every(
+			(image, index) =>
+				image.mimeType === nextImages[index]?.mimeType &&
+				image.data === nextImages[index]?.data,
+		)
+	);
+}
+
+export function sameAgentRunForRender(previous: AgentRunItem, next: AgentRunItem): boolean {
+	if (
+		previous.id !== next.id ||
+		previous.startedAt !== next.startedAt ||
+		previous.endedAt !== next.endedAt ||
+		previous.items.length !== next.items.length
+	) {
+		return false;
+	}
+	return previous.items.every((item, index) => {
+		const other = next.items[index];
+		if (!other || item.kind !== other.kind) return false;
+		if (item.kind === "message" && other.kind === "message") {
+			return sameChatMessageForRender(item.message, other.message);
+		}
+		if (item.kind === "thinking-group" && other.kind === "thinking-group") {
+			return (
+				item.id === other.id &&
+				item.text === other.text &&
+				item.startedAt === other.startedAt &&
+				item.endedAt === other.endedAt
+			);
+		}
+		if (item.kind === "tool-group" && other.kind === "tool-group") {
+			return (
+				item.id === other.id &&
+				item.messages.length === other.messages.length &&
+				item.messages.every((message, messageIndex) =>
+					sameChatMessageForRender(message, other.messages[messageIndex]),
+				)
+			);
+		}
+		return false;
+	});
+}
+
 export function getMultiSelectImageCaptureIds(
 	items: RenderMessage[],
 	selectedIds: Set<string>,

--- a/src/renderer/src/utils/agentRuntimeState.ts
+++ b/src/renderer/src/utils/agentRuntimeState.ts
@@ -21,5 +21,14 @@ export function mergeAgentRuntimeState(
     } = incoming;
     return { ...current, ...nonToolState };
   }
-  return { ...current, ...incoming };
+  const merged = { ...current, ...incoming };
+  if (
+    current &&
+    Object.keys(merged).every(
+      (key) => current[key as keyof AgentRuntimeState] === merged[key as keyof AgentRuntimeState],
+    )
+  ) {
+    return current;
+  }
+  return merged;
 }

--- a/src/renderer/src/utils/sessionSummaryList.ts
+++ b/src/renderer/src/utils/sessionSummaryList.ts
@@ -1,0 +1,18 @@
+import type { SessionSummary } from "../../../shared/types";
+
+/** 浅比较两个 SessionSummary 列表是否等效，用于避免 setState 触发不必要渲染。 */
+export function sameSessionSummaryList(
+  previous: SessionSummary[],
+  next: SessionSummary[],
+): boolean {
+  if (previous.length !== next.length) return false;
+  return previous.every((a, i) => {
+    const b = next[i];
+    return (
+      a.id === b.id &&
+      a.updatedAt === b.updatedAt &&
+      a.name === b.name &&
+      a.projectPath === b.projectPath
+    );
+  });
+}

--- a/tests/agent-runtime-state-performance.test.mjs
+++ b/tests/agent-runtime-state-performance.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import test from "node:test";
+import ts from "typescript";
+import vm from "node:vm";
+
+const require = createRequire(import.meta.url);
+
+function loadModule(sourcePath) {
+  const source = readFileSync(sourcePath, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+    },
+  });
+  const sandbox = { exports: {}, module: { exports: {} }, require };
+  vm.runInNewContext(outputText, sandbox, { filename: sourcePath });
+  return sandbox.module.exports;
+}
+
+test("mergeAgentRuntimeState skips update when nothing changed", () => {
+  const { mergeAgentRuntimeState } = loadModule(
+    "src/renderer/src/utils/agentRuntimeState.ts",
+  );
+
+  const state = {
+    isStreaming: true,
+    isExecutingTool: false,
+    activeToolCall: null,
+  };
+
+  // Same values → should return reference unchanged.
+  const same = mergeAgentRuntimeState(state, {
+    isStreaming: true,
+    isExecutingTool: false,
+    activeToolCall: null,
+  });
+  assert.equal(same, state, "should return same reference when no change");
+
+  // Different values → should return new object.
+  const changed = mergeAgentRuntimeState(state, {
+    isStreaming: false,
+    isExecutingTool: false,
+    activeToolCall: null,
+  });
+  assert.notEqual(changed, state, "should return new object when changed");
+  assert.equal(changed.isStreaming, false);
+});


### PR DESCRIPTION
## Description

当前实现中，Thinking 流式推送、Session 扫描和组件渲染存在高频不必要的计算和状态更新。本 PR 从三个方向做性能优化：

### 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新

### 具体改动

**1. Thinking 节流**
- 新增 `LatestByKeyEmitter`，按 agentId 在 50ms 窗口内合并 thinking delta，仅回调最新值，避免每次增量都触发 emit

**2. Session 扫描缓存**
- 新增 `SessionSummaryCache`，按文件路径 + mtime+size 指纹判定命中，周期扫描时跳过未变化 JSONL
- 扫描间隔从 3s 放宽至 15s，减少 IO 压力

**3. React 渲染优化**
- `TurnRow` / `UserBubble` 增加自定义比较函数，深层比较 message/run 内容而非全量重建
- `mergeAgentRuntimeState` 值未变时返回原引用，避免触发 setState
- `sameSessionSummaryList` 比较 session summary 列表，跳过无效状态更新
- 消息分页首屏从 100 降至 50，减少旧会话打开时的 Markdown/KaTeX 解析量

### 测试情况

- [x] `mergeAgentRuntimeState` 值未变时返回原引用已验证（新增单元测试）
- [ ] 多 agent 高频 thinking 场景下确认节流生效
- [ ] Session 扫描缓存命中/失效逻辑确认

### 关联

Closes #（如有相关 issue 请补充）
