### PR TITLE
fix: resolve CI failures after syncing dev to main

### DIFF
--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -24,7 +24,7 @@ features:
   - title: Git 集成
     details: 实时分支显示和切换，文件树展示 Git 状态，VS Code 风格三面板（变更/历史/比较），AI 提交摘要生成，branch graph 可视化，cherry-pick/revert/reset/drop 操作，worktree 工作区支持。
   - title: 对话 & 引用
-    details: & 会话引用快捷输入，跨会话上下文注入。消息队列在 Agent 忙碌时排队发送。会话大纲面板快速跳转。
+    details: "& 会话引用快捷输入，跨会话上下文注入。消息队列在 Agent 忙碌时排队发送。会话大纲面板快速跳转。"
   - title: 文件编辑器
     details: 多 Tab 文件编辑器，弹框/侧栏双模式，Diff 差异对比，Markdown 预览，Monaco 编辑器支持。
   - title: 内置工具

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1530,12 +1530,6 @@ export function App() {
     if (targetAgentId) setAttachedImagesForAgent(targetAgentId, value);
   }
 
-  function setAttachedImages(
-    value: ImageContent[] | ((current: ImageContent[]) => ImageContent[]),
-  ) {
-    const targetAgentId = activeAgentIdRef.current;
-    if (targetAgentId) setAttachedImagesForAgent(targetAgentId, value);
-  }
   const terminalDockState = activeAgentId
     ? terminalDockStateByAgent[activeAgentId]
     : undefined;


### PR DESCRIPTION
## 问题

- PR #76 合入后，main 上存在一个重复函数定义：`src/renderer/src/App.tsx` 中 `setAttachedImages` 被定义了两次
- `docs-site/index.md` 的 YAML frontmatter 中 `& 会话引用` 被 VitePress 解析为 YAML anchor，导致 docs build 失败

## 修复

- 删除 `App.tsx` 中重复的 `setAttachedImages` 实现
- 将 `docs-site/index.md` 中 details 字段的 `&` 转义为 YAML 字符串

## 验证

- npm run typecheck 通过
- npm run docs:build 通过