### PR TITLE
fix: 自定义域名下官网 base 改为根路径

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,10 @@ jobs:
   build:
     name: Build VitePress site
     runs-on: ubuntu-latest
+    # 自定义域名 pideck.caoayu.top 挂在站点根路径，不能再按 /PiDeck/ 子路径构建。
+    env:
+      VITEPRESS_BASE: /
+      DOCS_SITE_ORIGIN: https://pideck.caoayu.top
 
     steps:
       - name: Checkout repository
@@ -58,7 +62,8 @@ jobs:
 
       - name: Generate sitemap
         run: |
-          BASE="${VITEPRESS_BASE:-/PiDeck/}"
+          BASE="${VITEPRESS_BASE:-/}"
+          ORIGIN="${DOCS_SITE_ORIGIN:-https://pideck.caoayu.top}"
           SITEMAP="docs-site/.vitepress/dist/sitemap.xml"
           echo '<?xml version="1.0" encoding="UTF-8"?>' > "$SITEMAP"
           echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' >> "$SITEMAP"
@@ -70,7 +75,7 @@ jobs:
             else
               loc="$BASE$rel/"
             fi
-            echo "  <url><loc>https://ayuayue.github.io/PiDeck${loc}</loc></url>" >> "$SITEMAP"
+            echo "  <url><loc>${ORIGIN}${loc}</loc></url>" >> "$SITEMAP"
           done
           echo '</urlset>' >> "$SITEMAP"
           cat "$SITEMAP"

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitepress";
 
-const base = process.env.VITEPRESS_BASE ?? "/PiDeck/";
+// 自定义域名部署在站点根路径；本地/兼容旧 github.io 子路径时可用 VITEPRESS_BASE=/PiDeck/
+const base = process.env.VITEPRESS_BASE ?? "/";
+// 官网正式入口：自定义域名（GitHub Pages Settings + public/CNAME）
+const siteOrigin = process.env.DOCS_SITE_ORIGIN ?? "https://pideck.caoayu.top";
 
 export default defineConfig({
   title: "PiDeck - pi Agent Desktop Workbench",
@@ -11,7 +14,7 @@ export default defineConfig({
   lastUpdated: true,
   head: [
     ["link", { rel: "icon", href: `${base}icon.svg` }],
-    ["link", { rel: "canonical", href: "https://ayuayue.github.io/PiDeck/" }],
+    ["link", { rel: "canonical", href: `${siteOrigin}/` }],
     ["meta", { name: "keywords", content: "PiDeck, pi, pi-agent, ai-coding-agent, desktop, electron, rpc, local-ai, developer-tools, coding-assistant, workspace, session-management, git, terminal, windows, macos, linux, open-source" }],
     ["meta", { name: "author", content: "ayuayue" }],
     ["meta", { name: "robots", content: "index, follow" }],
@@ -19,14 +22,14 @@ export default defineConfig({
     ["meta", { property: "og:title", content: "PiDeck - pi Agent Desktop Workbench" }],
     ["meta", { property: "og:description", content: "Open-source desktop workbench to manage pi AI coding agents across local project folders. Features session history, Git integration, terminal, and plugin management." }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:url", content: "https://ayuayue.github.io/PiDeck/" }],
-    ["meta", { property: "og:image", content: "https://ayuayue.github.io/PiDeck/og-image.png" }],
+    ["meta", { property: "og:url", content: `${siteOrigin}/` }],
+    ["meta", { property: "og:image", content: `${siteOrigin}/og-image.png` }],
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
     ["meta", { name: "twitter:title", content: "PiDeck - pi Agent Desktop Workbench" }],
     ["meta", { name: "twitter:description", content: "Manage multiple pi AI coding agents in local workspaces. Open-source desktop app with sessions, Git, terminal, and extensions." }],
-    ["meta", { name: "twitter:image", content: "https://ayuayue.github.io/PiDeck/og-image.png" }],
+    ["meta", { name: "twitter:image", content: `${siteOrigin}/og-image.png` }],
     [
       "script",
       { type: "application/ld+json" },
@@ -37,7 +40,7 @@ export default defineConfig({
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Windows, macOS, Linux",
         "description": "Open-source desktop workbench for managing multiple pi AI coding agents across local project folders.",
-        "url": "https://ayuayue.github.io/PiDeck",
+        "url": siteOrigin,
         "downloadUrl": "https://github.com/ayuayue/PiDeck/releases",
         "sourceCodeRepository": "https://github.com/ayuayue/PiDeck",
         "license": "https://opensource.org/licenses/MIT",

--- a/docs-site/guide/development.md
+++ b/docs-site/guide/development.md
@@ -33,11 +33,13 @@
 
 本站点使用 VitePress，源码位于 `docs-site/`。GitHub Pages workflow 会在推送到 `main` 后构建 `docs-site/.vitepress/dist` 并发布。
 
-如果仓库改用自定义域名，可以在 Pages workflow 中设置：
+站点已使用自定义域名 `https://pideck.caoayu.top`，Pages workflow 中设置：
 
 ```yaml
 env:
   VITEPRESS_BASE: /
+  DOCS_SITE_ORIGIN: https://pideck.caoayu.top
 ```
 
-默认配置面向 `https://ayuayue.github.io/PiDeck/`，所以 base 为 `/PiDeck/`。
+`docs-site/public/CNAME` 写入 `pideck.caoayu.top`，构建后进入产物，避免部署冲掉域名绑定。
+若临时需要兼容旧地址 `https://ayuayue.github.io/PiDeck/`，可本地设置 `VITEPRESS_BASE=/PiDeck/`。

--- a/docs-site/public/CNAME
+++ b/docs-site/public/CNAME
@@ -1,0 +1,1 @@
+pideck.caoayu.top

--- a/docs-site/public/robots.txt
+++ b/docs-site/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://ayuayue.github.io/PiDeck/sitemap.xml
+Sitemap: https://pideck.caoayu.top/sitemap.xml


### PR DESCRIPTION
## Summary
- VitePress 默认 `base` 从 `/PiDeck/` 改为 `/`，匹配自定义域名 `https://pideck.caoayu.top`
- 新增 `docs-site/public/CNAME`，部署后保留域名绑定
- Pages workflow / sitemap / robots / canonical / OG 绝对地址同步到新域名

## Test plan
- [x] 本地 `npm run docs:build` 成功
- [x] 产物包含 `CNAME=pideck.caoayu.top`
- [x] 产物资源路径为 `/assets/...`，canonical 为 `https://pideck.caoayu.top/`
- [ ] 合并后确认 Pages workflow 部署成功
- [ ] 打开 `https://pideck.caoayu.top/` 验证样式与内链正常