### PR TITLE
fix: extension install/uninstall UX and sidebar expand persistence

### DIFF
--- a/src/main/extensions/ExtensionManager.ts
+++ b/src/main/extensions/ExtensionManager.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
-import { readFile, readdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
 import { homedir } from "node:os";
 import type { AppSettings, PiCliUpdateResult, PiExtensionListResult, PiExtensionSummary, PiUpdateCheckResult } from "../../shared/types";
 import type { PiLocator } from "../pi/PiLocator";
@@ -31,6 +31,11 @@ export class ExtensionManager {
 	private listInflight: Promise<PiExtensionListResult> | null = null;
 	/** 进行中请求是否为强制刷新（含版本信息）。 */
 	private listInflightForce = false;
+	/**
+	 * 列表缓存代数：安装/卸载/开关后递增。
+	 * 用于丢弃失效前已发出的 in-flight 结果，避免旧列表写回缓存导致 UI 不刷新。
+	 */
+	private listCacheGeneration = 0;
 
 	constructor(
 		private readonly locator: PiLocator,
@@ -52,10 +57,17 @@ export class ExtensionManager {
 	private piVersion: string | null = null;
 	private piVersionPromise: Promise<string | null> | null = null;
 
-	/** 安装/卸载/开关后主动清缓存，下一次 list 重新获取。 */
+	/**
+	 * 安装/卸载/开关后主动清缓存。
+	 * 同时递增 generation 并断开 inflight 复用，避免旧请求完成后把已删除/已变更的列表写回。
+	 */
 	invalidateListCache() {
 		this.listCache = null;
 		this.listCacheHasVersionInfo = false;
+		this.listCacheGeneration += 1;
+		// 允许下一次 list() 立刻发起新请求，而不是复用失效前的 inflight。
+		this.listInflight = null;
+		this.listInflightForce = false;
 	}
 
 	/**
@@ -73,18 +85,28 @@ export class ExtensionManager {
 			return this.listInflight;
 		}
 
+		// 捕获当前代数：若请求返回前发生 install/uninstall/toggle，丢弃结果并改走最新 list。
+		const generation = this.listCacheGeneration;
 		this.listInflightForce = forceRefresh;
-		this.listInflight = this.loadList(forceRefresh)
+		const request = this.loadList(forceRefresh)
 			.then((result) => {
+				if (generation !== this.listCacheGeneration) {
+					// 失效前的调用方也必须拿到变更后的列表，否则 UI 会短暂/永久停在旧数据。
+					return this.list(forceRefresh);
+				}
 				this.listCache = result;
 				this.listCacheHasVersionInfo = forceRefresh;
 				return result;
 			})
 			.finally(() => {
-				this.listInflight = null;
-				this.listInflightForce = false;
+				// 仅清理自己：失效后新发起的请求可能已经接管 listInflight。
+				if (this.listInflight === request) {
+					this.listInflight = null;
+					this.listInflightForce = false;
+				}
 			});
-		return this.listInflight;
+		this.listInflight = request;
+		return request;
 	}
 
 	private async loadList(includeVersionInfo: boolean): Promise<PiExtensionListResult> {
@@ -181,18 +203,64 @@ export class ExtensionManager {
 		return result;
 	}
 
+	/**
+	 * 判断是否为本地文件扩展（~/.pi/agent/extensions 下自动发现的 .ts/目录）。
+	 * pi list 的包源都带 npm:/file:/github: 等协议前缀；裸文件名只能走文件系统删除。
+	 */
+	private isLocalFileExtension(source: string): boolean {
+		return !/^(?:npm|file|github|git|https?):/i.test(source);
+	}
+
+	/**
+	 * 删除本地扩展文件/目录。
+	 * 只允许删除 extensions 目录下的单层 basename，防止路径穿越。
+	 */
+	private async removeLocalExtension(source: string): Promise<void> {
+		const extensionsDir = join(this.homeDir, ".pi", "agent", "extensions");
+		const trimmed = source.trim();
+		const name = basename(trimmed);
+		// source 必须等于 basename（如 orca-agent-status.ts），拒绝 ../ 或绝对路径穿越。
+		if (!name || name !== trimmed || name === "." || name === "..") {
+			throw new Error("非法扩展路径");
+		}
+		const targetPath = join(extensionsDir, name);
+		await rm(targetPath, { recursive: true, force: true });
+	}
+
+	/** 卸载后从 disabledExtensions 清掉对应项，避免残留无效禁用记录。 */
+	private async clearDisabledEntry(source: string): Promise<void> {
+		try {
+			const settingsPath = join(this.homeDir, ".pi", "agent", "settings.json");
+			const raw = await readFile(settingsPath, "utf8");
+			const settings = JSON.parse(raw) as { disabledExtensions?: string[] };
+			const disabled = settings.disabledExtensions ?? [];
+			if (!disabled.includes(source)) return;
+			settings.disabledExtensions = disabled.filter((item) => item !== source);
+			await writeFile(settingsPath, JSON.stringify(settings, null, 2), "utf8");
+		} catch {
+			// settings 不存在或解析失败时忽略；卸载主流程已成功
+		}
+	}
+
 	async uninstall(source: string, scope: PiExtensionSummary["scope"] = "user"): Promise<void> {
 		const normalized = source.trim();
 		if (!normalized) throw new Error("扩展来源不能为空");
 		// 阻止卸载 PiDeck 内置扩展（如 pi-deck-file-capture）
-		if (source.startsWith("pi-deck-")) {
+		if (normalized.startsWith("pi-deck-")) {
 			throw new Error("PiDeck 内置扩展不可卸载");
 		}
-		await this.runPi([
-			"remove",
-			normalized,
-			...(scope === "project" ? ["-l"] : []),
-		], 30_000);
+		// 本地 .ts/目录扩展不在 pi package 列表里，pi remove 会报 No matching package；
+		// 例如 orca-agent-status.ts 只能直接删文件。
+		if (this.isLocalFileExtension(normalized)) {
+			await this.removeLocalExtension(normalized);
+		} else {
+			await this.runPi([
+				"remove",
+				normalized,
+				...(scope === "project" ? ["-l"] : []),
+			], 30_000);
+		}
+		await this.clearDisabledEntry(normalized);
 		// 列表已变，清缓存，避免 UI 继续读到旧安装态。
 		this.invalidateListCache();
 	}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -298,6 +298,58 @@ function isAbsoluteFilePath(path: string) {
   return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("/");
 }
 
+/** 侧栏展开项目 id（含 chat）；localStorage 作首屏缓存，settings.json 作跨进程可靠落盘 */
+const SIDEBAR_EXPANDED_PROJECTS_KEY = "pid:sidebar-expanded-projects";
+/** 旧版「折叠集合」key，仅用于一次性迁移 */
+const SIDEBAR_COLLAPSED_PROJECTS_LEGACY_KEY = "pid:sidebar-collapsed-projects";
+/** 与主进程 ProjectStore 内置 chat id 保持一致 */
+const BUILTIN_CHAT_PROJECT_ID = "builtin-chat";
+
+function parseProjectIdArray(raw: string | null): string[] | null {
+	if (raw === null) return null;
+	try {
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return null;
+		return parsed.filter((id): id is string => typeof id === "string");
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * 读取侧栏展开项目 id。
+ * 优先新 key；若仅有旧折叠 key 则返回 null，等拿到项目列表后再反演迁移。
+ */
+function loadExpandedSidebarProjectsFromLocal(): string[] | null {
+	const expanded = parseProjectIdArray(
+		localStorage.getItem(SIDEBAR_EXPANDED_PROJECTS_KEY),
+	);
+	if (expanded) return expanded;
+	// 旧 key 存在但还不能反演（缺项目全集）→ 交给后续迁移
+	if (localStorage.getItem(SIDEBAR_COLLAPSED_PROJECTS_LEGACY_KEY) !== null) {
+		return null;
+	}
+	return null;
+}
+
+function saveExpandedSidebarProjectsToLocal(ids: Set<string>) {
+	try {
+		localStorage.setItem(
+			SIDEBAR_EXPANDED_PROJECTS_KEY,
+			JSON.stringify([...ids]),
+		);
+		// 迁移完成后清掉旧 key，避免两套数据源互相打架
+		localStorage.removeItem(SIDEBAR_COLLAPSED_PROJECTS_LEGACY_KEY);
+	} catch {
+		// localStorage 不可用时静默忽略；settings.json 仍会落盘
+	}
+}
+
+/** 默认只展开内置 chat，与「启动不全量扫会话」策略一致 */
+function defaultExpandedSidebarProjects(): Set<string> {
+	return new Set([BUILTIN_CHAT_PROJECT_ID]);
+}
+
 /** 从 localStorage 恢复会话来源过滤配置 */
 function loadSessionSourceFilter(): Record<string, Set<"pi" | "codex" | "claude" | "opencode"> | null> {
 	try {
@@ -505,11 +557,17 @@ export function App() {
   activeAgentIdRef.current = activeAgentId;
   const agentsRef = useRef<AgentTab[]>(agents);
   agentsRef.current = agents;
-  const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(
-    new Set(),
+  // 侧栏展开集合：有 id = 展开。localStorage 首屏缓存 + settings.json 可靠落盘（dev 强杀也不丢）。
+  const [expandedSidebarProjects, setExpandedSidebarProjects] = useState<Set<string>>(
+    () => {
+      const cached = loadExpandedSidebarProjectsFromLocal();
+      return cached ? new Set(cached) : defaultExpandedSidebarProjects();
+    },
   );
-  const collapsedProjectsRef = useRef(collapsedProjects);
-  collapsedProjectsRef.current = collapsedProjects;
+  const expandedSidebarProjectsRef = useRef(expandedSidebarProjects);
+  expandedSidebarProjectsRef.current = expandedSidebarProjects;
+  /** 已从 settings.json 合并过展开状态，避免被后续 settings 刷新覆盖用户刚点的展开 */
+  const expandedSidebarFromSettingsRef = useRef(false);
   const [activeAgentByProject, setActiveAgentByProject] = useState<
     Record<string, string>
   >({});
@@ -2086,6 +2144,21 @@ export function App() {
     void api.settings.get().then((next) => {
       setSettings(next);
       setCustomPiPath(next.customPiPath ?? "");
+      // settings.json 为展开状态的权威来源（dev 强杀后 localStorage 可能丢写入）
+      if (
+        !expandedSidebarFromSettingsRef.current &&
+        Array.isArray(next.sidebarExpandedProjectIds)
+      ) {
+        expandedSidebarFromSettingsRef.current = true;
+        const fromSettings = new Set(
+          next.sidebarExpandedProjectIds.filter(
+            (id): id is string => typeof id === "string",
+          ),
+        );
+        expandedSidebarProjectsRef.current = fromSettings;
+        setExpandedSidebarProjects(fromSettings);
+        saveExpandedSidebarProjectsToLocal(fromSettings);
+      }
       if (!Object.values(next.externalEditors).some((editor) => editor.command)) {
         void api.editors
           .redetect()
@@ -2438,6 +2511,46 @@ export function App() {
     return off;
   }, []);
 
+  /**
+   * 更新侧栏展开集合并双写持久化：
+   * 1) localStorage：同步，首屏可读
+   * 2) settings.json：主进程 writeFile，dev 强杀/重启也不丢
+   */
+  const commitExpandedSidebarProjects = useCallback((next: Set<string>) => {
+    // 标记已有权威写入，防止启动时迟到的 settings.get 用旧值覆盖用户刚点的展开
+    expandedSidebarFromSettingsRef.current = true;
+    expandedSidebarProjectsRef.current = next;
+    setExpandedSidebarProjects(next);
+    saveExpandedSidebarProjectsToLocal(next);
+    void api.settings
+      .update({ sidebarExpandedProjectIds: [...next] })
+      .then((saved) => {
+        // 只合并本字段，避免覆盖用户在设置页刚改的其它项的本地缓存
+        setSettings((current) => ({
+          ...current,
+          sidebarExpandedProjectIds: saved.sidebarExpandedProjectIds,
+        }));
+      })
+      .catch(() => undefined);
+  }, []);
+
+  /** 展开/折叠某个项目；forceExpand=true 时只展开不切换 */
+  const setProjectSidebarExpanded = useCallback(
+    (projectId: string, forceExpand?: boolean) => {
+      const prev = expandedSidebarProjectsRef.current;
+      const next = new Set(prev);
+      const shouldExpand = forceExpand ?? !next.has(projectId);
+      if (shouldExpand) next.add(projectId);
+      else next.delete(projectId);
+      const unchanged =
+        next.size === prev.size && [...next].every((id) => prev.has(id));
+      if (unchanged) return next;
+      commitExpandedSidebarProjects(next);
+      return next;
+    },
+    [commitExpandedSidebarProjects],
+  );
+
   useEffect(() => {
     const projectIds = new Set(projects.map((project) => project.id));
     setSessionsByProject((current) =>
@@ -2461,13 +2574,56 @@ export function App() {
         ),
       ),
     );
-    // 启动时只加载 chat 项目的会话,其他项目延迟到展开时加载
-    for (const project of projects) {
-      if (project.kind === "chat") {
-        void refreshProjectSessions(project.id).catch(() => undefined);
+
+    if (projects.length === 0) return;
+
+    // 旧版 collapsed key → expanded 迁移（仅一次）
+    const legacyCollapsed = parseProjectIdArray(
+      localStorage.getItem(SIDEBAR_COLLAPSED_PROJECTS_LEGACY_KEY),
+    );
+    const hasExpandedCache =
+      localStorage.getItem(SIDEBAR_EXPANDED_PROJECTS_KEY) !== null;
+    if (legacyCollapsed && !hasExpandedCache && !expandedSidebarFromSettingsRef.current) {
+      const migrated = new Set(
+        projects
+          .map((project) => project.id)
+          .filter((id) => !legacyCollapsed.includes(id)),
+      );
+      // 至少保留 chat，避免迁移后侧栏全空
+      if (projectIds.has(BUILTIN_CHAT_PROJECT_ID)) {
+        migrated.add(BUILTIN_CHAT_PROJECT_ID);
+      }
+      commitExpandedSidebarProjects(migrated);
+    } else {
+      // 修剪已删除项目 id，不自动展开新建项目，也不把用户主动折叠的 chat 加回来
+      const prev = expandedSidebarProjectsRef.current;
+      const pruned = new Set([...prev].filter((id) => projectIds.has(id)));
+      if (pruned.size !== prev.size || [...pruned].some((id) => !prev.has(id))) {
+        expandedSidebarProjectsRef.current = pruned;
+        setExpandedSidebarProjects(pruned);
+        saveExpandedSidebarProjectsToLocal(pruned);
       }
     }
-  }, [projectIdsKey]);
+
+    // 按展开状态恢复会话列表
+    const expanded = expandedSidebarProjectsRef.current;
+    for (const project of projects) {
+      if (!expanded.has(project.id)) continue;
+      if (project.id in sessionsByProject) continue;
+      void refreshProjectSessions(project.id).catch(() => undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectIdsKey, commitExpandedSidebarProjects]);
+
+  // 展开集合变化时，为新展开且无缓存的项目补加载会话
+  useEffect(() => {
+    for (const project of projects) {
+      if (!expandedSidebarProjects.has(project.id)) continue;
+      if (project.id in sessionsByProject) continue;
+      void refreshProjectSessions(project.id).catch(() => undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedSidebarProjects]);
 
   useEffect(() => {
     // 当禁用版本检测时，不启动定时和启动后的自动检测
@@ -2493,7 +2649,8 @@ export function App() {
   }, [displayAgents]);
 
   useEffect(() => {
-    if (!activeProjectId || collapsedProjects.has(activeProjectId)) return;
+    // 折叠中的项目不跑周期扫描，避免后台无意义刷会话列表
+    if (!activeProjectId || !expandedSidebarProjects.has(activeProjectId)) return;
     // 进入/退出运行态时都立即扫描一次，保证最终 child session 不因最后一次写入时序而遗漏。
     let disposed = false;
     const scheduleRefresh = () => {
@@ -2511,7 +2668,7 @@ export function App() {
       disposed = true;
       window.clearInterval(timer);
     };
-  }, [activeProjectId, activeProjectHasBusyAgent, collapsedProjects]);
+  }, [activeProjectId, activeProjectHasBusyAgent, expandedSidebarProjects]);
 
   function getComposerMaxHeight() {
     const chatPane = chatPaneRef.current;
@@ -6033,7 +6190,7 @@ export function App() {
             );
             const hasProjectChildren =
               projectDisplay.children.length > 0 || projectSessionsLoading || !!project.worktreeEnabled;
-            const isCollapsed = collapsedProjects.has(project.id);
+            const isCollapsed = !expandedSidebarProjects.has(project.id);
             const isDraggingProject = draggingProjectId === project.id;
             const isProjectDropTarget = dragOverProjectId === project.id;
             const projectRowClass = [
@@ -6078,23 +6235,17 @@ export function App() {
                     el.classList.add('click-animating');
                     setTimeout(() => el.classList.remove('click-animating'), 400);
 
-                    // 点击项目行：切换展开/折叠状态
-                    const hasLoadedSessions = (sessionsByProject[project.id]?.length ?? 0) > 0;
-                    // 首次点击尚未加载会话 → 始终展开 + 加载；加载过之后点击 → 正常切换
-                    if (!hasLoadedSessions && !projectIsChat) {
-                      setCollapsedProjects((prev) => {
-                        const next = new Set(prev);
-                        next.delete(project.id);
-                        return next;
-                      });
+                    // 点击项目行：切换展开/折叠；首次展开未加载会话时顺带拉列表
+                    const hasLoadedSessions = project.id in sessionsByProject;
+                    if (!hasLoadedSessions && !projectIsChat && isCollapsed) {
+                      setProjectSidebarExpanded(project.id, true);
                       void refreshProjectSessions(project.id).catch(() => undefined);
                     } else {
-                      setCollapsedProjects((prev) => {
-                        const next = new Set(prev);
-                        if (next.has(project.id)) next.delete(project.id);
-                        else next.add(project.id);
-                        return next;
-                      });
+                      const wasCollapsed = isCollapsed;
+                      setProjectSidebarExpanded(project.id);
+                      if (wasCollapsed && !(project.id in sessionsByProject)) {
+                        void refreshProjectSessions(project.id).catch(() => undefined);
+                      }
                     }
 
                     setActiveProjectId(project.id);
@@ -6109,14 +6260,9 @@ export function App() {
                         : t("app.projectCollapse")
                     }
                     onClick={(e) => {
-                      // 点击折叠图标仅切换折叠状态，不加载会话
+                      // 点击折叠图标仅切换折叠状态；会话由 expanded 变化 effect 补加载
                       e.stopPropagation();
-                      setCollapsedProjects((prev) => {
-                        const next = new Set(prev);
-                        if (next.has(project.id)) next.delete(project.id);
-                        else next.add(project.id);
-                        return next;
-                      });
+                      setProjectSidebarExpanded(project.id);
                     }}
                   >
                     <Play size={12} />

--- a/src/renderer/src/ConfigModal.tsx
+++ b/src/renderer/src/ConfigModal.tsx
@@ -447,6 +447,15 @@ function ConfigModalContent(props: ConfigModalProps) {
 		showNotice(msg, 2500);
 	};
 
+	/** 去掉 Electron IPC 包装前缀，只保留真正业务错误，方便 toast 阅读。 */
+	const formatIpcError = (error: unknown): string => {
+		const raw = error instanceof Error ? error.message : String(error);
+		const matched = raw.match(
+			/Error invoking remote method '[^']+':\s*(?:Error:\s*)?([\s\S]+)$/i,
+		);
+		return (matched?.[1] ?? raw).trim();
+	};
+
 	/**
 	 * 模型配置保存后，通知所有运行中的 Agent 尝试刷新模型配置。
 	 *
@@ -1324,14 +1333,26 @@ function ConfigModalContent(props: ConfigModalProps) {
 			return;
 		}
 		setUninstallExtensionConfirm(null);
+		// 立刻进入卸载态以触发卡片退场动画，同时发起真实卸载；两者并行，避免“删完才闪一下”。
 		setUninstallingExtensionSource(target.source);
-		setError(null);
+		const exitAnimation = new Promise<void>((resolve) => {
+			window.setTimeout(resolve, 280);
+		});
 		try {
-			await api.extensions.uninstall(target.source, target.scope);
-			await refreshExtensions();
+			await Promise.all([
+				api.extensions.uninstall(target.source, target.scope),
+				exitAnimation,
+			]);
+			// 与禁用/手动刷新一致：强制重扫并跳过可能残留的 in-flight 缓存结果。
+			await refreshExtensions(true);
 			showToast(t("config.extensionUninstalledToast"));
 		} catch (e) {
-			setError(e instanceof Error ? e.message : String(e));
+			// 配置页顶部红字容易被滚出视口；卸载失败用 error toast，用户能立刻看到。
+			showNotice(
+				t("config.extensionUninstallFailed", { error: formatIpcError(e) }),
+				4500,
+				"error",
+			);
 		} finally {
 			setUninstallingExtensionSource(null);
 		}

--- a/src/renderer/src/config/ExtensionsTab.tsx
+++ b/src/renderer/src/config/ExtensionsTab.tsx
@@ -88,6 +88,7 @@ export function ExtensionsTab(props: {
 		try {
 			const nextEnabled = extension.enabled !== false ? false : true;
 			await getExtensionsApi().toggle(extension.source, nextEnabled);
+			// 与安装/卸载一致：强制刷新列表，确保 enabled 与缓存同步。
 			props.onRefresh();
 		} catch (e) {
 			alert(t("config.installFailed") + ": " + (e instanceof Error ? e.message : String(e)));
@@ -202,18 +203,20 @@ export function ExtensionsTab(props: {
 								</div>
 							</div>
 							<div className="extensions-recommended-action" onClick={(e) => e.stopPropagation()}>
-								{installing ? (
-									<span className="config-btn" style={{ opacity: 0.6 }}>{t("config.installing")}</span>
-								) : (
-									<button
-										className="config-icon-btn"
-										title={alreadyInstalled ? t("config.installed") : t("config.install")}
-										onClick={() => handleInstall(pkg)}
-										disabled={alreadyInstalled}
-									>
-										<Download size={15} strokeWidth={1.8} />
-									</button>
-								)}
+								{/* 安装中保持与图标按钮同尺寸，避免 config-btn 文本把操作区撑开错位 */}
+								<button
+									className="config-icon-btn"
+									title={installing ? t("config.installing") : alreadyInstalled ? t("config.installed") : t("config.install")}
+									onClick={() => handleInstall(pkg)}
+									disabled={alreadyInstalled || installing}
+									aria-busy={installing}
+								>
+									{installing ? (
+										<span className="skillhub-installing-dot" aria-hidden="true" />
+									) : (
+										<Download size={15} strokeWidth={1.8} aria-hidden="true" />
+									)}
+								</button>
 								<button
 									className="config-icon-btn"
 									title={t("common.copy")}
@@ -289,7 +292,10 @@ function ExtensionCard(props: {
 	const { extension } = props;
 	const name = extension.source.replace(/^(?:npm|file|github|git):/i, "");
 	return (
-		<article className="session-card skill-card extension-card">
+		<article
+			className={`session-card skill-card extension-card${props.uninstalling ? " extension-removing" : ""}`}
+			aria-busy={props.uninstalling}
+		>
 			<div className="session-card-display">
 				<div className="session-card-inner skill-card-main">
 					<div className="session-card-title skill-title-row">

--- a/src/renderer/src/i18n.ts
+++ b/src/renderer/src/i18n.ts
@@ -754,6 +754,7 @@ const zhCN = {
   "config.skillDisabledToast": "Skill 已禁用，重启 agent 后生效",
   "config.skillEnabledToast": "Skill 已启用，重启 agent 后生效",
   "config.extensionUninstalledToast": "扩展已卸载，重启 agent 后生效",
+  "config.extensionUninstallFailed": "卸载失败：{error}",
   "config.count.configItems": "{count} 个配置项",
   "config.count.extensions": "{count} 个扩展",
   "config.count.auth": "{count} 个认证",
@@ -2430,6 +2431,7 @@ const enUS: Record<TranslationKey, string> = {
     "Skill enabled. Restart agents for it to take effect.",
   "config.extensionUninstalledToast":
     "Extension uninstalled. Restart agents for it to take effect.",
+  "config.extensionUninstallFailed": "Uninstall failed: {error}",
   "config.count.configItems": "{count} settings",
   "config.count.auth": "{count} auth(s)",
   "config.retry.title": "Auto Retry",

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -16729,6 +16729,20 @@ a.config-btn {
   margin: 0;
 }
 
+/* 扩展卡片默认带过渡，卸载失败回弹时也不会瞬间跳变 */
+.extension-card {
+  transition:
+    opacity 0.28s ease,
+    transform 0.28s ease;
+}
+
+/* 卸载扩展时的退场动画：先淡出左移，再刷新列表，避免条目生硬消失 */
+.extension-card.extension-removing {
+  opacity: 0;
+  transform: translateX(-14px);
+  pointer-events: none;
+}
+
 .extensions-search-bar {
   border-bottom: 1px solid var(--color-border-subtle);
   padding-bottom: var(--space-4);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -417,6 +417,14 @@ export type AppSettings = {
 	 *  开启后自动跳过启动和定时检测，设置页中检测按钮也禁用。 */
 	disableUpdateCheck: boolean;
 
+	// ── 侧栏 UI 状态 ──
+	/**
+	 * 左侧边栏处于展开状态的项目 id 列表（含 builtin-chat）。
+	 * 写入 settings.json，避免 dev 模式强杀进程时 localStorage 来不及落盘而丢失。
+	 * 缺省时由渲染层按「仅展开 chat」处理。
+	 */
+	sidebarExpandedProjectIds?: string[];
+
 };
 
 // ── 桌面宠物类型 ──


### PR DESCRIPTION
## Summary
- Fix extension install button layout while installing (icon spinner instead of text button)
- Support uninstalling local file extensions (e.g. `orca-*.ts`) by deleting files instead of `pi remove`
- Force-refresh extension list/cache after uninstall; invalidate in-flight list results
- Show uninstall failures as error toast instead of hard-to-see top banner
- Add extension card exit animation on uninstall
- Also includes: persist sidebar project expand/collapse across restarts

## Test plan
- [x] Install recommended extension: loading spinner stays aligned
- [x] Uninstall local extension like `orca-agent-status.ts`: succeeds and list refreshes
- [x] Uninstall package extension still works
- [x] Failed uninstall shows bottom error toast
- [x] Uninstall card fades out before list refresh