### PR TITLE
fix: make local file links interactive and honor todo fonts

### DIFF
--- a/src/renderer/src/components/app/AppParts.tsx
+++ b/src/renderer/src/components/app/AppParts.tsx
@@ -597,7 +597,7 @@ export function ExtensionWidgetCard(props: {
 	}, [storageKey]);
 
 	return (
-		<div className="extension-widget-card">
+		<div className="extension-widget-card" data-widget-key={props.widgetKey}>
 			<div className="extension-widget-card-header">
 				<button
 					className="extension-widget-card-trigger"

--- a/src/renderer/src/components/app/AppParts.tsx
+++ b/src/renderer/src/components/app/AppParts.tsx
@@ -100,6 +100,7 @@ import { getFileIconSeti, getFileIconColor, getFileTypeLabel } from "../../fileI
 import { normalizeSessionPathForCompare } from "../../agentListDisplay";
 import { t, type TranslationKey } from "../../i18n";
 import { showNotice } from "../../utils/notice";
+import { filePathFromHref, stripFileLocation, toInternalFileHref } from "../../utils/fileLinks";
 import { Button } from "../ui/Button";
 import { CloseIconButton, IconButton } from "../ui/IconButton";
 import { Modal } from "../ui/Modal";
@@ -3321,7 +3322,12 @@ const remarkLinkifyPaths = () => {
 		const visit = (node: any) => {
 			if (!node || typeof node !== "object") return;
 			const type: string = node.type;
-			if (type === "code" || type === "inlineCode" || type === "link") return;
+			if (type === "code" || type === "inlineCode") return;
+			if (type === "link") {
+				const fileHref = typeof node.url === "string" ? toInternalFileHref(node.url) : null;
+				if (fileHref) node.url = fileHref;
+				return;
+			}
 			if (type === "text" && typeof node.value === "string") {
 				const text: string = node.value;
 				FILE_PATH_RE.lastIndex = 0;
@@ -3648,22 +3654,25 @@ function MarkdownLink(
 	},
 ) {
 	const { onOpenExternal, onOpenFile, children, className, title, ...anchorProps } = props;
-	// remarkLinkifyPaths 生成的文件路径链接走 file:// 协议，与普通外链区分展示
-	const isFileLink = props.href?.startsWith("file://") ?? false;
+	const filePath = filePathFromHref(props.href);
+	const isFileLink = filePath !== null;
 	const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
 		e.preventDefault();
 		if (!props.href) return;
-		
-		// 处理文件路径链接（file:// 协议）
-		if (props.href.startsWith('file://')) {
-			const filePath = decodeURIComponent(props.href.slice(7));
-			if (onOpenFile) {
-				void onOpenFile(filePath);
-			}
+
+		if (filePath !== null) {
+			if (onOpenFile) void onOpenFile(stripFileLocation(filePath));
 		} else {
-			// 普通 URL 链接用系统浏览器打开
 			void onOpenExternal(props.href);
 		}
+	};
+	const handleContextMenu = (e: React.MouseEvent<HTMLAnchorElement>) => {
+		if (filePath === null) return;
+		e.preventDefault();
+		void navigator.clipboard.writeText(filePath).then(
+			() => showNotice(t("app.pathCopied"), 1200),
+			() => showNotice(t("copy.failed"), 2000, "error"),
+		);
 	};
 	const linkClass =
 		[className, isFileLink ? "markdown-link-file" : undefined]
@@ -3674,9 +3683,8 @@ function MarkdownLink(
 			{...anchorProps}
 			className={linkClass}
 			onClick={handleClick}
-			// 文件链接 hover 展示解码后的完整路径，便于确认目标文件；
-			// 普通链接不传 title，保留 markdown 自带 title 语法的原行为
-			title={isFileLink ? decodeURIComponent(props.href!.slice(7)) : title}
+			onContextMenu={handleContextMenu}
+			title={isFileLink ? filePath : title}
 		>
 			{isFileLink ? (
 				<>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -7514,6 +7514,12 @@ body.is-composer-resizing .composer-resize-handle::after {
   color: var(--color-text-tertiary);
   line-height: var(--extension-widget-line-height);
 }
+.extension-widget-card:is(
+  [data-widget-key="pi-deck-todo"],
+  [data-widget-key="pi-deck-plan-todos"]
+) .extension-widget-card-line {
+  font-family: var(--font-family-base);
+}
 .extension-widget-card-line .widget-check-done {
   color: var(--color-success);
   font-weight: 700;

--- a/src/renderer/src/utils/fileLinks.ts
+++ b/src/renderer/src/utils/fileLinks.ts
@@ -1,0 +1,53 @@
+const WINDOWS_DRIVE_PATH_RE = /^\/?[A-Za-z]:[\\/]/;
+const WINDOWS_UNC_PATH_RE = /^\\\\[^\\/]+[\\/][^\\/]+/;
+const RELATIVE_PATH_RE = /^(?:\.\.?[\\/]|[^\\/:*?"<>|]+[\\/])/;
+const FILE_EXTENSION_RE = /\.[A-Za-z0-9][A-Za-z0-9._-]*(?::\d+(?::\d+)?)?$/;
+
+function safeDecode(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+export function stripFileLocation(path: string): string {
+	return path.replace(/:\d+(?::\d+)?$/, "");
+}
+
+export function normalizeLocalFilePath(value: string): string | null {
+	if (!value) return null;
+
+	let path = value.startsWith("file://")
+		? safeDecode(value.slice(7))
+		: safeDecode(value);
+
+	// Pi agents commonly emit /C:/... links so one Markdown form works across renderers.
+	if (/^\/[A-Za-z]:[\\/]/.test(path)) path = path.slice(1);
+
+	const withoutLocation = stripFileLocation(path);
+	const isWindowsPath = WINDOWS_DRIVE_PATH_RE.test(path) || WINDOWS_UNC_PATH_RE.test(path);
+	const isUnixPath = path.startsWith("/") && !path.startsWith("//");
+	const isRelativePath = RELATIVE_PATH_RE.test(path);
+	const isBareFileName =
+		!withoutLocation.includes(":") &&
+		!withoutLocation.includes("#") &&
+		!/[\\/]/.test(withoutLocation) &&
+		FILE_EXTENSION_RE.test(path);
+	const hasFileName = FILE_EXTENSION_RE.test(path);
+
+	if (isWindowsPath || WINDOWS_UNC_PATH_RE.test(withoutLocation)) return path;
+	if ((isUnixPath || isRelativePath) && hasFileName) return path;
+	if (isBareFileName) return path;
+	return null;
+}
+
+export function toInternalFileHref(value: string): string | null {
+	const path = normalizeLocalFilePath(value);
+	return path === null ? null : `file://${encodeURIComponent(path)}`;
+}
+
+export function filePathFromHref(href: string | undefined): string | null {
+	if (!href?.startsWith("file://")) return null;
+	return normalizeLocalFilePath(href);
+}

--- a/tests/file-links.test.ts
+++ b/tests/file-links.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import {
+	filePathFromHref,
+	normalizeLocalFilePath,
+	stripFileLocation,
+	toInternalFileHref,
+} from "../src/renderer/src/utils/fileLinks";
+
+const localTargets = [
+	"C:/Users/Administrator/.pi/agent/settings.json",
+	"C:\\Users\\Administrator\\.pi\\agent\\settings.json",
+	"/C:/Users/Administrator/project/src/App.tsx:392",
+	"/home/user/project/src/app.py:12:4",
+	"./src/app.ts",
+	"../docs/README.md",
+	"src/components/App.tsx:42",
+	"settings.json",
+	"settings.json:8",
+];
+
+for (const target of localTargets) {
+	const normalized = normalizeLocalFilePath(target);
+	assert.ok(normalized, `expected local file target: ${target}`);
+	const href = toInternalFileHref(target);
+	assert.ok(href?.startsWith("file://"), `expected internal href: ${target}`);
+	assert.equal(filePathFromHref(href), normalized);
+}
+
+const externalTargets = [
+	"https://example.com/docs/readme.md",
+	"http://example.com/file.json",
+	"mailto:user@example.com",
+	"#section",
+	"/docs/getting-started",
+	"//example.com/docs/file.md",
+];
+
+for (const target of externalTargets) {
+	assert.equal(normalizeLocalFilePath(target), null, `expected external target: ${target}`);
+	assert.equal(toInternalFileHref(target), null);
+}
+
+assert.equal(normalizeLocalFilePath("/C:/Users/Test/file.ts:9"), "C:/Users/Test/file.ts:9");
+assert.equal(stripFileLocation("C:/Users/Test/file.ts:9:3"), "C:/Users/Test/file.ts");
+assert.equal(stripFileLocation("C:/Users/Test/file.ts"), "C:/Users/Test/file.ts");
+assert.equal(
+	filePathFromHref("file://C%3A%2FUsers%2FTest%2FMy%20File.ts%3A9"),
+	"C:/Users/Test/My File.ts:9",
+);
+
+const markdownTargets = [
+	"[settings.json](C:/Users/Administrator/.pi/agent/settings.json)",
+	"[App.tsx](/C:/Users/Administrator/project/src/App.tsx:392)",
+	"[app.py](/home/user/project/app.py:12:4)",
+	"[README](../docs/README.md)",
+];
+const markdownParser = unified().use(remarkParse);
+for (const markdown of markdownTargets) {
+	const tree = markdownParser.parse(markdown) as any;
+	const link = tree.children[0]?.children[0];
+	assert.equal(link?.type, "link", `expected Markdown link node: ${markdown}`);
+	assert.ok(toInternalFileHref(link.url), `expected Markdown file target: ${link?.url}`);
+}
+
+console.log(`file link tests passed (${localTargets.length + externalTargets.length + 8} assertions)`);


### PR DESCRIPTION
## Summary

- recognize explicit Markdown links whose destinations are local Windows, Unix, or project-relative file paths
- keep local links interactive after `react-markdown` URL sanitization, strip `:line[:column]` before opening, and copy the original path on right click
- make the built-in `pi-deck-todo` and `pi-deck-plan-todos` widgets inherit the configured interface font while preserving the business/monospace font for other extension widgets

## Problem

Pi agents commonly emit links such as:

```md
[settings.json](C:/Users/example/.pi/agent/settings.json)
[App.tsx](/C:/project/src/App.tsx:392)
```

PiDeck rendered these as green anchors, but `react-markdown` rejected the Windows drive prefix as a URL scheme and produced an empty `href`. Hovering therefore showed PiDeck's own `index.html`; clicking did nothing and the file path could not be copied.

Extension widget content also used `--font-family-business` unconditionally. As a result, Todo widget titles followed a custom interface font but their task lines did not.

## Implementation

- normalize recognized local targets to PiDeck's internal encoded `file://` representation before URL sanitization
- keep HTTP(S), mail, fragment, and protocol-relative links unchanged
- remove editor-style line/column suffixes only when opening the file
- expose `widgetKey` as a data attribute and scope the interface-font override to the two built-in Todo widgets

## Verification

- `npm run typecheck`
- `npm run build:fast`
- `npx tsx tests/file-links.test.ts` (23 assertions covering path formats, external-link exclusions, line/column suffixes, encoded paths, and actual Markdown parsing)
