### PR TITLE
fix(titlebar): 系统标题栏模式下补充左右侧边栏开关入口

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -6388,6 +6388,18 @@ export function App() {
           </button>
         </div>
       )}
+      {/* 系统标题栏模式 + 列表已折叠：侧栏内容整体隐藏，需浮动按钮恢复 */}
+      {settings.useNativeTitleBar && listCollapsed && (
+        <button
+          type="button"
+          className="list-toggle-native floating"
+          title={t("app.expandList")}
+          aria-label={t("app.expandList")}
+          onClick={toggleListCollapsed}
+        >
+          <PanelLeft size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
+      )}
       <aside
         className="chat-list-pane v3-braun"
       >
@@ -6397,6 +6409,18 @@ export function App() {
             {/* 官方 π 标 + 字标；agent 启停时通过 replayToken 重播动画 */}
             <BrandLockup replayToken={brandLogoReplayToken} />
           </div>
+          {/* 系统标题栏模式下左上角没有 window-controls-left，折叠入口放到工具栏 */}
+          {settings.useNativeTitleBar && (
+            <button
+              type="button"
+              className="list-toggle-native"
+              title={t("app.collapseList")}
+              aria-label={t("app.collapseList")}
+              onClick={toggleListCollapsed}
+            >
+              <PanelLeft size={14} strokeWidth={2} aria-hidden="true" />
+            </button>
+          )}
         </div>
         <button
           className="collapse-button list-collapse"
@@ -7417,6 +7441,18 @@ export function App() {
                 </div>
               </div>
               </div>
+              {/* 系统标题栏模式下右上角没有 window-controls，右侧边栏开关放到会话头部 */}
+              {settings.useNativeTitleBar && (
+                <button
+                  type="button"
+                  className={`header-drawer-toggle${drawer && !drawerCollapsed ? " active" : ""}`}
+                  title={drawer && !drawerCollapsed ? t("app.collapseDrawer") : t("app.expandDrawer")}
+                  aria-label={drawer && !drawerCollapsed ? t("app.collapseDrawer") : t("app.expandDrawer")}
+                  onClick={toggleRightDrawer}
+                >
+                  <PanelRight size={14} strokeWidth={2} aria-hidden="true" />
+                </button>
+              )}
             </>
           </div>
         </header>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3064,6 +3064,78 @@ body.is-terminal-resizing {
   background: transparent;
 }
 
+/* 系统标题栏模式下的左侧列表开关：样式对齐 header-drawer-toggle */
+.list-toggle-native {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  width: 30px;
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-panel);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-md);
+  padding: 0;
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    box-shadow 0.15s,
+    color 0.15s;
+}
+.list-toggle-native:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-border-strong);
+  box-shadow: 0 1px 3px
+    color-mix(in srgb, var(--color-text-primary) 8%, transparent);
+}
+.list-toggle-native:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+/* 折叠后的浮动恢复入口：避开左侧 14px 折叠条 */
+.list-toggle-native.floating {
+  position: fixed;
+  top: 12px;
+  left: 22px;
+  z-index: 920;
+}
+
+/* 系统标题栏模式下的右侧边栏开关：宽高对齐 session-combo-trigger */
+.header-drawer-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  min-width: 90px;
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-panel);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-md);
+  padding: 0;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    box-shadow 0.15s,
+    color 0.15s;
+}
+.header-drawer-toggle:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-border-strong);
+  box-shadow: 0 1px 3px
+    color-mix(in srgb, var(--color-text-primary) 8%, transparent);
+}
+.header-drawer-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+.header-drawer-toggle.active {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
 /* ---- Session combo (合并新会话 + 下拉,类似 branch-select) ---- */
 .session-combo,
 .file-action-combo {


### PR DESCRIPTION
## 变更内容

开启系统标题栏（useNativeTitleBar）时，自定义标题栏的 window-controls 不渲染，导致：
- 右侧边栏（文件/Git/浏览器）关闭后没有任何重新打开的入口
- 左侧项目列表既无法折叠，折叠后也无法恢复（原有的 list-collapse 按钮一直 display:none）

本次修改仅在系统标题栏模式下新增入口，自定义标题栏模式行为不变：

- 右侧边栏：会话头部右侧操作区（"新建"旁）新增展开/折叠按钮，宽高对齐 session-combo-trigger，复用现有 toggleRightDrawer 逻辑
- 左侧列表：展开态在列表工具栏 Logo 旁新增折叠按钮；折叠态在左上角新增浮动恢复按钮，复用 toggleListCollapsed

样式沿用语义 token 与现有控件风格（26px 高、方圆角、hover/active/focus-visible 态齐全），文案复用现有 i18n key，未新增依赖。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 代码重构
- [ ] 文档更新

## 测试情况

- [x] 本地已测试
- [x] 已自测通过（npm run typecheck 通过；两种标题栏模式下入口显示/切换正常）

## 关联 Issue

无
