### PR TITLE
Add MiniMax endpoints for auth-only model discovery

### DIFF
--- a/src/renderer/src/config/providerHeaders.ts
+++ b/src/renderer/src/config/providerHeaders.ts
@@ -109,4 +109,6 @@ export const KNOWN_PROVIDER_ENDPOINTS: Record<
 	"huggingface": { baseUrl: "https://api-inference.huggingface.co/v1", apiType: "openai-completions" },
 	"opencode": { baseUrl: "https://opencode.ai/zen/v1", apiType: "openai-completions" },
 	"opencode-go": { baseUrl: "https://opencode.ai/zen/go/v1", apiType: "openai-completions" },
+	"minimax": { baseUrl: "https://api.minimax.io/v1", apiType: "openai-completions" },
+	"minimax-cn": { baseUrl: "https://api.minimaxi.com/v1", apiType: "openai-completions" },
 };


### PR DESCRIPTION
Reason: Auth-only model discovery was missing the MiniMax provider endpoints, forcing users to edit models.json by hand.

MiniMax and MiniMax (China) already ship as authentication presets, but `KNOWN_PROVIDER_ENDPOINTS` had no entry for either. When a provider only has an API key in auth.json and no models yet, the settings screen looks up its base URL in `KNOWN_PROVIDER_ENDPOINTS` to auto-discover the model list. Without an entry, that lookup returned nothing for MiniMax, so users had to configure `models.json` manually.

This adds the two missing entries so discovery works out of the box:

- `minimax` → `https://api.minimax.io/v1`
- `minimax-cn` → `https://api.minimaxi.com/v1`

Both use the `openai-completions` API type, matching their OpenAI-compatible `/v1` endpoints.

Checks:
- Transpiled `src/renderer/src/config/providerHeaders.ts` with the TypeScript compiler in a sandbox and asserted both new entries resolve to the expected base URLs and API type.
