### PR TITLE
feat(config): visual editor for custom request body + pi-deck-body-override extension

### DIFF
--- a/resources/extensions/pi-deck-body-override.ts
+++ b/resources/extensions/pi-deck-body-override.ts
@@ -1,0 +1,143 @@
+/**
+ * PiDeck Body Override Extension
+ *
+ * pi 的 models.json schema 没有"自定义请求体"字段,但 TypeBox 校验默认放行未知
+ * 字段。PiDeck 的可视化表单把每个 provider / model 的
+ *   body     —— 内联 JSON 对象
+ *   bodyFile —— 本地 JSON 文件路径(相对路径基于 ~/.pi/agent/)
+ * 直接写进 models.json。本扩展用 before_provider_request 钩子(payload 构建后、
+ * 发送前触发,返回值整体替换请求体)把这些字段深合并进请求体。
+ *
+ * models.json 示例:
+ * {
+ *   "providers": {
+ *     "Kimi Code": {
+ *       "body": { "temperature": 0.6 },          // provider 级内联
+ *       "bodyFile": "C:/extra/kimi-body.json",   // provider 级文件
+ *       "models": [
+ *         { "id": "k3", ..., "body": { "top_p": 0.9 }, "bodyFile": "./k3.json" }
+ *       ]
+ *     }
+ *   }
+ * }
+ *
+ * 合并顺序:provider.body → provider.bodyFile → model.body → model.bodyFile,
+ * 后者覆盖前者。深合并:嵌套对象递归合并,数组与标量整体替换。
+ * 每次请求按 mtime 重读 models.json / bodyFile,PiDeck 保存后即时生效。
+ *
+ * 注意:payload 是该 provider API 类型序列化后的格式(如 anthropic-messages),
+ * 要写的字段必须匹配对应 API 的请求体结构。
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const AGENT_DIR = path.join(os.homedir(), ".pi", "agent");
+const MODELS_JSON = path.join(AGENT_DIR, "models.json");
+
+type JsonObject = Record<string, unknown>;
+
+interface BodyTarget {
+	body?: unknown;
+	bodyFile?: unknown;
+}
+
+interface ModelsFile {
+	providers?: Record<string, BodyTarget & { models?: BodyTarget & { id?: unknown }[] }>;
+}
+
+let cachedModels: ModelsFile | undefined;
+let cachedMtimeMs = -1;
+let lastError: string | undefined;
+
+function readJsonFile(filePath: string): JsonObject | undefined {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf8")) as JsonObject;
+	} catch (err) {
+		lastError = `${path.basename(filePath)}: ${err instanceof Error ? err.message : String(err)}`;
+		return undefined;
+	}
+}
+
+function loadModelsFile(): ModelsFile | undefined {
+	let mtimeMs = -1;
+	try {
+		mtimeMs = fs.statSync(MODELS_JSON).mtimeMs;
+	} catch {
+		cachedModels = undefined;
+		cachedMtimeMs = -1;
+		return undefined;
+	}
+	if (mtimeMs === cachedMtimeMs) return cachedModels;
+	const parsed = readJsonFile(MODELS_JSON);
+	cachedModels = parsed as ModelsFile | undefined;
+	cachedMtimeMs = mtimeMs;
+	return cachedModels;
+}
+
+function isPlainObject(v: unknown): v is JsonObject {
+	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** body 必须是对象;非法值(字符串/数组等)忽略并报一次错。 */
+function asBody(v: unknown, where: string): JsonObject | undefined {
+	if (v === undefined || v === null) return undefined;
+	if (!isPlainObject(v)) {
+		lastError = `${where}: body 必须是 JSON 对象`;
+		return undefined;
+	}
+	return v;
+}
+
+function loadBodyFile(target: BodyTarget): JsonObject | undefined {
+	if (typeof target.bodyFile !== "string" || !target.bodyFile.trim()) return undefined;
+	const p = path.isAbsolute(target.bodyFile)
+		? target.bodyFile
+		: path.join(AGENT_DIR, target.bodyFile);
+	return readJsonFile(p);
+}
+
+function deepMerge(base: unknown, extra: unknown): unknown {
+	if (isPlainObject(base) && isPlainObject(extra)) {
+		const out: JsonObject = { ...base };
+		for (const [k, v] of Object.entries(extra)) {
+			out[k] = k in out ? deepMerge(out[k], v) : v;
+		}
+		return out;
+	}
+	return extra; // 数组 / 标量 / null:整体替换
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.on("before_provider_request", (event, ctx) => {
+		lastError = undefined;
+		const config = loadModelsFile();
+		if (!config?.providers || !ctx.model) return undefined;
+
+		const provider = config.providers[ctx.model.provider];
+		if (!provider) return undefined;
+
+		const modelEntry = Array.isArray(provider.models)
+			? provider.models.find((m) => m && m.id === ctx.model!.id)
+			: undefined;
+
+		const layers: (JsonObject | undefined)[] = [
+			asBody(provider.body, `${ctx.model.provider}.body`),
+			loadBodyFile(provider),
+			modelEntry ? asBody(modelEntry.body, `${ctx.model.provider}/${ctx.model.id}.body`) : undefined,
+			modelEntry ? loadBodyFile(modelEntry) : undefined,
+		];
+
+		let payload = event.payload;
+		let touched = false;
+		for (const layer of layers) {
+			if (!layer) continue;
+			payload = deepMerge(payload, layer);
+			touched = true;
+		}
+		if (lastError) ctx.ui.notify(`body-override: ${lastError}`, "warning");
+		return touched ? payload : undefined;
+	});
+}

--- a/src/renderer/src/config/ModelsTab.tsx
+++ b/src/renderer/src/config/ModelsTab.tsx
@@ -23,6 +23,8 @@ const KNOWN_PROVIDER_FIELDS = new Set([
 	"modelOverrides",
 	"compat",
 	"oauth",
+	"body",
+	"bodyFile",
 ]);
 const KNOWN_MODEL_FIELDS = new Set([
 	"id",
@@ -37,7 +39,78 @@ const KNOWN_MODEL_FIELDS = new Set([
 	"maxTokens",
 	"headers",
 	"compat",
+	"body",
+	"bodyFile",
 ]);
+
+// 自定义请求体编辑器：内联 JSON（body）+ 本地文件路径（bodyFile）。
+// body / bodyFile 不是 pi models.json 的官方字段，但 pi 的 TypeBox 校验放行未知
+// 字段；保存后由 pi-deck-body-override 扩展在 before_provider_request 时深合并进
+// 请求体。编辑时用本地文本状态，只有解析为合法 JSON 对象才提交，避免污染表单数据。
+function BodyOverrideFields(props: {
+	body?: Record<string, unknown>;
+	bodyFile?: string;
+	compact?: boolean;
+	onChangeBody: (value: Record<string, unknown> | undefined) => void;
+	onChangeBodyFile: (value: string | undefined) => void;
+}) {
+	const serialize = (value: Record<string, unknown> | undefined) =>
+		value ? JSON.stringify(value, null, 2) : "";
+	const [text, setText] = useState(() => serialize(props.body));
+	const [invalid, setInvalid] = useState(false);
+	// 外部 body 变化（非本次提交引起）时才重置本地文本，避免打字过程中被重新格式化
+	const bodyKey = JSON.stringify(props.body ?? null);
+	const lastCommittedRef = useRef(bodyKey);
+	useEffect(() => {
+		if (bodyKey !== lastCommittedRef.current) {
+			lastCommittedRef.current = bodyKey;
+			setText(serialize(props.body));
+			setInvalid(false);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [bodyKey]);
+	const handleText = (value: string) => {
+		setText(value);
+		const trimmed = value.trim();
+		if (!trimmed) {
+			setInvalid(false);
+			lastCommittedRef.current = "null";
+			props.onChangeBody(undefined);
+			return;
+		}
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				setInvalid(false);
+				lastCommittedRef.current = JSON.stringify(parsed);
+				props.onChangeBody(parsed);
+			} else {
+				setInvalid(true);
+			}
+		} catch {
+			setInvalid(true);
+		}
+	};
+	return (
+		<div className="config-body-override">
+			<textarea
+				className={`config-body-textarea${invalid ? " invalid" : ""}`}
+				value={text}
+				onChange={(e) => handleText(e.target.value)}
+				placeholder='{ "temperature": 0.6 }'
+				rows={props.compact ? 2 : 4}
+				spellCheck={false}
+			/>
+			{invalid && <span className="config-body-invalid">{t("config.bodyOverrideInvalid")}</span>}
+			<input
+				value={props.bodyFile ?? ""}
+				onChange={(e) => props.onChangeBodyFile(e.target.value.trim() || undefined)}
+				placeholder={t("config.bodyOverrideFilePlaceholder")}
+			/>
+			<span className="config-field-hint">{t("config.bodyOverrideHint")}</span>
+		</div>
+	);
+}
 
 function FetchedModelCombobox(props: {
 	models: FetchedModel[];
@@ -789,6 +862,16 @@ export function ModelsTab(props: {
 											</div>
 										</div>
 
+										<div className="config-form-row">
+											<label>{t("config.bodyOverride")}</label>
+											<BodyOverrideFields
+												body={provider.body}
+												bodyFile={provider.bodyFile}
+												onChangeBody={(value) => props.onChangeProvider(name, "body", value)}
+												onChangeBodyFile={(value) => props.onChangeProvider(name, "bodyFile", value)}
+											/>
+										</div>
+
 										{(providerComplexFields.length > 0 || providerAdvancedFields.length > 0) && (
 											<div className="config-advanced-preserved">
 												<strong>{t("config.advancedPreservedTitle")}</strong>
@@ -1019,6 +1102,15 @@ export function ModelsTab(props: {
 														</a>
 													</div>
 												)}
+												<div className="config-model-body-override">
+													<BodyOverrideFields
+														compact
+														body={m.body}
+														bodyFile={m.bodyFile}
+														onChangeBody={(value) => props.onUpdateModel(name, i, "body", value)}
+														onChangeBodyFile={(value) => props.onUpdateModel(name, i, "bodyFile", value)}
+													/>
+												</div>
 											</div>
 											);
 										})}

--- a/src/renderer/src/config/configTypes.ts
+++ b/src/renderer/src/config/configTypes.ts
@@ -18,6 +18,10 @@ export type ModelItem = {
 	input?: string[];
 	contextWindow?: number;
 	maxTokens?: number;
+	/** 自定义请求体：内联 JSON，由 pi-deck-body-override 扩展深合并进每次请求 */
+	body?: Record<string, unknown>;
+	/** 自定义请求体：本地 JSON 文件路径（相对路径基于 ~/.pi/agent/） */
+	bodyFile?: string;
 	[key: string]: unknown;
 };
 
@@ -27,6 +31,10 @@ export type ProviderConfig = {
 	apiKey?: string;
 	compat?: ProviderCompat;
 	models: ModelItem[];
+	/** 自定义请求体：内联 JSON，模型级同名字段优先级更高 */
+	body?: Record<string, unknown>;
+	/** 自定义请求体：本地 JSON 文件路径（相对路径基于 ~/.pi/agent/） */
+	bodyFile?: string;
 	[key: string]: unknown;
 };
 

--- a/src/renderer/src/i18n.ts
+++ b/src/renderer/src/i18n.ts
@@ -734,6 +734,10 @@ const zhCN = {
   "config.saveSelectedModels": "保存所选模型",
   "config.addSkill": "创建 Skill",
   "config.advancedPreservedTitle": "高级字段已保留",
+  "config.bodyOverride": "自定义请求体",
+  "config.bodyOverrideHint": "内联 JSON 与 bodyFile 按 供应商→模型 顺序深合并进每次请求（由 pi-deck-body-override 扩展应用）；字段需匹配当前 API 类型的请求体格式。",
+  "config.bodyOverrideFilePlaceholder": "可选：本地 JSON 文件路径（bodyFile）",
+  "config.bodyOverrideInvalid": "JSON 无效，未应用",
   "config.advancedPreservedProvider":
     "{fields} 不会被可视化表单丢弃；复杂结构请在源文件中编辑。",
   "config.advancedPreservedModel": "高级字段已保留：{fields}。",
@@ -2487,6 +2491,10 @@ const enUS: Record<TranslationKey, string> = {
   "config.saveSelectedModels": "Save selected models",
   "config.addSkill": "Create Skill",
   "config.advancedPreservedTitle": "Advanced fields preserved",
+  "config.bodyOverride": "Custom request body",
+  "config.bodyOverrideHint": "Inline JSON and bodyFile are deep-merged into every request in provider→model order (applied by the pi-deck-body-override extension); fields must match the current API type's request body format.",
+  "config.bodyOverrideFilePlaceholder": "Optional: local JSON file path (bodyFile)",
+  "config.bodyOverrideInvalid": "Invalid JSON — not applied",
   "config.advancedPreservedProvider":
     "{fields} will not be dropped by the visual form. Edit complex structures in Raw Files.",
   "config.advancedPreservedModel": "Advanced fields preserved: {fields}.",

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -21624,3 +21624,10 @@ body.is-git-pane-resizing, body.is-git-pane-resizing * { cursor: row-resize !imp
 }
 
 
+.config-body-override{display:flex;flex-direction:column;gap:6px;min-width:0}
+.config-body-textarea{border:1px solid var(--color-border-subtle);border-radius:var(--radius-sm);width:100%;min-height:56px;box-sizing:border-box;font-family:var(--font-mono,monospace);font-size:var(--font-size-control);background:var(--color-bg-panel);color:var(--color-text-primary);padding:8px 12px;resize:vertical;transition:border-color .15s}
+.config-body-textarea:focus{outline:none;border-color:var(--color-accent,#4f8cff)}
+.config-body-textarea.invalid{border-color:#e5534b}
+.config-body-invalid{font-size:var(--font-size-caption);color:#e5534b}
+.config-model-body-override{grid-column:1/-1;padding:2px 0 6px}
+.config-model-body-override .config-body-textarea{min-height:40px}


### PR DESCRIPTION
## 背景

pi 的 `models.json` 支持自定义 `headers`，但没有请求体（body）字段。一些供应商/代理需要注入额外请求参数（如 `temperature`、`top_p`、`metadata` 或厂商私有字段），目前只能手写扩展。

pi 本身提供了 `before_provider_request` 钩子：provider payload 序列化后、发送前触发，handler 返回值可整体替换请求体，且 pi 的 TypeBox 校验会放行 `models.json` 中的未知字段。基于这两点可以实现「可视化编辑请求体」而无需改动 pi。

## 改动内容

**1. 新增内置扩展 `resources/extensions/pi-deck-body-override.ts`**

- 读取 `models.json` 中 provider / model 级的 `body`（内联 JSON 对象）与 `bodyFile`（本地 JSON 文件路径，相对路径基于 `~/.pi/agent/`）；
- 在 `before_provider_request` 时按 `provider.body → provider.bodyFile → model.body → model.bodyFile` 顺序**深合并**进请求体（嵌套对象递归合并，数组/标量整体替换）；
- 按 mtime 重读文件，PiDeck 保存配置后下一个请求即生效，无需重启会话；
- 非法配置通过 `ctx.ui.notify` 告警，不静默失败。

**2. 供应商配置表单新增「自定义请求体」编辑器（`ModelsTab.tsx`）**

- provider 级（兼容性设置下方）+ 每个模型行内各一个编辑器：JSON 文本框（实时校验，非法 JSON 标红且不提交，避免污染表单数据）+ bodyFile 路径输入；
- `body` / `bodyFile` 加入 `KNOWN_PROVIDER_FIELDS` / `KNOWN_MODEL_FIELDS`，不再显示在「高级字段已保留」提示中；
- 编辑结果经现有 `onChangeProvider` / `onUpdateModel` → `normalizeModelsForPi`（展开符保留未知字段）链路原样写入 `models.json`。

**3. 配套改动**

- `configTypes.ts`：`ModelItem` / `ProviderConfig` 增加 `body` / `bodyFile` 显式类型；
- `i18n.ts`：新增 `config.bodyOverride*` 中英文案（避开已被连接测试占用的 `config.requestBody` key）；
- `styles.css`：编辑器样式。

## 注意点

- payload 是该 provider API 类型序列化后的格式（如 anthropic-messages），body 里要写的字段需匹配对应 API 的请求体结构，编辑器 hint 文案中已说明；
- 依赖 pi TypeBox 校验放行未知字段这一行为，若 pi 未来改为严格校验需要另寻存放位置。

## 测试

- `npm run typecheck` / `npm run build` 通过；
- 扩展逻辑用 mock 做过功能测试：深合并、provider/model 分层、未知 provider 不触碰、模型作用域正确；
- 已在本机安装版上实测：UI 编辑 → 保存 → models.json 落盘 → 扩展合并进请求体，全链路可用。

## 截图说明

供应商表单「兼容性」下方新增「自定义请求体」编辑区（JSON + bodyFile 路径），模型行内为紧凑版。