### PR TITLE
fix: respect allowOther in ask question select

### DIFF
--- a/src/main/pi/AgentManager.ts
+++ b/src/main/pi/AgentManager.ts
@@ -3437,7 +3437,7 @@ export class AgentManager {
 					options: typed.options as string[] | undefined,
 					placeholder: typed.placeholder as string | undefined,
 					prefill: typed.prefill as string | undefined,
-					allowOther: typed.allowOther === true,
+					allowOther: typed.allowOther !== false,
 			  };
 
 		// 记录 pending UI 请求，用于 abort 时自动 cancel

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -73,6 +73,7 @@ import {
   getComposerEnterIntent,
   getComposerHistoryLineBounds,
   isYesNoConfirmOptions,
+  shouldShowCustomSelectInput,
   parseArgumentHint,
   resolveComposerHistoryDraft,
   translateBuiltinPromptDescription,
@@ -8247,48 +8248,50 @@ export function App() {
                         </button>
                       );
                     })}
-                    {/* 仅普通 select 提供自定义输入；confirm/是否题不展示 */}
-                    <div className="ask-inline-bar-custom-input">
-                      <input
-                        id="ask-inline-bar-custom-field"
-                        className="ask-inline-bar-custom-field"
-                        placeholder={t("ask.customPlaceholder")}
-                        autoFocus
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
-                            e.preventDefault();
+                    {/* 只有 allowOther 未被显式禁止的普通 select 才提供自定义输入；confirm/是否题不展示。 */}
+                    {shouldShowCustomSelectInput(activeUiAsk.allowOther, isYesNoConfirm) && (
+                      <div className="ask-inline-bar-custom-input">
+                        <input
+                          id="ask-inline-bar-custom-field"
+                          className="ask-inline-bar-custom-field"
+                          placeholder={t("ask.customPlaceholder")}
+                          autoFocus
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              const el = document.getElementById("ask-inline-bar-custom-field") as HTMLInputElement | null;
+                              const val = el?.value?.trim() ?? "";
+                              if (val && activeUiAsk.requestId && activeAgentId) {
+                                // 先缓存真实自定义文本，再回 OTHER_LABEL 触发扩展第二步 input。
+                                // 顺序不能反：onUiRequest(input) 可能很快到达，必须先写 pending。
+                                pendingCustomInputRef.current = val;
+                                dismissAsk();
+                                api.agents.sendUiResponse(activeAgentId, activeUiAsk.requestId, {
+                                  value: "✎ 自行输入...",
+                                });
+                              }
+                            }
+                          }}
+                        />
+                        <button
+                          type="button"
+                          className="ask-inline-bar-submit-btn"
+                          onClick={() => {
                             const el = document.getElementById("ask-inline-bar-custom-field") as HTMLInputElement | null;
                             const val = el?.value?.trim() ?? "";
                             if (val && activeUiAsk.requestId && activeAgentId) {
-                              // 先缓存真实自定义文本，再回 OTHER_LABEL 触发扩展第二步 input。
-                              // 顺序不能反：onUiRequest(input) 可能很快到达，必须先写 pending。
                               pendingCustomInputRef.current = val;
                               dismissAsk();
                               api.agents.sendUiResponse(activeAgentId, activeUiAsk.requestId, {
                                 value: "✎ 自行输入...",
                               });
                             }
-                          }
-                        }}
-                      />
-                      <button
-                        type="button"
-                        className="ask-inline-bar-submit-btn"
-                        onClick={() => {
-                          const el = document.getElementById("ask-inline-bar-custom-field") as HTMLInputElement | null;
-                          const val = el?.value?.trim() ?? "";
-                          if (val && activeUiAsk.requestId && activeAgentId) {
-                            pendingCustomInputRef.current = val;
-                            dismissAsk();
-                            api.agents.sendUiResponse(activeAgentId, activeUiAsk.requestId, {
-                              value: "✎ 自行输入...",
-                            });
-                          }
-                        }}
-                      >
-                        {t("common.submit")}
-                      </button>
-                    </div>
+                          }}
+                        >
+                          {t("common.submit")}
+                        </button>
+                      </div>
+                    )}
                   </div>
                   )
                 ) : activeUiAsk.method === "input" || activeUiAsk.method === "editor" ? (

--- a/src/renderer/src/composerBehavior.ts
+++ b/src/renderer/src/composerBehavior.ts
@@ -322,3 +322,17 @@ export function isYesNoConfirmOptions(
 	);
 	return kinds.includes("yes") && kinds.includes("no") && !kinds.includes("other");
 }
+
+/**
+ * 判断普通 select 是否应该显示桌面端的自定义输入入口。
+ *
+ * allowOther 在 Extension UI 请求中是可选字段：只有显式 false 才禁止自定义答案，
+ * 这样既保留标准 select 请求的默认行为，也能尊重 ask_question 的 allowOther:false。
+ * 是/否确认题即使允许自定义，也必须保持为两个固定选项。
+ */
+export function shouldShowCustomSelectInput(
+	allowOther: boolean | undefined,
+	isYesNoConfirm: boolean,
+): boolean {
+	return allowOther !== false && !isYesNoConfirm;
+}

--- a/tests/composerBehavior.test.mjs
+++ b/tests/composerBehavior.test.mjs
@@ -148,3 +148,14 @@ test("detects yes/no confirm options and rejects multi-choice selects", () => {
 	assert.equal(isYesNoConfirmOptions(["是"]), false);
 	assert.equal(isYesNoConfirmOptions(["是", "否", "其它"]), false);
 });
+
+test("only hides custom select input when allowOther is explicitly false", () => {
+	const { shouldShowCustomSelectInput } = loadComposerBehaviorModule();
+
+	assert.equal(shouldShowCustomSelectInput(false, false), false);
+	assert.equal(shouldShowCustomSelectInput(true, false), true);
+	// Legacy/native select requests may omit allowOther; the default remains enabled.
+	assert.equal(shouldShowCustomSelectInput(undefined, false), true);
+	// Confirm-style select must stay constrained to its yes/no options.
+	assert.equal(shouldShowCustomSelectInput(true, true), false);
+});


### PR DESCRIPTION
## Problem
When the built-in `pideckaskquestion` extension sent a `select` question with `allowOther: false`, PiDeck still rendered the custom input field. Submitting custom text sent the `✎ 自行输入...` sentinel even though it was not a valid option, so the extension treated the response as cancelled.

## Root cause
The renderer's regular single-question select path rendered the custom input whenever options existed and ignored `allowOther`. In addition, the main process normalized an omitted `allowOther` to `false`, conflicting with the extension contract that only an explicit `false` disables custom input.

## Changes
- Preserve the default-allowed behavior by treating only explicit `allowOther: false` as disabled.
- Hide the regular select custom input when `allowOther` is false.
- Keep yes/no confirmation selects constrained to their fixed options.
- Add regression coverage for explicit false, true, omitted, and yes/no cases.

## Verification
- `node --test tests/composerBehavior.test.mjs`
- `node --test tests/extensionNameMatches.test.mjs tests/browserApiFallback.test.mjs`
- `npm run typecheck`
- `npm run build`
