### PR TITLE
fix: hide disallowed ask question input

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8072,10 +8072,13 @@ export function App() {
               : isPlanReviseEditor
                 ? rawTitle.replace(PLAN_REVISE_MARKER, "").trim()
                 : (rawTitle || t("ask.pending"));
-            const isSelectWithOptions =
+            const hasCustomSelectOption =
               activeUiAsk.method === "select" &&
               Array.isArray(activeUiAsk.options) &&
-              activeUiAsk.options.length > 0;
+              activeUiAsk.options.some((opt) => {
+                const label = typeof opt === "string" ? opt : String((opt as any).label ?? opt);
+                return label.startsWith("✎");
+              });
             // 扩展 confirm 实际走 select([是,否])：识别后只渲染是否按钮，不给自定义输入。
             const isYesNoConfirm =
               activeUiAsk.method === "confirm" ||
@@ -8247,13 +8250,13 @@ export function App() {
                         </button>
                       );
                     })}
-                    {/* 仅普通 select 提供自定义输入；confirm/是否题不展示 */}
-                    <div className="ask-inline-bar-custom-input">
+                    {/* 扩展仅在允许自定义时加入「✎ 自行输入...」选项；无该选项时隐藏输入框。 */}
+                    <div className="ask-inline-bar-custom-input" hidden={!hasCustomSelectOption || isYesNoConfirm}>
                       <input
                         id="ask-inline-bar-custom-field"
                         className="ask-inline-bar-custom-field"
                         placeholder={t("ask.customPlaceholder")}
-                        autoFocus
+                        autoFocus={hasCustomSelectOption && !isYesNoConfirm}
                         onKeyDown={(e) => {
                           if (e.key === "Enter") {
                             e.preventDefault();

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -6839,6 +6839,12 @@ body.ask-bar-active .ask-inline-bar--timeline {
   align-items: center;
   width: 100%;
 }
+/* .ask-inline-bar-custom-input 的 display:flex 优先级与浏览器 [hidden] 默认样式（display:none）相同，
+ * author 样式会覆盖 UA 样式，导致 hidden 属性被 display:flex 盖掉、
+ * 输入框在 allowOther:false 时仍然可见。显式声明 [hidden] 优先级更高的规则修正。 */
+.ask-inline-bar-custom-input[hidden] {
+  display: none;
+}
 .ask-inline-bar-custom-field {
   flex: 1;
   height: var(--control-height-sm);


### PR DESCRIPTION
## Problem
When the built-in `pideckaskquestion` extension sent a `select` question with `allowOther: false`, PiDeck still rendered the custom input field. Submitting custom text then sent `✎ 自行输入...`, which was not a valid option and was treated as cancellation.

## Root cause
`pideckaskquestion` already communicates custom-input permission through its select options: it appends `✎ 自行输入...` only when `allowOther` is enabled. The renderer filtered that sentinel from the visible options but rendered its own custom input unconditionally whenever a select had options.

## Change
Gate the existing custom input block on the sentinel option being present. This keeps the current one-step custom-input flow when allowed and hides the input completely when `allowOther:false`.

## Verification
- `node --test tests/composerBehavior.test.mjs`
- `npm run typecheck`
- `npm run build`
- Manual source-build verification: `allowOther:false` shows only predefined options and returns the selected value.
