### PR TITLE
feat: 系统通知支持会话结束与 AI 询问，点击跳转对应对话

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -44,8 +44,12 @@ function katexWoff2OnlyPlugin(): Plugin {
 }
 
 export default defineConfig({
-  main: {
+main: {
     plugins: [externalizeDepsPlugin()],
+    define: {
+      // 构建标记：npm run dist:win:dev 打包时注入 true，用于隔离 dev 构建的配置目录与 AppUserModelID。
+      __PIDECK_DEV_BUILD__: JSON.stringify(process.env.PIDECK_DEV_BUILD === "1"),
+    },
   },
   preload: {
     plugins: [externalizeDepsPlugin()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,7 +223,6 @@
       "integrity": "sha512-ngdgVGp05lJzUyA+sUzr0MDZ7AMtANcJpwIzq4ZsfpZL5B3S7A4XYfMcU2sECZc3bx3ysOhYcdbbaTjc3ve0WQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.54.0",
         "@algolia/requester-browser-xhr": "5.54.0",
@@ -397,7 +396,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -746,17 +744,6 @@
         "search-insights": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@electron-toolkit/preload": {
@@ -1147,6 +1134,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1168,6 +1156,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1184,6 +1173,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1198,6 +1188,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -5397,21 +5388,12 @@
         "xmlbuilder": ">=11.0.1"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5422,7 +5404,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5816,7 +5797,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5850,7 +5830,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5878,7 +5857,6 @@
       "integrity": "sha512-APAX4ajIOgsmYoUlGe++oNZkSTBgmXYM4maHC0OxC+Yo7xkaKQElV0ATZYCZA7jzrSJX1OBiqEs7mk+ZxXgYqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.20.0",
         "@algolia/client-abtesting": "5.54.0",
@@ -6289,7 +6267,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6808,7 +6785,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6861,7 +6839,6 @@
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7306,7 +7283,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7649,7 +7625,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -7801,7 +7776,6 @@
       "integrity": "sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -7990,6 +7964,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8010,6 +7985,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -8234,7 +8210,6 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -8598,7 +8573,6 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -10075,20 +10049,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -11369,6 +11329,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -11382,7 +11343,6 @@
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -11855,7 +11815,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11977,6 +11936,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11994,6 +11954,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -12255,7 +12216,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12265,7 +12225,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12661,6 +12620,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -13352,6 +13312,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -13556,7 +13517,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13914,7 +13874,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14960,7 +14919,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -15021,7 +14979,6 @@
       "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.38",
         "@vue/compiler-sfc": "3.5.38",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder",
     "dist:win": "node scripts/dist-win.js",
+    "dist:win:dev": "node scripts/dist-win-dev.js",
     "dist:mac": "npm run build && electron-builder --mac dmg zip",
     "dist:linux": "npm run build && electron-builder --linux AppImage deb tar.gz",
     "preview": "electron-vite preview",
@@ -88,6 +89,12 @@
   "build": {
     "appId": "com.ayuayue.pi-desktop",
     "productName": "PiDeck",
+    "protocols": [
+      {
+        "name": "PiDeck Agent Link",
+        "schemes": ["pideck"]
+      }
+    ],
     "asar": true,
     "compression": "maximum",
     "afterPack": "./scripts/after-pack-cleanup.js",
@@ -200,5 +207,14 @@
     "vite": "^7.3.5",
     "vitepress": "^1.6.4",
     "zustand": "^5.0.0"
+  },
+  "allowScripts": {
+    "electron@38.8.6": true,
+    "esbuild@0.25.12": true,
+    "esbuild@0.27.7": true,
+    "esbuild@0.21.5": true,
+    "node-pty@1.1.0": true,
+    "protobufjs@7.6.4": true,
+    "sharp@0.34.5": true
   }
 }

--- a/scripts/dist-win-dev.js
+++ b/scripts/dist-win-dev.js
@@ -1,0 +1,31 @@
+/**
+ * dist:win:dev 包装脚本：构建并打包独立的 Dev 验证版安装包。
+ *
+ * 与正式版（PiDeck）完全隔离，互不影响：
+ * - productName: PiDeckDev → 安装目录 %LOCALAPPDATA%\Programs\PiDeckDev、快捷方式名独立
+ * - appId: com.ayuayue.pi-desktop-dev → 通知中心归属（AppUserModelID）独立
+ * - 配置目录: %APPDATA%\pi-desktop-dev → 与 dev 模式共用，复用现有项目/模型/会话配置
+ *
+ * 注意：dev 与 dev 构建版共享配置目录，同版本单实例锁（instance-locks/0.6.7.lock）互斥，
+ * 运行时两者不能同时开启。
+ */
+const { execSync } = require("node:child_process");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+
+console.log(`[1/3] 构建代码（注入 dev 构建标记）…`);
+execSync("npm run build", {
+	cwd: root,
+	stdio: "inherit",
+	shell: true,
+	env: { ...process.env, PIDECK_DEV_BUILD: "1" },
+});
+
+console.log(`\n[2/3] electron-builder --win nsis …`);
+execSync(
+	`npx electron-builder --win nsis --config.productName=PiDeckDev --config.appId=com.ayuayue.pi-desktop-dev`,
+	{ cwd: root, stdio: "inherit", shell: true },
+);
+
+console.log(`\n[3/3] ✅ Dev 版打包完成！产物在 release/ 目录（PiDeckDev Setup *.exe）`);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,21 +26,26 @@ import {
 	readPetEnabledPreference,
 	readSingleInstancePreference,
 } from "./settings/SettingsStore";
-import { acquireVersionSingleInstance } from "./singleInstance";
+import { acquireVersionSingleInstance, type FocusPayload } from "./singleInstance";
 import type { StartupWindowMode } from "../shared/types";
 // 使用 ?asset 后缀导入图标，electron-vite 会在构建时将其复制到输出目录并提供正确的运行时路径
 // 这解决了打包后 build/ 目录不在 asar 中导致托盘图标丢失的问题
 import iconPath from "../../build/icon.png?asset";
 
+// 构建标记：npm run dist:win:dev 打包时由 vite define 注入 true（构建期替换，非运行时环境变量）。
+declare const __PIDECK_DEV_BUILD__: boolean;
+
+// 开发态（electron-vite dev）或 dev 构建（dist:win:dev）统一使用 -dev 配置目录，
+// 避免与正式版（pi-desktop / PiDeck）的数据、单实例锁和通知归属互相污染。
+const isDevBuild = !app.isPackaged || __PIDECK_DEV_BUILD__;
+
 // 开发态与正式版隔离 userData。
 // 否则 npm run dev 会与已安装的 PiDeck 共用数据/锁，表现为「开发启动被复用到正式版窗口」。
 // 必须在读取 settings / 版本单实例锁之前设置。
-if (!app.isPackaged) {
-	const baseUserData = app.getPath("userData");
-	// 仅在尚未指向 *-dev 时追加，避免重复拼接。
-	if (!/[\\/]pi-desktop-dev$/i.test(baseUserData) && !/dev$/i.test(baseUserData)) {
-		app.setPath("userData", `${baseUserData}-dev`);
-	}
+if (isDevBuild) {
+	// 显式固定为 pi-desktop-dev：dev 构建的 productName 是 PiDeckDev，
+	// 默认 userData 会落在 %APPDATA%\PiDeckDev，必须指回 dev 配置目录以复用现有配置。
+	app.setPath("userData", join(app.getPath("appData"), "pi-desktop-dev"));
 }
 
 // Linux XWayland 兼容层：仅当桌面宠物启用时才强制 ozone-platform=x11（#108，
@@ -59,16 +64,28 @@ if (!electronChromiumSandboxEnabled) {
 	app.commandLine.appendSwitch("no-sandbox");
 }
 
+// Windows 系统通知必须设置 AppUserModelID，否则通知不显示、点击事件不触发。
+// dev 与正式版使用不同 AppID，避免通知中心归属混淆（与 dev userData 隔离思路一致）。
+if (process.platform === "win32") {
+	app.setAppUserModelId(isDevBuild ? "com.ayuayue.pi-desktop-dev" : "com.ayuayue.pi-desktop");
+}
+
+// 注册 pideck:// 自定义协议：系统通知点击（toast activationType="protocol"）通过该协议唤起应用，
+// 唤起实例的 argv 携带 pideck://agent/<agentId> URL，主进程据此跳转对应对话。
+// 运行时注册写入 HKCU 注册表；打包安装时 electron-builder 的 protocols 配置会同步注册。
+app.setAsDefaultProtocolClient("pideck");
+
 // 按「应用版本」隔离的单实例：同版本复用窗口，不同版本可并行。
 // 不用 Electron requestSingleInstanceLock：它按 userData 全局互斥，会导致 0.6.7 与 0.6.8 无法同开。
 // focus 回调稍后挂到 focusMainWindow（定义在文件后部），避免顶层 TDZ。
-let focusExistingWindow: (() => void) | null = null;
+// payload 携带次实例的 argv，可解析「点击系统通知」激活时携带的 agentId。
+let focusExistingWindow: ((payload?: FocusPayload) => void) | null = null;
 const singleInstanceEnabled = readSingleInstancePreference();
 const versionSingleInstance = acquireVersionSingleInstance(
 	singleInstanceEnabled,
 	app.getVersion(),
-	() => {
-		focusExistingWindow?.();
+	(payload) => {
+		focusExistingWindow?.(payload);
 	},
 );
 const gotSingleInstanceLock = versionSingleInstance.isPrimary;
@@ -626,23 +643,55 @@ function focusMainWindow() {
 }
 
 /**
- * 同版本次实例请求聚焦：窗口已在则前置；若窗口尚未创建/已销毁，ready 后重建。
- * 挂到顶层 focusExistingWindow，供版本单实例锁的 .focus 信号调用。
+ * 从 argv 中提取通知激活携带的 agentId。
+ * 支持两种唤起参数格式：
+ * - pideck://agent/<uuid>（toast activationType="protocol" 的协议 URL，主路径）
+ * - pideck-agent:<uuid>（toast activationType="foreground" 的 launch 参数，兜底）
+ * 返回 undefined 表示本次唤起不是通知点击，仅聚焦窗口即可。
  */
-function handleVersionFocusRequest() {
+function extractAgentIdFromArgv(argv?: string[]): string | undefined {
+	if (!argv || argv.length === 0) return undefined;
+	const uuidRe = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+	for (const arg of argv) {
+		const protocolMatch = String(arg).match(new RegExp(`pideck://agent/(${uuidRe})`, "i"));
+		if (protocolMatch) return protocolMatch[1];
+		const legacyMatch = String(arg).match(new RegExp(`pideck-agent:(${uuidRe})`, "i"));
+		if (legacyMatch) return legacyMatch[1];
+	}
+	return undefined;
+}
+
+/**
+ * 同版本次实例请求聚焦：窗口已在则前置；若窗口尚未创建/已销毁，ready 后重建。
+ * 若唤起源自「点击系统通知」（argv 携带 pideck://agent/ 或 pideck-agent:），额外向 renderer
+ * 发送聚焦目标，切换到对应 Agent 对话。挂到顶层 focusExistingWindow，供版本单实例锁调用。
+ */
+function handleVersionFocusRequest(payload?: FocusPayload) {
+	const agentId = extractAgentIdFromArgv(payload?.argv);
+	const activateAgent = () => {
+		if (agentId && mainWindow && !mainWindow.isDestroyed()) {
+			mainWindow.webContents.send(ipcChannels.petFocusAgentTarget, { agentId });
+		}
+	};
 	if (mainWindow && !mainWindow.isDestroyed()) {
 		focusMainWindow();
+		activateAgent();
 		return;
 	}
 	void app.whenReady().then(() => {
 		if (mainWindow && !mainWindow.isDestroyed()) {
 			focusMainWindow();
+			activateAgent();
 			return;
-		}
+	}
 		if (settingsStore) {
-			void createWindow().catch((error) => {
-				void appLogger?.error("app", "Failed to recreate window on version focus request", error);
-			});
+			void createWindow()
+				.then(() => {
+					activateAgent();
+				})
+				.catch((error) => {
+					void appLogger?.error("app", "Failed to recreate window on version focus request", error);
+				});
 		}
 	});
 }
@@ -3848,6 +3897,13 @@ app.whenReady().then(async () => {
 	registerFeishuIpc();
 	await createWindow();
 	setupTray();
+
+	// 冷启动通知唤起：应用未运行时点击系统通知，本进程即为唯一实例（无次实例 .focus 流转），
+	// argv 携带 pideck://agent/<id>，窗口就绪后直接跳转到对应对话（agent 已加载时 renderer 会响应）。
+	const coldStartAgentId = extractAgentIdFromArgv(process.argv);
+	if (coldStartAgentId && mainWindow && !mainWindow.isDestroyed()) {
+		mainWindow.webContents.send(ipcChannels.petFocusAgentTarget, { agentId: coldStartAgentId });
+	}
 
 	void runPostWindowStartupTasks().catch((error) => {
 		void appLogger.warn("app", "Post-window startup tasks failed", error);

--- a/src/main/pi/AgentManager.ts
+++ b/src/main/pi/AgentManager.ts
@@ -156,6 +156,8 @@ export class AgentManager {
 	private readonly pendingUIRequests = new Map<string, Map<string, { method: string; title: string }>>();
 	/** abort 时正在等待 ask_question 响应的 agent，用于在工具结果中覆写 answer 为 null。 */
 	private readonly abortedDuringAsk = new Set<string>();
+	/** 已发送 ask_question 系统通知的 agent；新一轮 run（agent_start）时清除，避免重复通知。 */
+	private readonly notifiedAskAgents = new Set<string>();
 	/** 待处理的项目信任确认请求。key 为 requestId，用于在 Agent 启动前等待用户的信任决策。 */
 	private readonly pendingTrustRequests = new Map<string, { resolve: (choice: ProjectTrustChoice) => void }>();
 	private wslEnvironment: WslEnvironment | null = null;
@@ -3066,6 +3068,7 @@ export class AgentManager {
 			// 1) 清理 recentlyAborted，允许状态机恢复 running
 			// 2) 推进 stream generation，解封流式闸门（唯一合法解封点）
 			this.recentlyAborted.delete(agentId);
+			this.notifiedAskAgents.delete(agentId);
 			this.openAgentStream(agentId);
 			runtime.tab.status = "running";
 			this.activeAssistantMessageIds.delete(agentId);
@@ -3257,7 +3260,7 @@ export class AgentManager {
 				const messages = this.messages.get(agentId) ?? [];
 				const lastMessage = messages[messages.length - 1];
 				if (lastMessage?.role === "assistant") {
-					this.notifySessionEnd(runtime.tab.title);
+					this.notifySessionEnd(agentId, runtime.tab.title);
 				}
 			}
 		}
@@ -3456,6 +3459,13 @@ export class AgentManager {
 		// 通知渲染进程显示交互卡片
 		this.emit(ipcChannels.agentsUiRequest, request);
 		this.scheduleUIRequestTimeout(agentId, requestId, typed.timeout);
+
+		// 对话类 UI 请求（select/confirm/input/editor/batch_ask）发送系统通知，提醒用户 AI 正在等待回答。
+		// 与 ask_question 工具路径共用去重标记（agent_start 时清除），避免同一轮多次提问刷屏。
+		if (!this.notifiedAskAgents.has(agentId)) {
+			this.notifiedAskAgents.add(agentId);
+			this.notifyAskQuestion(agentId, request.title);
+		}
 	}
 
 	/**
@@ -3822,6 +3832,18 @@ export class AgentManager {
 		// pi RPC 返回格式可能为 result.details 嵌套 或 result 顶层（无 details 包装）
 		const askDetails = this.extractAskQuestionDetails(toolName, result, args);
 		const askCard = this.buildAskCard(agentId, askDetails);
+		// ask_question 工具执行完成且尚未回答时，发送系统通知提醒用户（每轮 run 只通知一次，
+		// 去重标记在 agent_start 时清除；abort 场景 tool_execution_end 已被封印拦截，不会误报）。
+		if (
+			toolName === "ask_question" &&
+			status === "done" &&
+			askCard &&
+			askCard.answered === false &&
+			!this.notifiedAskAgents.has(agentId)
+		) {
+			this.notifiedAskAgents.add(agentId);
+			this.notifyAskQuestion(agentId, String(askCard.question ?? ""));
+		}
 		const meta = {
 			status,
 			toolName,
@@ -4587,9 +4609,10 @@ export class AgentManager {
 	/**
 	 * 会话结束时发送系统通知。
 	 * 仅在设置中启用通知且 Electron Notification 可用时触发，
-	 * 通知用户 agent 已完成响应，可以查看结果或继续对话。
+	 * 通知用户 agent 已完成响应，可以查看结果或继续对话；
+	 * 点击通知会聚焦主窗口并切换到对应 Agent 对话。
 	 */
-	private notifySessionEnd(sessionTitle: string) {
+	private notifySessionEnd(agentId: string, sessionTitle: string) {
 		try {
 			const settings = this.settingsStore.get();
 			if (!settings.enableNotifications) return;
@@ -4597,15 +4620,98 @@ export class AgentManager {
 
 			// 使用应用名称作为通知标题，在 Windows/macOS 通知中心中显示为应用标识
 			const appName = app.getName();
+			const body = `${sessionTitle} 已完成响应`;
 			const notification = new Notification({
 				title: appName,
-				body: `${sessionTitle} 已完成响应`,
+				body,
 				silent: false,
+				// 自定义 toast XML：launch 携带 agentId，点击后通过 argv 跳转对应 Agent
+				toastXml: this.buildToastXml(appName, body, agentId),
+			});
+			notification.on("click", () => {
+				this.focusMainWindowForAgent(agentId);
 			});
 			notification.show();
 		} catch {
 			// 通知失败不影响主流程，静默处理
 		}
+	}
+
+	/**
+	 * AI 通过 ask_question 工具询问用户时发送系统通知。
+	 * 仅在设置中启用通知且 Electron Notification 可用时触发；
+	 * 点击通知会聚焦主窗口并切换到对应 Agent 对话。
+	 */
+	private notifyAskQuestion(agentId: string, question: string) {
+		try {
+			const settings = this.settingsStore.get();
+			if (!settings.enableNotifications) return;
+			if (!Notification.isSupported()) return;
+
+			const runtime = this.agents.get(agentId);
+			const sessionTitle = runtime?.tab.title ?? app.getName();
+			// 截断过长的提问内容，避免通知气泡被撑满
+			const questionText = question.length > 60 ? `${question.slice(0, 60)}…` : question;
+			const appName = app.getName();
+			const body = `${sessionTitle} 正在询问：${questionText}`;
+			const notification = new Notification({
+				title: appName,
+				body,
+				silent: false,
+				// 自定义 toast XML：launch 携带 agentId，点击后通过 argv 跳转对应 Agent
+				toastXml: this.buildToastXml(appName, body, agentId),
+			});
+			notification.on("click", () => {
+				this.focusMainWindowForAgent(agentId);
+			});
+			notification.on("failed", (_event, error) => {
+				// Windows 拒绝显示 toast 时触发（show() 本身不抛异常），记 warn 便于排查
+				void this.appLogger?.warn("agent", "Ask notification failed to show", { agentId, error: String(error) });
+			});
+			notification.show();
+		} catch {
+			// 通知失败不影响主流程，静默处理
+		}
+	}
+
+	/**
+	 * 聚焦主窗口并让渲染进程切换到指定 Agent 对话。
+	 * 复用桌面宠物的 onFocusTarget 通道（renderer 已监听并切到对应 project + agent tab）。
+	 */
+	private focusMainWindowForAgent(agentId: string) {
+		try {
+			const win = this.getWindow();
+			if (!win || win.isDestroyed()) {
+				void this.appLogger?.warn("agent", "Notification focus skipped: no main window", { agentId });
+				return;
+			}
+			if (win.isMinimized()) win.restore();
+			if (!win.isVisible()) win.show();
+			win.focus();
+			win.webContents.send(ipcChannels.petFocusAgentTarget, { agentId });
+		} catch (error) {
+			// 聚焦失败不影响主流程，静默处理
+			void this.appLogger?.warn("agent", "Notification focus failed", { agentId, error });
+		}
+	}
+
+	/**
+	 * 生成带 agentId 激活参数的 Windows toast XML。
+	 * 使用 activationType="protocol" + pideck:// 协议 URL：点击通知时 Windows 通过
+	 * 注册表协议关联唤起应用（不依赖 ToastActivatorCLSID / 快捷方式匹配，更可靠），
+	 * 被唤起实例的 argv 携带协议 URL，主实例据此识别要跳转的 Agent。
+	 */
+	private buildToastXml(title: string, body: string, agentId: string): string {
+		const esc = (s: string) =>
+			s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+		return `<toast activationType="protocol" launch="pideck://agent/${agentId}">
+  <visual>
+    <binding template="ToastGeneric">
+      <text>${esc(title)}</text>
+      <text>${esc(body)}</text>
+    </binding>
+  </visual>
+</toast>`;
 	}
 
 	/** 清理 ANSI 转义码，模型思考内容中常见终端颜色序列 */

--- a/src/main/singleInstance.ts
+++ b/src/main/singleInstance.ts
@@ -32,6 +32,17 @@ export type VersionSingleInstanceResult = {
 	dispose: () => void;
 };
 
+/**
+ * 次实例通过 .focus 文件传给主实例的信息。
+ * argv：次实例的完整命令行参数，用于识别「点击系统通知」激活场景
+ * （通知 toast 的 launch 参数会附加到被唤起实例的 argv 中）。
+ */
+export type FocusPayload = {
+	at: number;
+	fromPid: number;
+	argv?: string[];
+};
+
 type LockPayload = {
 	pid: number;
 	version: string;
@@ -120,12 +131,12 @@ function tryClaimLock(lockPath: string, version: string): boolean {
  * 尝试成为当前版本的主实例。
  * @param enabled 设置项 singleInstance；false 时允许多开（不写锁）
  * @param version app.getVersion()
- * @param onFocusRequest 同版本次实例请求前置窗口时回调
+ * @param onFocusRequest 同版本次实例请求前置窗口时回调（携带次实例的 argv，可解析通知激活参数）
  */
 export function acquireVersionSingleInstance(
 	enabled: boolean,
 	version: string,
-	onFocusRequest: () => void,
+	onFocusRequest: (payload: FocusPayload) => void,
 ): VersionSingleInstanceResult {
 	if (!enabled) {
 		return { isPrimary: true, dispose: () => undefined };
@@ -137,11 +148,17 @@ export function acquireVersionSingleInstance(
 	const focusName = basename(focusPath);
 
 	if (!tryClaimLock(lockPath, version)) {
-		// 次实例：通知主实例聚焦后自行退出
+		// 次实例：通知主实例聚焦后自行退出。
+		// 附带完整 argv：通知激活启动的实例 argv 里有 toast launch 参数，
+		// 主实例据此识别要跳转的 agent（Electron 自身无法完成该转发，因为次实例随即退出）。
 		try {
 			writeFileSync(
 				focusPath,
-				JSON.stringify({ at: Date.now(), fromPid: process.pid }),
+				JSON.stringify({
+					at: Date.now(),
+					fromPid: process.pid,
+					argv: process.argv.slice(1),
+				}),
 				"utf8",
 			);
 		} catch {
@@ -153,13 +170,19 @@ export function acquireVersionSingleInstance(
 	const handleFocusSignal = () => {
 		try {
 			if (!existsSync(focusPath)) return;
+			let payload: FocusPayload = { at: Date.now(), fromPid: 0 };
+			try {
+				payload = JSON.parse(readFileSync(focusPath, "utf8")) as FocusPayload;
+			} catch {
+				// 旧格式或损坏时退化为空 payload
+			}
 			// 读完即删，避免重复触发
 			try {
 				unlinkSync(focusPath);
 			} catch {
 				// ignore
 			}
-			onFocusRequest();
+			onFocusRequest(payload);
 		} catch {
 			// ignore
 		}

--- a/src/renderer/src/i18n.ts
+++ b/src/renderer/src/i18n.ts
@@ -1555,7 +1555,7 @@ const zhCN = {
   "settings.detecting": "检测中...",
   "settings.detectEnvironment": "检测环境",
   "settings.enableDesktopProxy": "启用桌面端网络代理",
-  "settings.enableNotifications": "会话结束时发送系统通知",
+  "settings.enableNotifications": "Agent 完成响应或向你提问时发送系统通知",
   "settings.enablePiProxy": "启用 pi agent 代理",
   "settings.enableWebService": "启用 Web 服务",
   "settings.environment": "环境",
@@ -3329,7 +3329,7 @@ const enUS: Record<TranslationKey, string> = {
   "settings.detectEnvironment": "Check environment",
   "settings.enableDesktopProxy": "Enable desktop network proxy",
   "settings.enableNotifications":
-    "Send system notifications when sessions finish",
+    "Send system notifications when agents finish or ask you a question",
   "settings.enablePiProxy": "Enable pi agent proxy",
   "settings.enableWebService": "Enable Web service",
   "settings.environment": "Environment",


### PR DESCRIPTION
## 功能概述

为 PiDeck 增加系统通知功能：Agent 完成响应或向用户发起询问时，发送系统通知；点击通知可置顶主窗口并跳转到对应 Agent 对话。

## 改动内容

### 1. 系统通知
- **会话结束**：Agent 回答完成（`agent_settled` 且最后消息为 assistant）时发送通知
- **AI 询问**：覆盖两条提问路径——`ask_question` 工具（`tool_execution_end`）与扩展 UI 请求（`extension_ui_request` 的 select/confirm/input/editor/batch_ask），任一触发均发通知
- 同一轮 run 只通知一次（`agent_start` 时清除去重标记），避免刷屏

### 2. 点击通知跳转对应对话（Windows 关键实现）
Windows 上通知点击的可靠方案：使用 `activationType="protocol"` + 自定义 `pideck://agent/<agentId>` 协议 URL，绕开不可靠的 foreground 激活与 ToastActivatorCLSID 依赖。

- 注册 `pideck://` 协议（运行时 `setAsDefaultProtocolClient` + electron-builder `protocols` 配置）
- 通知 toast 的 `launch` 携带 `pideck://agent/<id>`
- **应用运行中**：点击通知 → 协议唤起新实例 → 次实例退出前把 `argv` 写入 `.focus` 文件传给主实例 → 主实例解析协议 URL → 置顶窗口 + 发送 `petFocusAgentTarget` 切换到对应 Agent（复用桌面宠物已有的跳转链路）
- **冷启动**：应用未运行时点击通知，本进程即主实例，启动时扫描 `process.argv` 兜底跳转
- 设置 Windows `AppUserModelId`，保证通知归属与点击激活正确

### 3. Dev 独立打包脚本
新增 `npm run dist:win:dev`，生成与正式版完全隔离的 Dev 验证安装包：
- `productName: PiDeckDev`、`appId: com.ayuayue.pi-desktop-dev`
- 配置目录 `%APPDATA%\pi-desktop-dev`（与 dev 模式共用，复用现有配置）
- 通过构建期 `__PIDECK_DEV_BUILD__` 标记区分 dev/正式构建

## 涉及文件

| 文件 | 改动 |
|---|---|
| `src/main/pi/AgentManager.ts` | 通知发送（toastXml + click）、两条提问路径触发、去重、窗口聚焦 |
| `src/main/index.ts` | AppUserModelID、协议注册、`.focus` argv 解析跳转、冷启动扫描 |
| `src/main/singleInstance.ts` | 次实例退出前传 argv、回调携带 payload |
| `src/renderer/src/i18n.ts` | 通知开关文案泛化（会话结束 + 询问） |
| `electron.vite.config.ts` | `__PIDECK_DEV_BUILD__` 构建标记 |
| `package.json` | `dist:win:dev` 脚本、`protocols` 配置 |
| `scripts/dist-win-dev.js` | Dev 独立打包脚本（新增） |

## 验证

- `npm run typecheck` 通过
- Windows 打包安装版实测：会话结束通知、AI 询问通知均正常弹出；点击通知置顶窗口并切换到对应 Agent 对话
- Dev 打包版与正式版配置/安装路径隔离，互不影响

## 说明

本 PR 仅在 Windows 环境完整验证（通知点击跳转的协议方案针对 Windows 通知机制设计）。macOS/Linux 的通知行为走系统原生路径，click 事件可直接触发，已保留 `click` 回调作为双保险。
