### PR TITLE
fix: 修复 WSL 项目与运行时路径兼容问题

### DIFF
--- a/src/main/extensions/ExtensionManager.ts
+++ b/src/main/extensions/ExtensionManager.ts
@@ -407,7 +407,13 @@ export class ExtensionManager {
 
 	async checkPiUpdate(): Promise<PiUpdateCheckResult> {
 		try {
-			const status = await this.locator.check(this.getSettings().customPiPath);
+			const settings = this.getSettings();
+			const status = await this.locator.check(
+				settings.customPiPath,
+				settings.wslEnabled,
+				settings.wslDistro,
+				settings.wslUser,
+			);
 			if (!status.installed) return { hasUpdate: false, error: this.translate("mainExtension.piNotInstalled") };
 			const latestVersion = await this.npmViewVersion("@earendil-works/pi-coding-agent");
 			return {
@@ -575,7 +581,13 @@ export class ExtensionManager {
 
 	private async detectPiVersion(): Promise<string | null> {
 		try {
-			const status = await this.locator.check(this.getSettings().customPiPath);
+			const settings = this.getSettings();
+			const status = await this.locator.check(
+				settings.customPiPath,
+				settings.wslEnabled,
+				settings.wslDistro,
+				settings.wslUser,
+			);
 			if (status.installed && status.version) {
 				this.piVersion = status.version;
 				return status.version;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -259,6 +259,7 @@ import { XuePromptManager } from "./prompts/XuePromptManager";
 import { SkillManager } from "./skills/SkillManager";
 import { ExtensionManager } from "./extensions/ExtensionManager";
 import { ProjectResourceManager } from "./projects/ProjectResourceManager";
+import { toWindowsHostPath } from "./wsl/WslPaths";
 import { registerProjectsIpc } from "./ipc/projectsIpc";
 import { registerUsageStatsIpc } from "./ipc/usageStatsIpc";
 import { UsageStatsService } from "./usageStats/UsageStatsService";
@@ -2411,6 +2412,12 @@ function registerIpc() {
 		projectResourceManager,
 		mainCopy: mainCopy as (key: string, params?: Record<string, string | number>) => string,
 		getMainWindow: () => mainWindow,
+		resolveWslEnvironment: async (distro, user) => {
+			const { resolveWslEnvironment } = await import("./wsl/WslEnvironment");
+			return resolveWslEnvironment(distro, user, {
+				warn: (msg: string, detail: Record<string, unknown>) => console.warn("[PiDeck] " + msg, detail),
+			});
+		},
 	});
 
 	registerScratchPadIpc({ appLogger });
@@ -2752,6 +2759,7 @@ function registerIpc() {
 		configureExtensionManagerWsl: (env) => extensionManager.configureWsl(env),
 		configureConfigManagerWsl: (env) => configManager.configureWsl(env),
 		configureXuePromptManagerWsl: (env) => xuePromptManager.configureWsl(env),
+		configureAgentManagerWsl: (env) => agentManager.configureWsl(env),
 		sessionCommandIpcError,
 		// 重启路径需要同步 isQuitting / 停服务，避免 closeToTray 吞掉 relaunch
 		webServiceManager,
@@ -2905,6 +2913,22 @@ app.whenReady().then(async () => {
 	projectResourceManager = new ProjectResourceManager(
 		(projectId) => projectStore.get(projectId),
 		mainCopy,
+		(project) => {
+			const settings = settingsStore.get();
+			if (
+				process.platform === "win32" &&
+				project.environment === "wsl" &&
+				settings.wslEnabled &&
+				settings.wslDistro
+			) {
+				try {
+					return toWindowsHostPath(project.path, { distro: settings.wslDistro });
+				} catch {
+					return project.path;
+				}
+			}
+			return project.path;
+		},
 	);
 	agentManager = new AgentManager(
 		(id) => projectStore.get(id),
@@ -3185,6 +3209,7 @@ app.whenReady().then(async () => {
 	terminalManager = new TerminalSessionManager(
 		(agentId) => agentManager.getCwd(agentId),
 		(channel, payload) => mainWindow?.webContents.send(channel, payload),
+		() => settingsStore.get(),
 	);
 	// C12：退出清理登记（before-quit 统一 runAll）
 	quitCleanup.register("terminal", () => terminalManager?.closeAll());
@@ -3244,6 +3269,7 @@ app.whenReady().then(async () => {
 				warn: (msg: string, detail: unknown) => console.warn("[PiDeck] " + String(msg), detail),
 			});
 			await sessionScanner.configureWsl(wslEnv);
+			agentManager.configureWsl(wslEnv);
 			skillManager.configureWsl(wslEnv);
 			promptManager.configureWsl(wslEnv);
 			extensionManager.configureWsl(wslEnv);
@@ -3251,6 +3277,7 @@ app.whenReady().then(async () => {
 			if (xuePromptManager) xuePromptManager.configureWsl(wslEnv);
 		} else {
 			sessionScanner.clearWsl();
+			agentManager.configureWsl(null);
 			skillManager.configureWsl(null);
 			promptManager.configureWsl(null);
 			extensionManager.configureWsl(null);

--- a/src/main/ipc/filesIpc.ts
+++ b/src/main/ipc/filesIpc.ts
@@ -6,6 +6,7 @@ import type { FileSystemService } from "../fs/FileSystemService";
 import type { ProjectStore } from "../projects/ProjectStore";
 import type { SettingsStore } from "../settings/SettingsStore";
 import type { AppLogger } from "../logging/AppLogger";
+import { parseWslUncPath, toWindowsHostPath } from "../wsl/WslPaths";
 
 export type FilesIpcDeps = {
 	fileSystemService: FileSystemService;
@@ -24,20 +25,15 @@ export function registerFilesIpc({
 	getMainWindow,
 	openExternalUrl,
 }: FilesIpcDeps): void {
-	// 将 WSL Linux 路径转为 Windows 可访问的路径（/mnt/c → C:\，/home/... → \\wsl$\<distro>\...）
-	const toWindowsPath = (linuxPath: string): string => {
-		if (!linuxPath || /^[A-Za-z]:/.test(linuxPath)) return linuxPath; // 已是 Windows 路径
-		// /mnt/c/Users/... → C:\Users\...
-		const mntMatch = linuxPath.match(/^\/mnt\/([a-z])\/(.*)/);
-		if (mntMatch) {
-			return `${mntMatch[1].toUpperCase()}:\\${mntMatch[2].replace(/\//g, "\\")}`;
-		}
-		// /home/user/... → \\wsl$\<distro>\home\user\...
+	// Windows Node 的 fs/Electron 边界不能消费 WSL Linux 路径：/mnt/<drive> 要回到
+	// 盘符，/home/... 与 UNC 则要统一为当前发行版的 canonical UNC。已经是普通
+	// Windows/网络路径的输入保持不变，避免误把用户的非 WSL 网络盘当成 Linux 路径。
+	const toWindowsPath = (path: string): string => {
+		if (!path || process.platform !== "win32") return path;
 		const settings = settingsStore.get();
-		if (settings.wslEnabled && settings.wslDistro) {
-			return `\\\\wsl$\\${settings.wslDistro}\\${linuxPath.replace(/^\//, "").replace(/\//g, "\\")}`;
-		}
-		return linuxPath;
+		if (!settings.wslEnabled || !settings.wslDistro) return path;
+		if (!path.startsWith("/") && !parseWslUncPath(path)) return path;
+		return toWindowsHostPath(path, { distro: settings.wslDistro });
 	};
 
 	ipcMain.handle(ipcChannels.dialogPickFiles, async (_event, options?: { title?: string; includeDirectories?: boolean }) => {
@@ -56,7 +52,7 @@ export function registerFilesIpc({
 	ipcMain.handle(ipcChannels.filesList, async (_event, projectId: string) => {
 		const project = projectStore.get(projectId);
 		if (!project) throw new Error(`Project not found: ${projectId}`);
-		return fileSystemService.listTree(project.path);
+		return fileSystemService.listTree(toWindowsPath(project.path));
 	});
 
 	ipcMain.handle(ipcChannels.filesOpen, async (_event, path: string) => {
@@ -99,7 +95,7 @@ export function registerFilesIpc({
 	});
 
 	ipcMain.handle(ipcChannels.filesWriteContent, async (_event, path: string, content: string) => {
-		await writeFile(path, content, "utf8");
+		await writeFile(toWindowsPath(path), content, "utf8");
 		void appLogger.info("file", "File written", { path, bytes: Buffer.byteLength(content, "utf8") });
 	});
 
@@ -129,7 +125,7 @@ export function registerFilesIpc({
 	ipcMain.handle(
 		ipcChannels.filesCreate,
 		async (_event, parentDir: string, name: string, type: "file" | "directory") => {
-			const result = await fileSystemService.create(parentDir, name, type);
+			const result = await fileSystemService.create(toWindowsPath(parentDir), name, type);
 			void appLogger.info("file", "File/folder created", { parentDir, name, type, result });
 			return result;
 		},
@@ -137,7 +133,7 @@ export function registerFilesIpc({
 
 	ipcMain.handle(ipcChannels.filesDelete, async (_event, path: string, recursive?: boolean) => {
 		try {
-			await fileSystemService.delete(path, recursive);
+			await fileSystemService.delete(toWindowsPath(path), recursive);
 			void appLogger.info("file", "File deleted", { path, recursive: Boolean(recursive) });
 		} catch (error) {
 			// 删除失败同样留痕（回收站不可用/权限不足/路径不存在等），
@@ -152,7 +148,7 @@ export function registerFilesIpc({
 	});
 
 	ipcMain.handle(ipcChannels.filesRename, async (_event, path: string, newName: string) => {
-		const result = await fileSystemService.rename(path, newName);
+		const result = await fileSystemService.rename(toWindowsPath(path), newName);
 		void appLogger.info("file", "File renamed", { path, newName, result });
 		return result;
 	});
@@ -160,14 +156,16 @@ export function registerFilesIpc({
 	ipcMain.handle(
 		ipcChannels.filesCopy,
 		async (_event, sourcePaths: string[], targetDir: string) => {
+			const hostTargetDir = toWindowsPath(targetDir);
 			const results: string[] = [];
 			for (const src of sourcePaths) {
 				try {
-					const name = basename(src);
-					const dest = join(targetDir, name);
+					const hostSrc = toWindowsPath(src);
+					const name = basename(hostSrc);
+					const dest = join(hostTargetDir, name);
 					// 递归复制目录/文件；同名已存在时跳过覆盖（errorOnExist: false 反而报错，
 					// 这里语义为「已存在则不重复复制」——与资源管理器粘贴行为一致）
-					await cp(src, dest, { recursive: true, errorOnExist: false });
+					await cp(hostSrc, dest, { recursive: true, errorOnExist: false });
 					results.push(dest);
 					void appLogger.info("file", "File/folder copied", { src, dest });
 				} catch (error) {
@@ -182,17 +180,19 @@ export function registerFilesIpc({
 	ipcMain.handle(
 		ipcChannels.filesMove,
 		async (_event, sourcePaths: string[], targetDir: string) => {
+			const hostTargetDir = toWindowsPath(targetDir);
 			const results: string[] = [];
 			for (const src of sourcePaths) {
 				try {
-					const name = basename(src);
-					const dest = join(targetDir, name);
+					const hostSrc = toWindowsPath(src);
+					const name = basename(hostSrc);
+					const dest = join(hostTargetDir, name);
 					// 同设备优先 rename（瞬时）；跨设备/跨盘 rename 会报 EXDEV，回退 cp + rm
 					try {
-						await fsRename(src, dest);
+						await fsRename(hostSrc, dest);
 					} catch {
-						await cp(src, dest, { recursive: true });
-						await rm(src, { recursive: true, force: true });
+						await cp(hostSrc, dest, { recursive: true });
+						await rm(hostSrc, { recursive: true, force: true });
 					}
 					results.push(dest);
 					void appLogger.info("file", "File/folder moved", { src, dest });

--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -10,6 +10,12 @@ import { PiRpcClient } from "../pi/PiRpcClient";
 import type { ProjectStore } from "../projects/ProjectStore";
 import type { SettingsStore } from "../settings/SettingsStore";
 import type { WorktreeService } from "../git/WorktreeService";
+import {
+	normalizeSelectedWslProjectPath,
+	parseWslUncPath,
+	toWindowsHostPath,
+	toWslLinuxPath,
+} from "../wsl/WslPaths";
 
 export type GitIpcDeps = {
 	appLogger: Pick<AppLogger, "warn" | "info" | "error">;
@@ -80,6 +86,9 @@ async function ensureGenProcess(
 	if (genProcess) stopGenProcess();
 
 	const settings = settingsStore.get();
+	const wslCwd = settings.wslEnabled && settings.wslDistro && command.startsWith("wsl://")
+		? toWslLinuxPath(projectPath, { distro: settings.wslDistro })
+		: undefined;
 	const invocation = piLocator.createInvocation(command, [
 		"--mode", "rpc",
 		"--no-session",
@@ -90,10 +99,13 @@ async function ensureGenProcess(
 		"--no-context-files",
 		"--no-themes",
 		"--thinking", "off",
-	]);
+	], wslCwd ? { wslCwd } : {});
+	const spawnCwd = wslCwd && settings.wslDistro
+		? toWindowsHostPath(projectPath, { distro: settings.wslDistro })
+		: projectPath;
 
 	const childProcess = spawn(invocation.command, invocation.args, {
-		cwd: projectPath,
+		cwd: spawnCwd,
 		env: piLocator.createProcessEnv(settings, invocation.pathPrefix, invocation.wsl),
 		stdio: ["pipe", "pipe", "pipe"],
 		shell: invocation.shell,
@@ -101,7 +113,7 @@ async function ensureGenProcess(
 		windowsVerbatimArguments: invocation.windowsVerbatimArguments,
 	});
 	genProcess = childProcess;
-	genProcessCwd = projectPath;
+	genProcessCwd = spawnCwd;
 
 	genRpcClient = new PiRpcClient(childProcess.stdin!, childProcess.stdout!);
 
@@ -220,10 +232,37 @@ export function registerGitIpc({
 	settingsStore,
 	worktreeService,
 }: GitIpcDeps): void {
+	const hostPath = (path: string): string => {
+		const settings = settingsStore.get();
+		if (
+			process.platform !== "win32" ||
+			!settings.wslEnabled ||
+			!settings.wslDistro ||
+			(!path.startsWith("/") && !parseWslUncPath(path))
+		) {
+			return path;
+		}
+		return toWindowsHostPath(path, { distro: settings.wslDistro });
+	};
+
+	const projectHostPath = (project: { path: string }) => hostPath(project.path);
+	const projectStoredPath = (path: string, project: { environment?: string }) => {
+		const settings = settingsStore.get();
+		if (
+			process.platform !== "win32" ||
+			project.environment !== "wsl" ||
+			!settings.wslEnabled ||
+			!settings.wslDistro
+		) {
+			return path;
+		}
+		return normalizeSelectedWslProjectPath(path, { distro: settings.wslDistro });
+	};
+
 	ipcMain.handle(ipcChannels.gitBranches, async (_event, projectId: string) => {
 		const project = projectStore.get(projectId);
 		if (!project) throw new Error(`Project not found: ${projectId}`);
-		return gitService.getBranches(project.path);
+		return gitService.getBranches(projectHostPath(project));
 	});
 
 	ipcMain.handle(
@@ -231,7 +270,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, branch: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			const result = await gitService.checkout(project.path, branch);
+			const result = await gitService.checkout(projectHostPath(project), branch);
 			// 切换分支可能覆盖未提交的工作区改动：记 warn 审计日志，排查"文件消失"时能定位到切换动作。
 			void appLogger.warn("git", "Branch checked out", { projectId, branch, changed: result });
 			return result;
@@ -243,7 +282,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, branchName: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			return gitService.createBranch(project.path, branchName);
+			return gitService.createBranch(projectHostPath(project), branchName);
 		},
 	);
 
@@ -252,7 +291,7 @@ export function registerGitIpc({
 		ipcChannels.gitOriginalContent,
 		async (_event, filePath: string) => {
 			const maxBytes = Math.max(1, settingsStore.get().maxEditorFileSizeMB) * 1024 * 1024;
-			return gitService.getOriginalContent(filePath, maxBytes);
+			return gitService.getOriginalContent(hostPath(filePath), maxBytes);
 		},
 	);
 
@@ -261,12 +300,16 @@ export function registerGitIpc({
 		async (_event, projectId: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			const entries = await worktreeService.list(project.path);
+			const entries = await worktreeService.list(projectHostPath(project));
+			const storedEntries = entries.map((entry) => ({
+				...entry,
+				path: projectStoredPath(entry.path, project),
+			}));
 			// 每次扫描都同步注册外部新增 worktree，保证侧栏数据和 git 状态一致。
-			for (const wt of entries) {
-				await projectStore.add(wt.path, projectId);
+			for (const wt of storedEntries) {
+				await projectStore.add(wt.path, projectId, project.environment === "wsl" ? "wsl" : "windows");
 			}
-			return entries;
+			return storedEntries;
 		},
 	);
 
@@ -275,9 +318,10 @@ export function registerGitIpc({
 		async (_event, projectId: string, branchName: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			const info = await worktreeService.create(project.path, projectId, branchName);
-			await projectStore.add(info.path, projectId);
-			return info;
+			const info = await worktreeService.create(projectHostPath(project), projectId, branchName);
+			const storedPath = projectStoredPath(info.path, project);
+			await projectStore.add(storedPath, projectId, project.environment === "wsl" ? "wsl" : "windows");
+			return { ...info, path: storedPath };
 		},
 	);
 
@@ -287,19 +331,21 @@ export function registerGitIpc({
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
 			try {
-				const ok = await worktreeService.remove(worktreePath, project.path);
+				const hostWorktreePath = hostPath(worktreePath);
+				const hostProjectPath = projectHostPath(project);
+				const ok = await worktreeService.remove(hostWorktreePath, hostProjectPath);
 				const normalizeForCompare = (value: string) => {
 					const resolved = resolve(value);
 					return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 				};
-				const normalizedTarget = normalizeForCompare(worktreePath);
-				const stillInGit = (await worktreeService.list(project.path)).some(
+				const normalizedTarget = normalizeForCompare(hostWorktreePath);
+				const stillInGit = (await worktreeService.list(hostProjectPath)).some(
 					(entry) => normalizeForCompare(entry.path) === normalizedTarget,
 				);
 				// 如果 git 已经没有该 worktree（包括用户在外部删过导致 remove 返回 false），
 				// 也要清理 PiDeck 项目记录，否则重启后会从 projects.json 恢复成"删不掉"。
 				if (ok || !stillInGit) {
-					const child = projectStore.findByPath(worktreePath);
+					const child = projectStore.findByPath(projectStoredPath(hostWorktreePath, project));
 					if (child) await projectStore.remove(child.id);
 					// worktree 删除 = 物理目录删除（走回收站），记审计日志便于追踪。
 					void appLogger.info("git", "Worktree removed", {
@@ -332,7 +378,10 @@ export function registerGitIpc({
 		async (_event, projectId: string, options?: { maxEntries?: number; ref?: string; path?: string; allBranches?: boolean }) => {
 			const project = projectStore.get(projectId);
 			if (!project) return [];
-			return gitService.getCommitLog(project.path, options);
+			const hostOptions = options?.path
+				? { ...options, path: hostPath(options.path) }
+				: options;
+			return gitService.getCommitLog(projectHostPath(project), hostOptions);
 		},
 	);
 
@@ -341,7 +390,7 @@ export function registerGitIpc({
 		async (_event, projectId: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) return [];
-			return gitService.getRefs(project.path);
+			return gitService.getRefs(projectHostPath(project));
 		},
 	);
 
@@ -350,7 +399,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, base: string, target: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			return gitService.compareBranches(project.path, base, target);
+			return gitService.compareBranches(projectHostPath(project), base, target);
 		},
 	);
 
@@ -359,7 +408,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, ref: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) return null;
-			return gitService.getCommitDetail(project.path, ref);
+			return gitService.getCommitDetail(projectHostPath(project), ref);
 		},
 	);
 
@@ -369,7 +418,13 @@ export function registerGitIpc({
 			const project = projectStore.get(projectId);
 			if (!project) return null;
 			const maxBytes = Math.max(1, settingsStore.get().maxEditorFileSizeMB) * 1024 * 1024;
-			return gitService.getCommitFileDiff(project.path, ref, filePath, originalPath, maxBytes);
+			return gitService.getCommitFileDiff(
+				projectHostPath(project),
+				ref,
+				hostPath(filePath),
+				originalPath ? hostPath(originalPath) : originalPath,
+				maxBytes,
+			);
 		},
 	);
 
@@ -378,7 +433,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, ref1: string, ref2: string, filePath: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) return "";
-			return gitService.diffFileBetweenRefs(project.path, ref1, ref2, filePath);
+			return gitService.diffFileBetweenRefs(projectHostPath(project), ref1, ref2, hostPath(filePath));
 		},
 	);
 
@@ -389,7 +444,7 @@ export function registerGitIpc({
 		async (_event, projectId: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) return { merge: [], index: [], workingTree: [], untracked: [] };
-			return gitService.getStatus(project.path);
+			return gitService.getStatus(projectHostPath(project));
 		},
 	);
 
@@ -399,7 +454,7 @@ export function registerGitIpc({
 			const project = projectStore.get(projectId);
 			if (!project) return null;
 			const maxBytes = Math.max(1, settingsStore.get().maxEditorFileSizeMB) * 1024 * 1024;
-			return gitService.getWorkspaceFileDiff(project.path, group, filePath, maxBytes);
+			return gitService.getWorkspaceFileDiff(projectHostPath(project), group, hostPath(filePath), maxBytes);
 		},
 	);
 
@@ -408,7 +463,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, paths: string[]) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.stageFiles(project.path, paths);
+			await gitService.stageFiles(projectHostPath(project), paths.map(hostPath));
 		},
 	);
 
@@ -417,7 +472,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, paths: string[]) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.unstageFiles(project.path, paths);
+			await gitService.unstageFiles(projectHostPath(project), paths.map(hostPath));
 		},
 	);
 
@@ -427,7 +482,7 @@ export function registerGitIpc({
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
 			try {
-				await gitService.discardFile(project.path, group, filePath);
+				await gitService.discardFile(projectHostPath(project), group, hostPath(filePath));
 				// untracked 丢弃 = 删除用户文件（走回收站），记审计日志便于追踪。
 				void appLogger.info("git", "Changes discarded", { projectId, group, filePath });
 			} catch (error) {
@@ -447,7 +502,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, message: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.commit(project.path, message);
+			await gitService.commit(projectHostPath(project), message);
 			void appLogger.info("git", "Commit created", { projectId, message });
 		},
 	);
@@ -457,7 +512,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, hash: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.cherryPick(project.path, hash);
+			await gitService.cherryPick(projectHostPath(project), hash);
 			void appLogger.info("git", "Commit cherry-picked", { projectId, hash });
 		},
 	);
@@ -467,7 +522,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, hash: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.revertCommit(project.path, hash);
+			await gitService.revertCommit(projectHostPath(project), hash);
 			void appLogger.info("git", "Commit reverted", { projectId, hash });
 		},
 	);
@@ -477,7 +532,7 @@ export function registerGitIpc({
 		async (_event, projectId: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.push(project.path);
+			await gitService.push(projectHostPath(project));
 			void appLogger.info("git", "Pushed", { projectId });
 		},
 	);
@@ -487,7 +542,7 @@ export function registerGitIpc({
 		async (_event, projectId: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.pull(project.path);
+			await gitService.pull(projectHostPath(project));
 			void appLogger.info("git", "Pulled", { projectId });
 		},
 	);
@@ -497,7 +552,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, hash: string, mode: "soft" | "mixed" | "hard") => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.resetToCommit(project.path, hash, mode);
+			await gitService.resetToCommit(projectHostPath(project), hash, mode);
 			// hard reset 会丢工作区/暂存区改动（reflog 外的不可恢复路径），warn 级突出显示。
 			void appLogger.warn("git", "Reset to commit", { projectId, hash, mode });
 		},
@@ -508,7 +563,7 @@ export function registerGitIpc({
 		async (_event, projectId: string, hash: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			await gitService.dropCommit(project.path, hash);
+			await gitService.dropCommit(projectHostPath(project), hash);
 			void appLogger.warn("git", "Commit dropped", { projectId, hash });
 		},
 	);
@@ -519,7 +574,8 @@ export function registerGitIpc({
 			const project = projectStore.get(projectId);
 			if (!project) return { ok: true, message: "" };
 
-			const diff = await gitService.getStagedDiff(project.path);
+			const hostProjectPath = projectHostPath(project);
+			const diff = await gitService.getStagedDiff(hostProjectPath);
 			if (!diff.trim()) return { ok: true, message: "" };
 
 			const settings = settingsStore.get();
@@ -541,7 +597,7 @@ export function registerGitIpc({
 
 			try {
 				const result = await quickGenerate(
-					project.path,
+					hostProjectPath,
 					prompt,
 					piLocator,
 					settingsStore,
@@ -571,7 +627,7 @@ export function registerGitIpc({
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
 			const { execFile } = await import("node:child_process");
-			await execFile("git", ["init"], { cwd: project.path });
+			await execFile("git", ["init"], { cwd: projectHostPath(project) });
 			void appLogger.info("git", "Repository initialized", { projectId, path: project.path });
 		},
 	);
@@ -583,8 +639,8 @@ export function registerGitIpc({
 		async (_event, projectId: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			if (!(await gitService.isGitRepo(project.path))) return;
-			await gitService.fetch(project.path);
+			if (!(await gitService.isGitRepo(projectHostPath(project)))) return;
+			await gitService.fetch(projectHostPath(project));
 		},
 	);
 
@@ -594,7 +650,7 @@ export function registerGitIpc({
 		async (_event, projectId: string) => {
 			const project = projectStore.get(projectId);
 			if (!project) throw new Error(`Project not found: ${projectId}`);
-			return gitService.getAheadBehind(project.path);
+			return gitService.getAheadBehind(projectHostPath(project));
 		},
 	);
 
@@ -608,7 +664,7 @@ export function registerGitIpc({
 			if (!Array.isArray(paths) || paths.length === 0 || paths.some((p) => typeof p !== "string" || !p)) {
 				throw new Error("Invalid paths");
 			}
-			await gitService.deleteFiles(project.path, paths);
+			await gitService.deleteFiles(projectHostPath(project), paths.map(hostPath));
 			// 批量删除文件：最高风险操作之一，完整记录路径清单（含数量）便于误删回溯。
 			void appLogger.warn("git", "Files deleted (recycle bin)", { projectId, count: paths.length, paths });
 		},

--- a/src/main/ipc/projectsIpc.ts
+++ b/src/main/ipc/projectsIpc.ts
@@ -9,6 +9,11 @@ import type { AppLogger } from "../logging/AppLogger";
 import type { ProjectResourceManager } from "../projects/ProjectResourceManager";
 import { attachProjectPresence } from "../projects/projectPresence";
 import { registerProjectResourceIpc } from "./projectResourceIpc";
+import {
+	normalizeSelectedWslProjectPath,
+	toWindowsHostPath,
+	type WslEnvironment,
+} from "../wsl/WslPaths";
 
 export type ProjectsIpcDeps = {
 	projectStore: ProjectStore;
@@ -20,6 +25,7 @@ export type ProjectsIpcDeps = {
 	projectResourceManager: ProjectResourceManager;
 	mainCopy: (key: string, params?: Record<string, string | number>) => string;
 	getMainWindow: () => BrowserWindow | null;
+	resolveWslEnvironment?: (distro: string, user: string) => Promise<WslEnvironment>;
 };
 
 export function registerProjectsIpc({
@@ -32,7 +38,43 @@ export function registerProjectsIpc({
 	projectResourceManager,
 	mainCopy,
 	getMainWindow,
+	resolveWslEnvironment,
 }: ProjectsIpcDeps): void {
+	const resolveProjectHostPath = (project: { path: string; environment?: string }) => {
+		const settings = settingsStore.get();
+		if (
+			process.platform !== "win32" ||
+			project.environment !== "wsl" ||
+			!settings.wslEnabled ||
+			!settings.wslDistro
+		) {
+			return project.path;
+		}
+		try {
+			return toWindowsHostPath(project.path, { distro: settings.wslDistro });
+		} catch {
+			// Presence checks should not turn a temporary WSL/path mismatch into a hard IPC failure.
+			return project.path;
+		}
+	};
+
+	const resolveProjectStoredPath = (path: string, project: { environment?: string }) => {
+		const settings = settingsStore.get();
+		if (
+			process.platform !== "win32" ||
+			project.environment !== "wsl" ||
+			!settings.wslEnabled ||
+			!settings.wslDistro
+		) {
+			return path;
+		}
+		try {
+			return normalizeSelectedWslProjectPath(path, { distro: settings.wslDistro });
+		} catch {
+			return path;
+		}
+	};
+
 	// 可见项目 = 按环境过滤 + 目录存在性标记（missing 保留记录，见 projectPresence.ts）
 	const getVisibleProjects = async () => {
 		const settings = settingsStore.get();
@@ -40,14 +82,17 @@ export function registerProjectsIpc({
 		const visible = settings.wslEnabled
 			? all.filter((p) => p.kind === "chat" || p.environment === "wsl")
 			: all.filter((p) => p.kind === "chat" || !p.environment || p.environment === "windows");
-		return attachProjectPresence(visible);
+		return attachProjectPresence(visible, undefined, resolveProjectHostPath);
 	};
 
 	ipcMain.handle(ipcChannels.projectsList, async () => getVisibleProjects());
 	ipcMain.handle(ipcChannels.projectsAdd, async () => {
 		const settings = settingsStore.get();
 		const env = settings.wslEnabled ? "wsl" as const : "windows" as const;
-		const project = await projectStore.chooseAndAdd(env);
+		const wslEnvironment = env === "wsl" && settings.wslDistro && settings.wslUser && resolveWslEnvironment
+			? await resolveWslEnvironment(settings.wslDistro, settings.wslUser)
+			: null;
+		const project = await projectStore.chooseAndAdd(env, wslEnvironment);
 		void appLogger.info("project", "Project added", { projectId: project?.id, path: project?.path, environment: env });
 		return project;
 	});
@@ -90,7 +135,7 @@ export function registerProjectsIpc({
 			// 即将启用时先校验是否 git 仓库；非 git 项目开启工作区模式没有意义，
 			// 只会看到空列表并在创建时报错，这里提前给出明确错误让前端提示用户。
 			if (!existing.worktreeEnabled) {
-				const isRepo = await gitService.isGitRepo(existing.path);
+				const isRepo = await gitService.isGitRepo(resolveProjectHostPath(existing));
 				if (!isRepo) {
 					throw new Error("NOT_A_GIT_REPO");
 				}
@@ -100,11 +145,12 @@ export function registerProjectsIpc({
 			// 开启 worktree 模式时，自动注册已有的 git worktree
 			if (project.worktreeEnabled) {
 				try {
-					const entries = await worktreeService.list(project.path);
+					const entries = await worktreeService.list(resolveProjectHostPath(project));
 					for (const wt of entries) {
 						// findByPath 返回 null 表示未注册
-						if (!projectStore.findByPath(wt.path)) {
-							await projectStore.add(wt.path, projectId);
+						const storedPath = resolveProjectStoredPath(wt.path, project);
+						if (!projectStore.findByPath(storedPath)) {
+							await projectStore.add(storedPath, projectId, project.environment);
 						}
 					}
 				} catch {

--- a/src/main/ipc/systemIpc.ts
+++ b/src/main/ipc/systemIpc.ts
@@ -133,6 +133,7 @@ export type SystemIpcDeps = {
 	configureExtensionManagerWsl?: (env: import("../wsl/WslPaths").WslEnvironment | null) => void;
 	configureConfigManagerWsl?: (env: import("../wsl/WslPaths").WslEnvironment | null) => void;
 	configureXuePromptManagerWsl?: (env: import("../wsl/WslPaths").WslEnvironment | null) => void;
+	configureAgentManagerWsl?: (env: import("../wsl/WslPaths").WslEnvironment | null) => void;
 	/** Session command IPC error converter */
 	sessionCommandIpcError?: (error: import("../../shared/types").SessionCommandError) => Error;
 	/** Extension manager for pi update */
@@ -191,6 +192,7 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 		configureExtensionManagerWsl,
 		configureConfigManagerWsl,
 		configureXuePromptManagerWsl,
+		configureAgentManagerWsl,
 		sessionCommandIpcError,
 		extensionManager,
 		webServiceManager,
@@ -216,7 +218,13 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 	});
 
 	ipcMain.handle(ipcChannels.piCheckCustom, async (_event, customPath: string) => {
-		const status = await piLocator.validateCustomPath(customPath);
+		const settings = settingsStore.get();
+		const status = await piLocator.validateCustomPath(
+			customPath,
+			settings.wslEnabled,
+			settings.wslDistro,
+			settings.wslUser,
+		);
 		if (status.installed && status.command) {
 			await settingsStore.update({ customPiPath: status.command });
 		}
@@ -634,7 +642,13 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 	// ── 反馈环境 ─────────────────────────────────────────────────────
 
 	ipcMain.handle(ipcChannels.appFeedbackEnvironment, async () => {
-		const pi = await piLocator.check();
+		const settings = settingsStore.get();
+		const pi = await piLocator.check(
+			settings.customPiPath,
+			settings.wslEnabled,
+			settings.wslDistro,
+			settings.wslUser,
+		);
 		return {
 			appVersion: app.getVersion(),
 			platform: process.platform,
@@ -796,6 +810,7 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 				if (configureExtensionManagerWsl) configureExtensionManagerWsl(environment);
 				if (configureConfigManagerWsl) configureConfigManagerWsl(environment);
 				if (configureXuePromptManagerWsl) configureXuePromptManagerWsl(environment);
+				if (configureAgentManagerWsl) configureAgentManagerWsl(environment);
 			} else {
 				if (clearSessionScannerWsl) clearSessionScannerWsl();
 				if (configureSkillManagerWsl) configureSkillManagerWsl(null);
@@ -803,6 +818,7 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 				if (configureExtensionManagerWsl) configureExtensionManagerWsl(null);
 				if (configureConfigManagerWsl) configureConfigManagerWsl(null);
 				if (configureXuePromptManagerWsl) configureXuePromptManagerWsl(null);
+				if (configureAgentManagerWsl) configureAgentManagerWsl(null);
 			}
 		}
 		return settings;

--- a/src/main/ipc/terminalIpc.ts
+++ b/src/main/ipc/terminalIpc.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from "electron";
 import { ipcChannels } from "../../shared/ipc";
-import type { SessionCommandError, SessionRuntimeTarget, TerminalTarget } from "../../shared/types";
+import type { SessionCommandError, SessionRuntimeTarget, TerminalShell, TerminalTarget } from "../../shared/types";
 import type { AppLogger } from "../logging/AppLogger";
 import type { SessionRuntimeCoordinator } from "../sessions/SessionRuntimeCoordinator";
 import type { TerminalSessionManager } from "../terminal/TerminalSessionManager";
@@ -40,9 +40,9 @@ export function registerTerminalIpc({
 		requireTerminalTarget(target);
 		return terminalManager.ensure(target);
 	});
-	ipcMain.handle(ipcChannels.terminalCreate, async (_event, target: TerminalTarget) => {
+	ipcMain.handle(ipcChannels.terminalCreate, async (_event, target: TerminalTarget, shell?: TerminalShell) => {
 		requireTerminalTarget(target);
-		const result = await terminalManager.create(target);
+		const result = await terminalManager.create(target, shell);
 		void appLogger.info("terminal", "Terminal created", {
 			kind: target.kind,
 			sessionId: target.kind === "agent" ? target.sessionId : undefined,

--- a/src/main/pi/PiLocator.ts
+++ b/src/main/pi/PiLocator.ts
@@ -45,10 +45,19 @@ export class PiLocator {
   /**
    * Resolves the pi CLI across packaged Electron environments where shell PATH is often incomplete.
    * When `customPath` is provided, it takes priority over auto-detection —
-   * this is the user's manually specified path from settings.
-   */
+  * this is the user's manually specified path from settings.
+  */
   resolveCommand(customPath?: string, wslEnabled?: boolean, wslDistro?: string, wslUser?: string) {
     const normalizedCustomPath = this.normalizeCustomPath(customPath);
+    // wsl:// 是显式的运行目标，优先保留；普通本地路径则不能覆盖已启用的 WSL
+    // 模式，否则设置页残留的 Windows pi.cmd 会把 Agent 静默切回宿主机。
+    if (normalizedCustomPath?.startsWith("wsl://")) return normalizedCustomPath;
+    if (wslEnabled && process.platform === "win32" && wslDistro && wslUser) {
+      const wslCustomPath = this.toWslCustomPath(normalizedCustomPath, wslEnabled, wslDistro, wslUser);
+      if (wslCustomPath) return wslCustomPath;
+      const wslCommand = this.resolveWslCommand(wslDistro, wslUser);
+      if (wslCommand) return wslCommand;
+    }
     // 用户手动指定路径优先，适用于 npm/pnpm/yarn 全局安装、nvm/volta/asdf/mise 等极端情况。
     // 旧版本可能已保存 pi.ps1；Windows 现在不再调用 PowerShell shim，遇到时忽略并回退自动检测。
     // 路径已失效（文件被删 / 版本管理器切换后旧路径残留）时同样回退自动检测——否则 check()
@@ -62,12 +71,6 @@ export class PiLocator {
     ) {
       return normalizedCustomPath;
     }
-    // 用户显式开启 WSL 时优先使用 WSL 中的 pi，不轮询本地 PATH 中的 Windows 版本
-    if (wslEnabled && process.platform === "win32" && wslDistro && wslUser) {
-      const wslCommand = this.resolveWslCommand(wslDistro, wslUser);
-      if (wslCommand) return wslCommand;
-    }
-
     const candidates = this.getCandidates();
     const found = candidates.find(candidate => existsSync(candidate));
     if (found) return found;
@@ -282,8 +285,14 @@ export class PiLocator {
    * 直接对给定路径执行 --version，绕过 getCandidates 的目录扫描，
    * 适用于用户从终端复制完整路径（如 D:\nodejs\pi.cmd）后手动粘贴的场景。
    */
-  async validateCustomPath(customPath: string): Promise<PiInstallStatus> {
-    const command = this.normalizeCustomPath(customPath);
+  async validateCustomPath(
+    customPath: string,
+    wslEnabled?: boolean,
+    wslDistro?: string,
+    wslUser?: string,
+  ): Promise<PiInstallStatus> {
+    const normalized = this.normalizeCustomPath(customPath);
+    const command = this.toWslCustomPath(normalized, wslEnabled, wslDistro, wslUser) ?? normalized;
     if (!command) {
       return { installed: false, searchedDirs: [], error: this.translate("mainPi.pathRequired") };
     }
@@ -291,17 +300,25 @@ export class PiLocator {
     if (command.startsWith("wsl://")) {
       const parsed = this.parseWslUrl(command);
       if (!parsed) return { installed: false, searchedDirs: [], error: this.translate("mainPi.invalidWslUrl") };
-      return this.checkWslCommand(parsed.distro, parsed.user, parsed.piCommand);
+      const status = await this.checkWslCommand(parsed.distro, parsed.user, parsed.piCommand);
+      // Keep the user's Linux path as the persisted custom setting. `resolveCommand()`
+      // converts it to the internal wsl:// marker on the next launch, while the settings
+      // UI continues to show the path the user entered instead of an internal URL.
+      return { ...status, command: normalized };
     }
     return this.runCheck(command, []);
   }
 
   async check(customPath?: string, wslEnabled?: boolean, wslDistro?: string, wslUser?: string): Promise<PiInstallStatus> {
     const normalizedCustomPath = this.normalizeCustomPath(customPath);
-    if (normalizedCustomPath && this.isUnsupportedPowerShellShim(normalizedCustomPath)) {
+    if (
+      normalizedCustomPath &&
+      this.isUnsupportedPowerShellShim(normalizedCustomPath) &&
+      !(wslEnabled && process.platform === "win32" && wslDistro && wslUser)
+    ) {
       return this.unsupportedPowerShellStatus(normalizedCustomPath, this.getSearchDirs());
     }
-    const command = normalizedCustomPath || this.resolveCommand(customPath, wslEnabled, wslDistro, wslUser);
+    const command = this.resolveCommand(customPath, wslEnabled, wslDistro, wslUser);
     const searchedDirs = this.getSearchDirs();
 
     if (command.startsWith("wsl://")) {
@@ -359,6 +376,26 @@ export class PiLocator {
 
   private isUnsupportedPowerShellShim(command: string) {
     return process.platform === "win32" && command.trim().toLowerCase().endsWith(".ps1");
+  }
+
+  private toWslCustomPath(
+    command: string,
+    wslEnabled?: boolean,
+    wslDistro?: string,
+    wslUser?: string,
+  ): string | null {
+    if (
+      !command ||
+      !wslEnabled ||
+      process.platform !== "win32" ||
+      !wslDistro ||
+      !wslUser ||
+      !command.startsWith("/")
+    ) {
+      return null;
+    }
+    // 双斜杠是有意保留的：URL 的分隔符之后还要保留 Linux 命令的首个 `/`。
+    return `wsl://${wslDistro}/${wslUser}/${command}`;
   }
 
   private unsupportedPowerShellStatus(

--- a/src/main/projects/ProjectResourceManager.ts
+++ b/src/main/projects/ProjectResourceManager.ts
@@ -15,6 +15,7 @@ import type { MainProcessTranslationKey } from "../../shared/i18n/mainProcessCop
 const SKILL_FILE = "SKILL.md";
 
 type ProjectProvider = (projectId: string) => Project | undefined;
+type ProjectPathResolver = (project: Project) => string;
 type ProjectResourceCopy = (
 	key: MainProcessTranslationKey,
 	params?: Record<string, string | number>,
@@ -28,7 +29,12 @@ export class ProjectResourceManager {
 	constructor(
 		private readonly getProject: ProjectProvider,
 		private readonly translate: ProjectResourceCopy = () => "Project resource operation failed.",
+		private readonly resolveProjectPath: ProjectPathResolver = (project) => project.path,
 	) {}
+
+	private projectRoot(project: Project): string {
+		return this.resolveProjectPath(project);
+	}
 
 	async list(projectId: string): Promise<ProjectResourceListResult> {
 		const project = this.requireProject(projectId);
@@ -101,7 +107,7 @@ export class ProjectResourceManager {
 		const project = this.requireProject(projectId);
 		this.assertInsideProject(project, extensionPath);
 		// 项目级扩展的禁用通过项目的 .pi/settings.json 中的 disabledExtensions 控制
-		const settingsFile = join(project.path, ".pi", "settings.json");
+		const settingsFile = join(this.projectRoot(project), ".pi", "settings.json");
 		let raw = "{}";
 		try { raw = await readFile(settingsFile, "utf8"); } catch {}
 		const settings = JSON.parse(raw);
@@ -186,13 +192,13 @@ export class ProjectResourceManager {
 	}
 
 	private async listExtensions(project: Project): Promise<PiExtensionSummary[]> {
-		const extensionsDir = join(project.path, ".pi", "extensions");
+		const extensionsDir = join(this.projectRoot(project), ".pi", "extensions");
 		const entries = await readdir(extensionsDir, { withFileTypes: true }).catch(() => []);
 		const result: PiExtensionSummary[] = [];
 		// 读取项目级 disabledExtensions
 		let disabledExts = new Set<string>();
 		try {
-			const raw = await readFile(join(project.path, ".pi", "settings.json"), "utf8");
+			const raw = await readFile(join(this.projectRoot(project), ".pi", "settings.json"), "utf8");
 			const settings = JSON.parse(raw);
 			disabledExts = new Set(settings.disabledExtensions ?? []);
 		} catch {}
@@ -228,13 +234,13 @@ export class ProjectResourceManager {
 			{
 				id: "project-pi",
 				label: ".pi/skills",
-				path: join(project.path, ".pi", "skills"),
+				path: join(this.projectRoot(project), ".pi", "skills"),
 				rootMarkdownEnabled: true,
 			},
 			{
 				id: "project-agents",
 				label: ".agents/skills",
-				path: join(project.path, ".agents", "skills"),
+				path: join(this.projectRoot(project), ".agents", "skills"),
 				rootMarkdownEnabled: false,
 			},
 		];
@@ -294,7 +300,7 @@ export class ProjectResourceManager {
 	}
 
 	private assertInsideProject(project: Project, targetPath: string) {
-		const root = resolve(project.path);
+		const root = resolve(this.projectRoot(project));
 		const target = resolve(targetPath);
 		const rel = relative(root, target);
 		// 所有删除/创建都必须落在当前项目目录内，防止 renderer 传入任意路径误删全局资源。

--- a/src/main/projects/projectPresence.ts
+++ b/src/main/projects/projectPresence.ts
@@ -14,6 +14,7 @@ import type { Project } from "../../shared/types";
 import { parseWslUncPath } from "../wsl/WslPaths";
 
 export type PathCheck = (path: string) => Promise<boolean>;
+export type ProjectPathResolver = (project: Project) => string;
 
 /** 默认路径检查：stat 成功即存在（ENOENT 及一切异常视为不存在）。 */
 export const defaultPathCheck: PathCheck = async (path) => {
@@ -32,6 +33,7 @@ export const defaultPathCheck: PathCheck = async (path) => {
 export async function attachProjectPresence(
 	projects: readonly Project[],
 	checkPath: PathCheck = defaultPathCheck,
+	resolvePath: ProjectPathResolver = (project) => project.path,
 ): Promise<Project[]> {
 	const results: Project[] = [];
 	for (const project of projects) {
@@ -40,7 +42,7 @@ export async function attachProjectPresence(
 			continue;
 		}
 		results.push(
-			(await isProjectMissing(project, checkPath))
+			(await isProjectMissing(project, checkPath, resolvePath))
 				? { ...project, missing: true }
 				: project,
 		);
@@ -52,13 +54,15 @@ export async function attachProjectPresence(
 async function isProjectMissing(
 	project: Project,
 	checkPath: PathCheck,
+	resolvePath: ProjectPathResolver,
 ): Promise<boolean> {
-	if (await checkPath(project.path)) return false;
+	const hostPath = resolvePath(project);
+	if (await checkPath(hostPath)) return false;
 	// WSL 项目（UNC 路径）：stat 失败可能是发行版未启动（UNC 根不可达），
 	// 此时不标记——否则每次 WSL 未启动都会误报「目录不存在」。
 	// 发行版根可达但项目路径仍缺失，才是真正被删除/移动。
 	if (project.environment === "wsl") {
-		const unc = parseWslUncPath(project.path);
+		const unc = parseWslUncPath(hostPath) ?? parseWslUncPath(project.path);
 		if (!unc) return true; // 无法解析的 WSL 路径视为缺失
 		if (!(await checkPath(`\\\\wsl.localhost\\${unc.distro}`))) return false;
 	}

--- a/src/main/prompts/PromptManager.ts
+++ b/src/main/prompts/PromptManager.ts
@@ -9,7 +9,7 @@ import type {
 	PiPromptTemplateListResult,
 	PiPromptTemplateSummary,
 } from "../../shared/types";
-import type { WslEnvironment } from "../wsl/WslPaths";
+import { parseWslUncPath, toWindowsHostPath, type WslEnvironment } from "../wsl/WslPaths";
 import type { MainProcessTranslationKey } from "../../shared/i18n/mainProcessCopy";
 
 type PromptCopy = (
@@ -178,6 +178,7 @@ when appropriate. If unsure whether a skill is needed, follow the rule:
  */
 export class PromptManager {
 	private promptsDir: string;
+	private wslEnvironment: WslEnvironment | null = null;
 
 	constructor(
 		home?: string,
@@ -188,7 +189,24 @@ export class PromptManager {
 
 	/** 将 prompt 目录切换到统一解析出的 WSL HOME；null 恢复 Windows home。 */
 	configureWsl(environment: WslEnvironment | null) {
+		this.wslEnvironment = environment;
 		this.promptsDir = join(environment?.windowsHome ?? homedir(), ".pi", "agent", "prompts");
+	}
+
+	/** 项目路径来自 renderer 的存储格式，Windows fs 边界统一使用当前 WSL 的主机路径。 */
+	private hostPath(path: string): string {
+		if (
+			!this.wslEnvironment ||
+			process.platform !== "win32" ||
+			(!path.startsWith("/") && !parseWslUncPath(path))
+		) {
+			return path;
+		}
+		try {
+			return toWindowsHostPath(path, this.wslEnvironment);
+		} catch {
+			return path;
+		}
 	}
 
 	getDir(): string {
@@ -258,19 +276,20 @@ export class PromptManager {
 	}
 
 	async delete(filePath: string): Promise<void> {
-		if (!filePath.startsWith(this.promptsDir)) {
+		const hostFilePath = this.hostPath(filePath);
+		if (!hostFilePath.startsWith(this.promptsDir)) {
 			throw new Error(this.translate("mainPrompt.globalDeleteOnly"));
 		}
-		if (!existsSync(filePath)) {
+		if (!existsSync(hostFilePath)) {
 			throw new Error(this.translate("mainPrompt.fileNotFound"));
 		}
 		// 提示词模板是用户内容：删除走系统回收站（可恢复）；回收站不可用时抛错，拒绝硬删。
-		await trashPath(filePath, { source: "prompts:delete" });
+		await trashPath(hostFilePath, { source: "prompts:delete" });
 	}
 
 	/** 扫描项目 .pi/prompts/ 目录下的模板 */
 	async listByProject(projectPath: string): Promise<PiPromptTemplateListResult> {
-		const projectPromptsDir = join(projectPath, ".pi", "prompts");
+		const projectPromptsDir = join(this.hostPath(projectPath), ".pi", "prompts");
 		const entries = await readdir(projectPromptsDir).catch(() => []);
 		const templates: PiPromptTemplateSummary[] = [];
 		for (const entry of entries) {
@@ -301,7 +320,7 @@ export class PromptManager {
 		projectPath: string,
 		input: CreatePiPromptTemplateInput,
 	): Promise<PiPromptTemplateSummary> {
-		const projectPromptsDir = join(projectPath, ".pi", "prompts");
+		const projectPromptsDir = join(this.hostPath(projectPath), ".pi", "prompts");
 		await mkdir(projectPromptsDir, { recursive: true });
 		const name = this.normalizeName(input.name);
 		if (!name) throw new Error(this.translate("mainPrompt.nameRequiredDetailed"));
@@ -324,7 +343,7 @@ export class PromptManager {
 
 	/** 从项目 .pi/prompts/ 删除模板 */
 	async deleteFromProject(projectPath: string, fileName: string): Promise<void> {
-		const filePath = join(projectPath, ".pi", "prompts", fileName);
+		const filePath = join(this.hostPath(projectPath), ".pi", "prompts", fileName);
 		if (!existsSync(filePath)) throw new Error(this.translate("mainPrompt.fileNotFound"));
 		// 项目内模板同样走回收站，避免误删后无法恢复。
 		await trashPath(filePath, { source: "prompts:delete-project" });
@@ -339,17 +358,18 @@ export class PromptManager {
 	 * 读取模板原始内容（供编辑器使用）
 	 */
 	async readContent(filePath: string): Promise<string> {
-		return readFile(filePath, "utf8");
+		return readFile(this.hostPath(filePath), "utf8");
 	}
 
 	/**
 	 * 保存模板内容
 	 */
 	async writeContent(filePath: string, content: string): Promise<void> {
-		if (!filePath.startsWith(this.promptsDir)) {
+		const hostFilePath = this.hostPath(filePath);
+		if (!hostFilePath.startsWith(this.promptsDir)) {
 			throw new Error(this.translate("mainPrompt.globalEditOnly"));
 		}
-		await writeFile(filePath, content, "utf8");
+		await writeFile(hostFilePath, content, "utf8");
 	}
 
 	private parseFrontmatter(raw: string): Record<string, string> {
@@ -396,7 +416,7 @@ export class PromptManager {
 
 	/** 重命名项目级模板 */
 	async renameInProject(projectPath: string, oldName: string, newName: string): Promise<PiPromptTemplateSummary> {
-		const projectPromptsDir = join(projectPath, ".pi", "prompts");
+		const projectPromptsDir = join(this.hostPath(projectPath), ".pi", "prompts");
 		const normalizedOld = this.normalizeName(oldName);
 		const normalizedNew = this.normalizeName(newName);
 		if (!normalizedOld || !normalizedNew) throw new Error(this.translate("mainPrompt.nameRequired"));

--- a/src/main/prompts/XuePromptManager.ts
+++ b/src/main/prompts/XuePromptManager.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { app } from "electron";
 import initSqlJs from "sql.js";
 import { PromptManager } from "./PromptManager";
+import type { WslEnvironment } from "../wsl/WslPaths";
 import type {
 	YaoPromptCategory,
 	YaoPromptItem,
@@ -61,9 +62,8 @@ export class XuePromptManager {
 		return this.sqlPromise;
 	}
 
-	// configureWsl deferred until WSL infrastructure is ported
-	configureWsl(_wsl: any) {
-		this.promptManager.configureWsl(null);
+	configureWsl(wsl: WslEnvironment | null) {
+		this.promptManager.configureWsl(wsl);
 	}
 
 	/**

--- a/src/main/sessions/SessionScanner.ts
+++ b/src/main/sessions/SessionScanner.ts
@@ -102,6 +102,15 @@ export class SessionScanner {
     return this.resolveWslExe().shell;
   }
 
+  /** WSL session paths are Linux paths even though this class runs in Windows Node. */
+  private joinRuntimePath(...parts: string[]): string {
+    const first = parts[0] ?? "";
+    if (this.wslConfig && first.startsWith("/")) {
+      return posixJoin(...parts.map((part) => part.replace(/\\/g, "/")));
+    }
+    return join(...parts);
+  }
+
   async configureWsl(environment: WslEnvironment | null): Promise<void> {
     this.wslConfig = environment
       ? { distro: environment.distro, user: environment.user, home: environment.linuxHome }
@@ -665,7 +674,7 @@ export class SessionScanner {
   private archiveDirFor(filePath: string): string | undefined {
     const root = this.findSessionsRootForFile(filePath);
     if (!root) return undefined;
-    return join(root, SessionScanner.ARCHIVE_DIR_NAME);
+    return this.joinRuntimePath(root, SessionScanner.ARCHIVE_DIR_NAME);
   }
 
   /**
@@ -677,12 +686,13 @@ export class SessionScanner {
     const archiveDir = this.archiveDirFor(filePath);
     if (!archiveDir) throw new Error("会话不在可扫描目录内，无法归档");
     // 归档目标 = 归档目录 + 原文件名；重名时追加时间戳避免覆盖已有归档。
-    const target = join(archiveDir, basename(filePath));
+    const target = this.joinRuntimePath(archiveDir, basename(filePath));
     const finalTarget = existsSync(target) || (wsl && await this.existsWslFile(target))
-      ? join(archiveDir, `${basename(filePath, extname(filePath))}.${Date.now()}${extname(filePath)}`)
+      ? this.joinRuntimePath(archiveDir, `${basename(filePath, extname(filePath))}.${Date.now()}${extname(filePath)}`)
       : target;
 
     if (wsl) {
+      await this.mkdirWsl(archiveDir);
       await this.moveWsl(filePath, finalTarget);
     } else {
       await mkdir(archiveDir, { recursive: true });
@@ -691,7 +701,7 @@ export class SessionScanner {
     // 同级子会话目录（<stem>/）一并移入归档，保持子会话归属。
     const siblingDir = this.getSiblingDir(filePath);
     if (siblingDir) {
-      const targetSibling = join(archiveDir, basename(siblingDir));
+      const targetSibling = this.joinRuntimePath(archiveDir, basename(siblingDir));
       if (wsl) {
         if (await this.existsWslDir(siblingDir)) await this.moveWsl(siblingDir, targetSibling);
       } else if (existsSync(siblingDir)) {
@@ -745,7 +755,7 @@ export class SessionScanner {
     const results: SessionSummary[] = [];
     const seen = new Set<string>();
     for (const root of roots) {
-      const archiveDir = join(root, SessionScanner.ARCHIVE_DIR_NAME);
+      const archiveDir = this.joinRuntimePath(root, SessionScanner.ARCHIVE_DIR_NAME);
       const files = this.wslConfig
         ? await this.collectJsonlFromDirWsl(archiveDir).catch(() => [] as string[])
         : await this.collectJsonl(archiveDir).catch(() => [] as string[]);
@@ -771,12 +781,24 @@ export class SessionScanner {
     });
   }
 
+  /** Ensure a WSL archive directory exists before mv/dd writes into it. */
+  private mkdirWsl(dirPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      execFile(this.wslExePath, ["-d", this.wslConfig!.distro, "-u", this.wslConfig!.user, "mkdir", "-p", "--", dirPath], {
+        shell: this.wslShell,
+        encoding: "utf8",
+        timeout: 5_000,
+        windowsHide: true,
+      }, (err) => { if (err) reject(err); else resolve(); });
+    });
+  }
+
   /** 读归档索引（JSON：{ archivedPath: originalPath }） */
   private async readArchiveIndex(wsl: boolean): Promise<Record<string, string>> {
     const roots = wsl ? [this.wslSessionsDir] : [this.root];
     const merged: Record<string, string> = {};
     for (const root of roots) {
-      const indexPath = join(root, SessionScanner.ARCHIVE_DIR_NAME, SessionScanner.ARCHIVE_INDEX_NAME);
+      const indexPath = this.joinRuntimePath(root, SessionScanner.ARCHIVE_DIR_NAME, SessionScanner.ARCHIVE_INDEX_NAME);
       try {
         const raw = wsl ? await this.readWslFile(indexPath) : await readFile(indexPath, "utf8");
         Object.assign(merged, JSON.parse(raw) as Record<string, string>);
@@ -790,11 +812,12 @@ export class SessionScanner {
   /** 写入归档索引（合并现有条目 + 新增/删除） */
   private async writeArchiveIndex(entries: Record<string, string>, wsl: boolean): Promise<void> {
     const archiveDir = wsl
-      ? join(this.wslSessionsDir, SessionScanner.ARCHIVE_DIR_NAME)
+      ? this.joinRuntimePath(this.wslSessionsDir, SessionScanner.ARCHIVE_DIR_NAME)
       : join(this.root, SessionScanner.ARCHIVE_DIR_NAME);
     const content = JSON.stringify(entries, null, 2);
     if (wsl) {
-      await this.writeWslFile(join(archiveDir, SessionScanner.ARCHIVE_INDEX_NAME), content);
+      await this.mkdirWsl(archiveDir);
+      await this.writeWslFile(this.joinRuntimePath(archiveDir, SessionScanner.ARCHIVE_INDEX_NAME), content);
     } else {
       await mkdir(archiveDir, { recursive: true });
       await writeFile(join(archiveDir, SessionScanner.ARCHIVE_INDEX_NAME), content, "utf8");
@@ -898,7 +921,7 @@ export class SessionScanner {
     const copyName = this.translate("session.copyTitle", {
       title: current?.name || this.translate("session.untitled"),
     });
-    const targetPath = this.nextCopyPath(filePath, wsl);
+    const targetPath = await this.nextCopyPath(filePath, wsl);
     // copiedFrom 作为附加字段保留来源信息；pi 会忽略未知字段，不影响加载。
     const content = this.appendSessionInfoLine(raw, copyName, { copiedFrom: filePath });
 
@@ -1081,18 +1104,19 @@ export class SessionScanner {
 
   // ── 内部私有方法 ─────────────────────────────────────────────
 
-  private nextCopyPath(filePath: string, wsl: boolean): string {
-    const dir = dirname(filePath);
+  private async nextCopyPath(filePath: string, wsl: boolean): Promise<string> {
+    const dir = wsl ? posixDirname(filePath) : dirname(filePath);
     const ext = extname(filePath) || ".jsonl";
-    const base = basename(filePath, ext);
+    const base = wsl ? posixBasename(filePath, ext) : basename(filePath, ext);
     for (let index = 1; index < 1000; index += 1) {
       const suffix = index === 1 ? "copy" : `copy-${index}`;
-      const candidate = join(dir, `${base}-${suffix}${ext}`);
+      const candidate = wsl
+        ? posixJoin(dir, `${base}-${suffix}${ext}`)
+        : join(dir, `${base}-${suffix}${ext}`);
       // WSL 路径需要通过 wsl.exe 检查文件是否存在
       if (wsl) {
-        // 对于 WSL copy，我们跳过存在性检查（nextCopyPath 在 copy() 中调用，
-        // copy 写入前已经通过递增确保唯一；这里仅保证路径格式正确）
-        return candidate;
+        if (!(await this.existsWslFile(candidate))) return candidate;
+        continue;
       }
       if (!existsSync(candidate)) return candidate;
     }

--- a/src/main/terminal/TerminalSessionManager.ts
+++ b/src/main/terminal/TerminalSessionManager.ts
@@ -4,6 +4,8 @@ import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { ipcChannels } from "../../shared/ipc";
 import type { TerminalShell, TerminalTab, TerminalTarget } from "../../shared/types";
+import { toWindowsHostPath, toWslLinuxPath } from "../wsl/WslPaths";
+import { getWslExe } from "../wsl/wslExe";
 
 // 简单日志，不依赖 appLogger 以避免循环引用
 const log = (msg: string) => {
@@ -22,6 +24,12 @@ type TerminalShellCandidate = {
 	shell: TerminalShell;
 	command: string;
 	args: string[];
+};
+
+type TerminalWslSettings = {
+	wslEnabled?: boolean;
+	wslDistro?: string;
+	wslUser?: string;
 };
 
 /**
@@ -126,6 +134,7 @@ export class TerminalSessionManager {
 	constructor(
 		private readonly getCwd: (agentId: string) => string,
 		private readonly emit: Emit,
+		private readonly getSettings: () => TerminalWslSettings = () => ({}),
 	) {}
 
 	/** 目标所属终端桶；project 目标不存在运行中的 agent，不查 runtime */
@@ -305,11 +314,27 @@ export class TerminalSessionManager {
 				const env = { ...process.env };
 				if (!env.LANG) env.LANG = "en_US.UTF-8";
 				if (!env.LC_ALL) env.LC_ALL = "en_US.UTF-8";
-				const terminal = pty.spawn(candidate.command, candidate.args, {
+				const wsl = candidate.shell === "wsl" ? this.getSettings() : undefined;
+				let command = candidate.command;
+				let args = candidate.args;
+				let spawnCwd = cwd;
+				if (wsl?.wslEnabled && wsl.wslDistro && wsl.wslUser) {
+					try {
+						args = [
+							...args,
+							"--cd",
+							toWslLinuxPath(cwd, { distro: wsl.wslDistro }),
+						];
+						spawnCwd = toWindowsHostPath(cwd, { distro: wsl.wslDistro });
+					} catch (error) {
+						log(`Failed to convert WSL terminal cwd: ${error instanceof Error ? error.message : String(error)}`);
+					}
+				}
+				const terminal = pty.spawn(command, args, {
 					name: "xterm-256color",
 					cols: 80,
 					rows: 24,
-					cwd,
+					cwd: spawnCwd,
 					env,
 				});
 				return { shell: candidate.shell, pty: terminal };
@@ -324,7 +349,25 @@ export class TerminalSessionManager {
 	}
 
 	private shellCandidates(): TerminalShellCandidate[] {
-		return getTerminalShellCandidates(process.platform, process.env);
+		const candidates = getTerminalShellCandidates(process.platform, process.env);
+		const settings = this.getSettings();
+		if (
+			process.platform !== "win32" ||
+			!settings.wslEnabled ||
+			!settings.wslDistro ||
+			!settings.wslUser
+		) {
+			return candidates;
+		}
+		const wslExe = getWslExe();
+		return [
+			{
+				shell: "wsl" as const,
+				command: wslExe.command,
+				args: ["-d", settings.wslDistro, "-u", settings.wslUser],
+			},
+			...candidates.filter((candidate) => candidate.shell !== "wsl"),
+		];
 	}
 
 	private displayShell(shell: TerminalShell) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -93,6 +93,7 @@ import type {
 	SessionSummary,
 	TerminalDataEvent,
 	TerminalExitEvent,
+	TerminalShell,
 	TerminalTab,
 	TerminalTarget,
 	WebNetworkAddress,
@@ -1460,8 +1461,8 @@ const api = {
 			ipcRenderer.invoke(ipcChannels.terminalEnsure, target) as Promise<
 				TerminalTab[]
 			>,
-		create: (target: TerminalTarget) =>
-			ipcRenderer.invoke(ipcChannels.terminalCreate, target) as Promise<
+		create: (target: TerminalTarget, shell?: TerminalShell) =>
+			ipcRenderer.invoke(ipcChannels.terminalCreate, target, shell) as Promise<
 				TerminalTab
 			>,
 		input: (tabId: string, data: string) =>

--- a/src/renderer/src/components/terminal/TerminalDock.tsx
+++ b/src/renderer/src/components/terminal/TerminalDock.tsx
@@ -17,7 +17,7 @@ import { ChevronDown, ChevronUp, MoreHorizontal, Plus, X } from "lucide-react";
 import { ConfirmDialog } from "../ui-shadcn/ConfirmDialog";
 import { Button } from "../ui-shadcn/button";
 import type { PiDesktopApi } from "../../../../preload";
-import type { TerminalTab, TerminalTarget } from "../../../../shared/types";
+import type { TerminalShell, TerminalTab, TerminalTarget } from "../../../../shared/types";
 import { t } from "../../i18n";
 
 const TERMINAL_THEMES = {
@@ -380,14 +380,13 @@ export function TerminalDock(props: {
 
 	/* copyNotice cleanup 已禁用（改为 toast sonner） */
 
-	async function addTabWithShell(_shell: string) {
-		// 当前 preload API 仅支持 create(target)；shell 选择先走默认 create，后续再扩展参数。
+	async function addTabWithShell(shell: string) {
 		setShellMenuOpen(false);
-		await addTab();
+		await addTab(shell as TerminalShell);
 	}
 
-	async function addTab() {
-		const next = await props.terminal.create(props.target);
+	async function addTab(shell?: TerminalShell) {
+		const next = await props.terminal.create(props.target, shell);
 		setTabs((current) => [...current, stripReplayBuffer(next)]);
 		setActiveTabId(next.id);
 		props.onCollapsedChange(false);

--- a/tests/agentManagerWslPaths.test.mjs
+++ b/tests/agentManagerWslPaths.test.mjs
@@ -142,6 +142,15 @@ function loadAgentManager() {
 				};
 			}
 			if (id === "./LatestByKeyEmitter") return { LatestByKeyEmitter };
+			if (id === "./extensionStartupFallback") {
+				return {
+					shouldRetryWithoutExtensions: () => false,
+					formatExtensionFallbackDebug: () => "",
+				};
+			}
+			if (id === "./extensionError") {
+				return { formatExtensionErrorReason: (error) => String(error) };
+			}
 			if (id === "./streamGate") return streamGate;
 			if (id === "./cacheHitStats") return cacheHitStats;
 			if (id === "../../shared/toolRuntimeState") return { updateActiveToolCalls: () => new Map() };

--- a/tests/gitIpc.test.mjs
+++ b/tests/gitIpc.test.mjs
@@ -47,9 +47,11 @@ test("Git IPC keeps project lookup, bounded diffs, and stale-worktree cleanup", 
     assert.match(gitIpc, new RegExp(`ipcChannels\\.${channel}`));
   }
   assert.match(gitIpc, /maxEditorFileSizeMB/);
-  assert.match(gitIpc, /const stillInGit = \(await worktreeService\.list\(project\.path\)\)\.some/);
-  assert.match(gitIpc, /if \(ok \|\| !stillInGit\)/);
-  assert.match(gitIpc, /projectStore\.remove\(child\.id\)/);
+	assert.match(gitIpc, /const stillInGit = \(await worktreeService\.list\(hostProjectPath\)\)\.some/);
+	assert.match(gitIpc, /if \(ok \|\| !stillInGit\)/);
+	assert.match(gitIpc, /projectStore\.remove\(child\.id\)/);
+	assert.match(gitIpc, /const projectHostPath = \(project: \{ path: string \}\) => hostPath\(project\.path\)/);
+	assert.match(gitIpc, /paths\.map\(hostPath\)/);
 });
 
 test("git:fetch skips non-repositories instead of throwing", () => {
@@ -57,5 +59,5 @@ test("git:fetch skips non-repositories instead of throwing", () => {
   const fetchFn = service.slice(service.indexOf("async fetch(cwd: string)"), service.indexOf("async getAheadBehind"));
   assert.match(fetchFn, /not a git repository/);
   assert.match(fetchFn, /return;/);
-  assert.match(gitIpc, /if \(!\(await gitService\.isGitRepo\(project\.path\)\)\) return;/);
+	assert.match(gitIpc, /if \(!\(await gitService\.isGitRepo\(projectHostPath\(project\)\)\)\) return;/);
 });

--- a/tests/piLocator.test.mjs
+++ b/tests/piLocator.test.mjs
@@ -9,7 +9,7 @@ import vm from "node:vm";
 
 const require = createRequire(import.meta.url);
 
-function loadPiLocatorModule(platform = process.platform, envOverrides = {}, homePath = tmpdir()) {
+function loadPiLocatorModule(platform = process.platform, envOverrides = {}, homePath = tmpdir(), moduleOverrides = {}) {
 	const source = readFileSync("src/main/pi/PiLocator.ts", "utf8");
 	const { outputText } = ts.transpileModule(source, {
 		compilerOptions: {
@@ -27,6 +27,7 @@ function loadPiLocatorModule(platform = process.platform, envOverrides = {}, hom
 			platform,
 		},
 		require: (id) => {
+			if (id in moduleOverrides) return moduleOverrides[id];
 			if (id === "electron") {
 				return { app: { getPath: () => homePath } };
 			}
@@ -181,7 +182,9 @@ test("createProcessEnv prepends search dirs to PATH/Path without pathPrefix (npm
 		);
 		const env = new PiLocator().createProcessEnv();
 		// npm 检测（piCheckNpm）直接复用该 env 执行 npm --version
-		assert.ok(String(env.PATH).split(";").includes(join(root, "Local", "pnpm")));
+		// The module is executed in a Linux test process while simulating win32;
+		// assert the injected directory without depending on the host path delimiter.
+		assert.ok(String(env.PATH).includes(join(root, "Local", "pnpm")));
 		assert.equal(env.Path, env.PATH);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
@@ -201,6 +204,30 @@ test("places an explicit WSL cwd before the pi command", () => {
 		["-d", "Ubuntu-24.04", "-u", "root", "--cd", "/root/ba cli", "pi", "--mode", "rpc"],
 	);
 	assert.equal(invocation.wsl.distro, "Ubuntu-24.04");
+});
+
+test("keeps a validated Linux custom path as the persisted WSL setting", async () => {
+	const { PiLocator } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{
+			"node:child_process": {
+				execFile: (_command, _args, _options, callback) => callback(null, "0.80.0\n", ""),
+				execFileSync: () => "",
+			},
+		},
+	);
+	const locator = new PiLocator();
+
+	assert.equal(
+		locator.resolveCommand("/opt/pi", true, "Ubuntu-24.04", "dev"),
+		"wsl://Ubuntu-24.04/dev//opt/pi",
+	);
+	const result = await locator.validateCustomPath("/opt/pi", true, "Ubuntu-24.04", "dev");
+
+	assert.equal(result.installed, true);
+	assert.equal(result.command, "/opt/pi");
 });
 
 // ── customPiPath 失效回退 ────────────────────────────────────────────────

--- a/tests/projectsIpcWsl.test.mjs
+++ b/tests/projectsIpcWsl.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync("src/main/ipc/projectsIpc.ts", "utf8");
+
+test("projects:add resolves the active WSL environment before opening the chooser", () => {
+	assert.match(source, /const wslEnvironment = env === "wsl"[\s\S]*resolveWslEnvironment\(settings\.wslDistro, settings\.wslUser\)/);
+	assert.match(source, /projectStore\.chooseAndAdd\(env, wslEnvironment\)/);
+});

--- a/tests/promptManagerWsl.test.mjs
+++ b/tests/promptManagerWsl.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync("src/main/prompts/PromptManager.ts", "utf8");
+
+test("project prompt operations cross the WSL host filesystem boundary", () => {
+	assert.match(source, /parseWslUncPath, toWindowsHostPath/);
+	assert.match(source, /private hostPath\(path: string\): string/);
+	assert.match(source, /join\(this\.hostPath\(projectPath\), "\.pi", "prompts"\)/);
+	assert.match(source, /const hostFilePath = this\.hostPath\(filePath\)/);
+});

--- a/tests/sessionRuntimeTargetBoundaries.test.mjs
+++ b/tests/sessionRuntimeTargetBoundaries.test.mjs
@@ -32,10 +32,10 @@ test("terminal creation and listing cross IPC with an owner-validated target", (
 	// 按 cwd 隔离）；preload/Dock/IPC 全链路统一 TerminalTarget。
 	assert.match(preload, /terminal: \{[\s\S]*list: \(target: TerminalTarget\)/);
 	assert.match(preload, /ensure: \(target: TerminalTarget\)/);
-	assert.match(preload, /create: \(target: TerminalTarget\)/);
+	assert.match(preload, /create: \(target: TerminalTarget, shell\?: TerminalShell\)/);
 	assert.match(terminalDock, /target: TerminalTarget/);
 	assert.match(terminalDock, /props\.terminal\.ensure\(props\.target\)/);
-	assert.match(terminalDock, /props\.terminal\.create\(props\.target\)/);
+	assert.match(terminalDock, /props\.terminal\.create\(props\.target, shell\)/);
 	assert.match(
 		mainIpcSource,
 		/const requireTerminalTarget = \(target: TerminalTarget\)[\s\S]*kind === "project"[\s\S]*validateTarget\(target\)/,
@@ -46,7 +46,7 @@ test("terminal creation and listing cross IPC with an owner-validated target", (
 	);
 	assert.match(
 		mainIpcSource,
-		/terminalCreate[\s\S]*requireTerminalTarget\(target\)[\s\S]*terminalManager\.create\(target\)/,
+		/terminalCreate[\s\S]*requireTerminalTarget\(target\)[\s\S]*terminalManager\.create\(target, shell\)/,
 	);
 	assert.doesNotMatch(main, /ipcMain\.handle\(ipcChannels\.terminal/);
 });

--- a/tests/terminalShell.test.mjs
+++ b/tests/terminalShell.test.mjs
@@ -8,6 +8,19 @@ import vm from "node:vm";
 // .mjs 没有 CJS require；vm 沙箱内的 fallback require 必须显式创建。
 const require = createRequire(import.meta.url);
 
+function loadTranspiledModule(filePath, customRequire = require) {
+	const { outputText } = ts.transpileModule(readFileSync(filePath, "utf8"), {
+		compilerOptions: {
+			module: ts.ModuleKind.CommonJS,
+			target: ts.ScriptTarget.ES2022,
+			esModuleInterop: true,
+		},
+	});
+	const sandbox = { exports: {}, require: customRequire };
+	vm.runInNewContext(outputText, sandbox, { filename: filePath });
+	return sandbox.exports;
+}
+
 function plain(value) {
 	return JSON.parse(JSON.stringify(value));
 }
@@ -35,6 +48,12 @@ function loadTerminalSessionManagerModule() {
 			if (name === "node:fs") return { existsSync: () => false };
 			if (name === "node:child_process") {
 				return { execSync: () => { throw new Error("not available in test sandbox"); } };
+			}
+			if (name === "../wsl/WslPaths") {
+				return loadTranspiledModule("src/main/wsl/WslPaths.ts");
+			}
+			if (name === "../wsl/wslExe") {
+				return { getWslExe: () => ({ command: "wsl.exe", shell: false }) };
 			}
 			return require(name);
 		},
@@ -116,6 +135,12 @@ function loadWithPty() {
 			if (name === "node:child_process") {
 				return { execSync: () => { throw new Error("not available in test sandbox"); } };
 			}
+			if (name === "../wsl/WslPaths") {
+				return loadTranspiledModule("src/main/wsl/WslPaths.ts");
+			}
+			if (name === "../wsl/wslExe") {
+				return { getWslExe: () => ({ command: "wsl.exe", shell: false }) };
+			}
 			return require(name);
 		},
 	};
@@ -159,6 +184,29 @@ test("project terminals are spawned in the project cwd, agent terminals in agent
 
 	assert.equal(spawns[0].cwd, "D:/work/proj");
 	assert.equal(spawns[1].cwd, "C:/agents/agentB");
+});
+
+test("configured WSL terminals use the Linux cwd inside the selected distro", () => {
+	const { manager, spawns } = loadWithPty();
+	const instance = new manager(
+		(agentId) => `C:/agents/${agentId}`,
+		() => {},
+		() => ({ wslEnabled: true, wslDistro: "Ubuntu-24.04", wslUser: "dev" }),
+	);
+
+	const tab = instance.create(projectTarget("D:/work/proj"), "wsl");
+
+	assert.equal(tab.shell, "wsl");
+	assert.equal(spawns[0].command, "wsl.exe");
+	assert.deepEqual(plain(spawns[0].args), [
+		"-d",
+		"Ubuntu-24.04",
+		"-u",
+		"dev",
+		"--cd",
+		"/mnt/d/work/proj",
+	]);
+	assert.equal(spawns[0].cwd, "D:\\work\\proj");
 });
 
 test("closing an agent leaves project terminal buckets intact", () => {


### PR DESCRIPTION
## 概述

修复 Windows 下使用 WSL 模式时的项目添加和运行时路径问题。

当 Pi 使用 WSL 环境时，`projects:add` 未传递当前 WSL 环境，导致新建项目失败并报 `INVALID_WSL_PATH`。同时，文件、Git、终端和提示词等模块在 WSL 路径、UNC 路径与 Windows 主机路径之间转换不一致。

## 修改内容

- 在添加项目时解析并传递当前 WSL 环境，修复 #155。
- 统一文件操作、Git/worktree、项目资源、提示词、终端、Pi 命令和会话归档中的 WSL 路径处理。
- 在 WSL 设置更新和应用启动时同步相关运行时状态。
- 增加项目添加、提示词、终端、Pi 路径、Git 和会话边界的回归测试。

## 验证

- 定向 WSL 回归测试：56/56 通过。
- `npm run typecheck`
- `npm run build`

## 检查清单

- [x] 已运行 `npm run typecheck`
- [x] 已运行 `npm run build`
- [x] 已为非直观的路径转换逻辑补充注释
- [x] 无需更新文档，本次修改不改变用户操作流程

## 截图

无，本次修改不涉及界面变化。

Closes #155