### PR TITLE
feat: add project session pinning

### DIFF
--- a/src/main/settings/SettingsStore.ts
+++ b/src/main/settings/SettingsStore.ts
@@ -11,6 +11,7 @@ import {
   parseImageGenWatermark,
 } from "../../shared/imageGenParams";
 import { createDefaultExternalEditorSettings, DEFAULT_PET_SCALE, type AppSettings } from "../../shared/types";
+import { normalizePinnedSessionIds } from "../../shared/pinnedSessions";
 import { parseBusySendDelivery } from "../../shared/busySendDelivery";
 import { normalizeThemeSchedule } from "../../shared/themeSchedule";
 import { getAppLogger } from "../logging/sharedLogger";
@@ -286,6 +287,8 @@ export class SettingsStore {
       });
       this.settings.themeScheduleLightStart = schedule.lightStart;
       this.settings.themeScheduleDarkStart = schedule.darkStart;
+      // 置顶状态只接受稳定、非空的 SessionRecord id；旧设置缺省时自然回落为空。
+      this.settings.pinnedSessionIds = normalizePinnedSessionIds(parsed.pinnedSessionIds);
     } catch {
       this.settings = { ...defaultSettings };
     }
@@ -346,6 +349,9 @@ export class SettingsStore {
     // 忙碌时投递行为来自渲染层，非法值丢掉，避免发送链路带着坏语义。
     if ("busySendDelivery" in safePatch) {
       safePatch.busySendDelivery = parseBusySendDelivery(safePatch.busySendDelivery);
+    }
+    if ("pinnedSessionIds" in safePatch) {
+      safePatch.pinnedSessionIds = normalizePinnedSessionIds(safePatch.pinnedSessionIds);
     }
     // 闲置 agent 释放参数来自渲染层，钳制到合理范围避免非法值（0/负数/超大）写入磁盘
     if ("idleAgentKeepCount" in safePatch) {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3145,6 +3145,7 @@ export function App() {
       onOpenFeedback={() => overlays.setFeedbackOpen(true)}
       settingsExpandedProjectIds={settings.sidebarExpandedProjectIds}
       settingsNavTab={settings.sidebarNavTab}
+      settingsPinnedSessionIds={settings.pinnedSessionIds}
       settingsLoaded={settingsLoaded}
       onExpandedProjectsReady={() => setExpandedProjectsReady(true)}
       // 官网主页是品牌入口，强制系统浏览器打开：不受「链接打开方式=内置浏览器」设置影响

--- a/src/renderer/src/agentListDisplay.ts
+++ b/src/renderer/src/agentListDisplay.ts
@@ -61,6 +61,29 @@ export type ProjectAgentSessionDisplay = {
 };
 
 /**
+ * Resolve the durable session identity carried by a project child row.
+ * Transient agents without a catalog Session deliberately return undefined and
+ * cannot be pinned because agentId is not stable across restarts.
+ */
+export function getProjectChildSessionId(child: ProjectChildItem): string | undefined {
+	return child.type === "session" ? child.session.id : undefined;
+}
+
+/** Pinned rows lead their project while each partition keeps the existing time order. */
+export function compareProjectChildren(
+	left: ProjectChildItem,
+	right: ProjectChildItem,
+	pinnedSessionIds: ReadonlySet<string>,
+): number {
+	const leftId = getProjectChildSessionId(left);
+	const rightId = getProjectChildSessionId(right);
+	const leftPinned = leftId !== undefined && pinnedSessionIds.has(leftId);
+	const rightPinned = rightId !== undefined && pinnedSessionIds.has(rightId);
+	if (leftPinned !== rightPinned) return leftPinned ? -1 : 1;
+	return right.sortAt - left.sortAt;
+}
+
+/**
  * 统一列表（Agent/历史会话行）已占用的 catalog Session ID。
  * draft 区块必须排除这些 ID，否则启动后会出现「draft 标题行 + Agent 行」重复入口。
  */
@@ -211,10 +234,13 @@ export function getProjectAgentSessionDisplay({
 	agents,
 	sessions,
 	visibleChildCount,
+	pinnedSessionIds = new Set<string>(),
 }: {
 	agents: AgentTab[];
 	sessions: SessionSummary[];
 	visibleChildCount?: number;
+	/** Stable SessionRecord ids pinned inside this project's list. Unknown ids are ignored. */
+	pinnedSessionIds?: ReadonlySet<string>;
 }): ProjectAgentSessionDisplay {
 	const sessionByKey = new Map<string, SessionSummary>();
 	const unkeyedSessions: SessionSummary[] = [];
@@ -439,7 +465,7 @@ export function getProjectAgentSessionDisplay({
 		}
 	}
 
-	children.sort((left, right) => right.sortAt - left.sortAt);
+	children.sort((left, right) => compareProjectChildren(left, right, pinnedSessionIds));
 
 	const limit = visibleChildCount ?? DEFAULT_VISIBLE_PROJECT_CHILD_LIMIT;
 	const visibleChildren = children.slice(0, limit);

--- a/src/renderer/src/components/sidebar/AppSidebar.tsx
+++ b/src/renderer/src/components/sidebar/AppSidebar.tsx
@@ -33,6 +33,8 @@ interface AppSidebarProps {
   settingsExpandedProjectIds?: readonly string[];
   /** settings.json 中已保存的侧栏分段（Chats/项目），权威来源 */
   settingsNavTab?: SidebarNavTab;
+  /** settings.json 中已保存的稳定 SessionRecord 置顶 id。 */
+  settingsPinnedSessionIds?: readonly string[];
   /** 首次 settings.get 已完成，controller 可安全处理旧 key 迁移。 */
   settingsLoaded: boolean;
   /** 展开集合完成权威 hydration 后，允许 App 按它懒加载会话。 */
@@ -43,10 +45,12 @@ export function AppSidebar(props: AppSidebarProps) {
   const setSettingsOpen = useSetAtom(settingsOpenAtom);  // 快速连续点击展开/折叠会触发多次 IPC；按顺序写入可避免旧请求最后完成后覆盖新集合。
   const expandedProjectsSaveQueueRef = useRef<Promise<unknown>>(Promise.resolve());
   const navTabSaveQueueRef = useRef<Promise<unknown>>(Promise.resolve());
+  const pinnedSessionIdsSaveQueueRef = useRef<Promise<unknown>>(Promise.resolve());
   const controller = useSidebarController({
     getRpcLogging: props.actions.rpc.getLogging,
     settingsExpandedProjectIds: props.settingsExpandedProjectIds,
     settingsNavTab: props.settingsNavTab,
+    settingsPinnedSessionIds: props.settingsPinnedSessionIds,
     settingsLoaded: props.settingsLoaded,
     onExpandedProjectsReady: props.onExpandedProjectsReady,
     persistExpandedProjectIds: (projectIds) => {
@@ -60,6 +64,13 @@ export function AppSidebar(props: AppSidebarProps) {
       navTabSaveQueueRef.current = navTabSaveQueueRef.current
         .catch(() => undefined)
         .then(() => desktopApi.settings.update({ sidebarNavTab: tab }))
+        .catch(() => undefined);
+    },
+    persistPinnedSessionIds: (sessionIds) => {
+      // 快速连续置顶/取消置顶必须按触发顺序落盘，避免较慢的旧请求覆盖新集合。
+      pinnedSessionIdsSaveQueueRef.current = pinnedSessionIdsSaveQueueRef.current
+        .catch(() => undefined)
+        .then(() => desktopApi.settings.update({ pinnedSessionIds: sessionIds }))
         .catch(() => undefined);
     },
   });

--- a/src/renderer/src/components/sidebar/SessionTree.tsx
+++ b/src/renderer/src/components/sidebar/SessionTree.tsx
@@ -1,5 +1,5 @@
 import { Fragment, type ReactNode } from "react";
-import { ChevronDown, ChevronUp, Ellipsis, HatGlasses, Image as ImageIcon, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Ellipsis, HatGlasses, Image as ImageIcon, Pin, Trash2 } from "lucide-react";
 import type { AgentTab, Project, SessionRecord, SessionSummary } from "../../../../shared/types";
 import { collectDisplayedSessionIds, filterAgentsForSidebarDisplay, getProjectAgentSessionDisplay, sessionStatusDotClass, type ProjectChildItem } from "../../agentListDisplay";
 import { sessionRecordToSummary } from "../../atoms";
@@ -113,6 +113,7 @@ export function SessionTree(props: {
     agents: displayAgents,
     sessions: summaries,
     visibleChildCount: props.visibleChildCount ?? (props.nested ? Number.MAX_SAFE_INTEGER : props.controller.visibleChildCountFor(props.project.id)),
+    pinnedSessionIds: props.controller.pinnedSessionIds,
   });
   const displayedSessionIds = collectDisplayedSessionIds(
     display.visibleChildren,
@@ -158,12 +159,12 @@ export function SessionTree(props: {
     },
   });
 
-  const openContext = (event: React.MouseEvent, session: SessionSummary) => {
+  const openContext = (event: React.MouseEvent, session: SessionSummary, pinnable = true) => {
     event.preventDefault();
     const runtime = getBoundSidebarRuntimeAgent(props.controller.catalog, session.id);
     void props.controller.openMenu(runtime
-      ? { kind: "agent", agentId: runtime.id, x: event.clientX, y: event.clientY }
-      : { kind: "session", projectId: props.project.id, sessionId: session.id, x: event.clientX, y: event.clientY });
+      ? { kind: "agent", agentId: runtime.id, pinnable, x: event.clientX, y: event.clientY }
+      : { kind: "session", projectId: props.project.id, sessionId: session.id, pinnable, x: event.clientX, y: event.clientY });
   };
   const openDraftContext = (event: React.MouseEvent, session: SessionRecord) => {
     event.preventDefault();
@@ -173,6 +174,7 @@ export function SessionTree(props: {
       void props.controller.openMenu({
         kind: "agent",
         agentId: runtimeAgent.id,
+        pinnable: false,
         x: event.clientX,
         y: event.clientY,
       });
@@ -191,7 +193,7 @@ export function SessionTree(props: {
       <div
         key={session.id}
         className={rowContainerClass}
-        onContextMenu={(event) => openContext(event, session)}
+        onContextMenu={(event) => openContext(event, session, false)}
       >
         <button
           type="button"
@@ -217,7 +219,7 @@ export function SessionTree(props: {
           title={t("sidebar.moreActions")}
           onClick={(event) => {
             event.stopPropagation();
-            openContext(event, session);
+            openContext(event, session, false);
           }}
         >
           <Ellipsis size={14} aria-hidden="true" />
@@ -304,6 +306,7 @@ export function SessionTree(props: {
     }
     const runtime = getBoundSidebarRuntimeAgent(props.controller.catalog, child.session.id);
     const runtimeSnapshot = props.controller.catalog.runtimeBySessionId[child.session.id];
+    const pinned = props.controller.isSessionPinned(child.session.id);
     return <Fragment key={child.session.id}>
       <div
         className={rowContainerClass}
@@ -323,6 +326,12 @@ export function SessionTree(props: {
           {...sessionDragProps(child.session.id)}
         >
           {renderRuntimeStatusDot(runtimeSnapshot?.status)}
+          {pinned && (
+            <Pin
+              className="size-3 shrink-0 text-muted-foreground"
+              aria-hidden="true"
+            />
+          )}
           <div className="conversation-body min-w-0 flex-1 transition-[padding-right] group-hover/row:pr-7 group-focus-within/row:pr-7"><div className="conversation-title flex min-w-0 items-center gap-1.5">
             {/* 历史会话（无运行态）文字降一级，与活跃 Agent/运行中会话形成层级差 */}
             <strong className={cn("min-w-0 flex-1 truncate", runtime ? "font-medium" : "font-normal text-muted-foreground/90")}>{child.session.name || t("common.untitled")}</strong>

--- a/src/renderer/src/components/sidebar/SidebarComponents.tsx
+++ b/src/renderer/src/components/sidebar/SidebarComponents.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, type ReactNode } from "react";
-import { Archive, Boxes, Check, CircleAlert, CircleDot, Code2, Copy, Download, FileDown, FileText, Filter, Folder, FolderSearch, GitBranch, Link2, List, LoaderCircle, MessageCircle, Pencil, Plus, Power, Radio, RefreshCw, RotateCw, ScrollText, Settings2, SquarePen, Trash2, UserPlus, XCircle } from "lucide-react";
+import { Archive, Boxes, Check, CircleAlert, CircleDot, Code2, Copy, Download, FileDown, FileText, Filter, Folder, FolderSearch, GitBranch, Link2, List, LoaderCircle, MessageCircle, Pencil, Pin, PinOff, Plus, Power, Radio, RefreshCw, RotateCw, ScrollText, Settings2, SquarePen, Trash2, UserPlus, XCircle } from "lucide-react";
 import { t } from "../../i18n";
 import {
 	AlertDialog,
@@ -702,6 +702,8 @@ export function AgentContextMenu(props: {
 	actionLoading?: "copy" | "export" | null;
 	onClose: () => void;
 	onRename: () => void;
+	isPinned?: boolean;
+	onTogglePinned?: () => void;
 	onExport: () => void;
 	onCopySession: () => void;
 	onCopySessionFilePath: () => void;
@@ -730,6 +732,14 @@ export function AgentContextMenu(props: {
 				<Pencil className="size-3.5" aria-hidden="true" />
 				{t("common.rename")}
 			</DropdownMenuItem>
+			{props.onTogglePinned && (
+				<DropdownMenuItem disabled={busy} onSelect={props.onTogglePinned}>
+					{props.isPinned
+						? <PinOff className="size-3.5" aria-hidden="true" />
+						: <Pin className="size-3.5" aria-hidden="true" />}
+					{t(props.isPinned ? "menu.unpinSession" : "menu.pinSession")}
+				</DropdownMenuItem>
+			)}
 			{/* DSH 运行中会话的复制走 clone 分流（fork 无锚点完整副本），保留入口；
 			    导出 HTML 无 DSH 实现（G10 待决策），对 dsh agent 隐藏 */}
 			<DropdownMenuItem disabled={busy} onSelect={props.onCopySession}>
@@ -828,6 +838,8 @@ export function SessionContextMenu(props: {
 	actionLoading?: "copy" | "export" | null;
 	onClose: () => void;
 	onRename: () => void;
+	isPinned?: boolean;
+	onTogglePinned?: () => void;
 	onExport: () => void;
 	onCopySession: () => void;
 	onCopySessionFilePath: () => void;
@@ -861,6 +873,14 @@ export function SessionContextMenu(props: {
 				<Pencil className="size-3.5" aria-hidden="true" />
 				{t("common.rename")}
 			</DropdownMenuItem>
+			{props.onTogglePinned && (
+				<DropdownMenuItem disabled={busy} onSelect={props.onTogglePinned}>
+					{props.isPinned
+						? <PinOff className="size-3.5" aria-hidden="true" />
+						: <Pin className="size-3.5" aria-hidden="true" />}
+					{t(props.isPinned ? "menu.unpinSession" : "menu.pinSession")}
+				</DropdownMenuItem>
+			)}
 			{props.onRestartSession && (
 				<DropdownMenuItem disabled={busy} onSelect={props.onRestartSession}>
 					<span className="inline-flex items-center gap-2">

--- a/src/renderer/src/components/sidebar/SidebarContent.tsx
+++ b/src/renderer/src/components/sidebar/SidebarContent.tsx
@@ -142,6 +142,16 @@ export function SidebarContent(props: SidebarContentProps) {
   const menuAgent = menu?.kind === "agent"
     ? controller.catalog.agents.find((agent) => agent.id === menu.agentId)
     : undefined;
+  const menuAgentSessionId = menuAgent
+    ? Object.entries(controller.catalog.runtimeBySessionId).find(
+      ([, runtime]) => runtime?.agentId === menuAgent.id,
+    )?.[0]
+    : undefined;
+  const menuAgentSessionRecord = menuAgentSessionId && menuAgent
+    ? controller.catalog.sessionsByProject[menuAgent.projectId]?.find(
+      (session) => session.id === menuAgentSessionId,
+    )
+    : undefined;
 
   // 底栏主题按钮：图标与文案反映当前主题模式；点击翻转浅/暗（规则见 themeAppearance.toggleThemeMode）
   const ThemeModeIcon =
@@ -438,6 +448,11 @@ export function SidebarContent(props: SidebarContentProps) {
           menu={{ x: menu.x, y: menu.y, agent: menuAgent }}
           onClose={controller.closeMenu}
           onRename={() => { actions.agents.rename(menuAgent); controller.closeMenu(); }}
+          isPinned={menuAgentSessionRecord ? controller.isSessionPinned(menuAgentSessionRecord.id) : false}
+          onTogglePinned={menuAgentSessionRecord && menu.pinnable !== false ? () => {
+            controller.toggleSessionPin(menuAgentSessionRecord.id);
+            controller.closeMenu();
+          } : undefined}
           onExport={() => { void actions.agents.export(menuAgent); controller.closeMenu(); }}
           onCopySession={() => { void actions.agents.copySession(menuAgent); controller.closeMenu(); }}
           onCopySessionFilePath={() => { void actions.agents.copyPath(menuAgent); controller.closeMenu(); }}
@@ -506,6 +521,11 @@ export function SidebarContent(props: SidebarContentProps) {
           menu={{ x: menu.x, y: menu.y, session: menuSession }}
           onClose={controller.closeMenu}
           onRename={() => { actions.sessions.rename(menu.projectId, menuSession); controller.closeMenu(); }}
+          isPinned={controller.isSessionPinned(menuSession.id)}
+          onTogglePinned={menu.pinnable ? () => {
+            controller.toggleSessionPin(menuSession.id);
+            controller.closeMenu();
+          } : undefined}
           onOpenProxySetting={() => { controller.closeMenu(); setProxyDialogSessionId(menuSession.id); }}
           // 重启会话（未启动的历史会话走 activateRuntime 启动；有绑定则走 restartRuntime）
           onRestartSession={() => { controller.closeMenu(); void actions.sessions.restart(menu.projectId, menuSession); }}

--- a/src/renderer/src/hooks/useSidebarController.ts
+++ b/src/renderer/src/hooks/useSidebarController.ts
@@ -42,8 +42,8 @@ export type SidebarSourceFilterMenu = {
 };
 export type SidebarMenuTarget =
   | { kind: "project"; projectId: string; x: number; y: number }
-  | { kind: "agent"; agentId: string; x: number; y: number }
-  | { kind: "session"; projectId: string; sessionId: string; x: number; y: number }
+  | { kind: "agent"; agentId: string; pinnable?: boolean; x: number; y: number }
+  | { kind: "session"; projectId: string; sessionId: string; pinnable: boolean; x: number; y: number }
   | { kind: "draft"; projectId: string; sessionId: string; x: number; y: number };
 
 export type SidebarRpcLog = {
@@ -85,6 +85,10 @@ export type SidebarController = {
   /** 侧栏 Chats/项目分段当前选中；记忆上次选择，双写到 localStorage 与 settings.json */
   navTab: SidebarNavTab;
   setNavTab: (tab: SidebarNavTab) => void;
+  /** Stable SessionRecord ids pinned within their owning project list. */
+  pinnedSessionIds: ReadonlySet<string>;
+  isSessionPinned: (sessionId: string) => boolean;
+  toggleSessionPin: (sessionId: string) => void;
   expandedProjectIds: ReadonlySet<string>;
   isProjectCollapsed: (projectId: string) => boolean;
   toggleProject: (projectId: string) => void;
@@ -218,6 +222,10 @@ export function useSidebarController(options: {
   persistNavTab?: (tab: SidebarNavTab) => void;
   /** settings.json 中的权威侧栏分段，首次拿到时覆盖本地缓存 */
   settingsNavTab?: SidebarNavTab;
+  /** 置顶会话 id 的权威 settings.json 值。 */
+  settingsPinnedSessionIds?: readonly string[];
+  /** 置顶集合变更时写入 settings.json。 */
+  persistPinnedSessionIds?: (sessionIds: string[]) => void;
   /** 初始 settings.get 已完成；旧 key 迁移必须等此时才允许落盘。 */
   settingsLoaded?: boolean;
   /** 权威 settings 已应用且旧 key 已完成迁移后通知 App 开始懒加载会话。 */
@@ -233,6 +241,7 @@ export function useSidebarController(options: {
   const [search, setSearch] = useState("");
   const [expandedProjectIds, setExpandedProjectIds] = useAtom(sidebarExpandedProjectIdsAtom);
   const [navTab, setNavTabState] = useAtom(sidebarNavTabAtom);
+  const [pinnedSessionIds, setPinnedSessionIds] = useState<ReadonlySet<string>>(() => new Set());
   const [sourceFilters, setSourceFilters] = useState<SidebarSourceFilters>(() =>
     readSidebarSourceFilters(options.storage ?? (typeof window === "undefined" ? undefined : window.localStorage)),
   );
@@ -256,6 +265,11 @@ export function useSidebarController(options: {
   const [worktreeCreateProjectId, setWorktreeCreateProjectId] = useState<string>();
   const [rpcLogAgentId, setRpcLogAgentId] = useState<string>();
   const requestGateRef = useRef(createSidebarRequestGate());
+  const pinnedSessionIdsRef = useRef(pinnedSessionIds);
+  pinnedSessionIdsRef.current = pinnedSessionIds;
+  const pinnedSessionIdsHydratedRef = useRef(false);
+  const persistPinnedSessionIdsRef = useRef(options.persistPinnedSessionIds);
+  persistPinnedSessionIdsRef.current = options.persistPinnedSessionIds;
 
   useEffect(() => {
     const storage = options.storage ?? (typeof window === "undefined" ? undefined : window.localStorage);
@@ -266,6 +280,31 @@ export function useSidebarController(options: {
       // Local preferences are optional and must not make the Sidebar unusable.
     }
   }, [options.storage, sourceFilters]);
+
+  // 置顶状态只落 settings.json：首次 hydration 后由 controller 独占运行时状态，
+  // 避免迟到的 settings 响应覆盖用户刚完成的置顶操作。
+  useEffect(() => {
+    if (pinnedSessionIdsHydratedRef.current || !options.settingsLoaded) return;
+    pinnedSessionIdsHydratedRef.current = true;
+    const hydrated = new Set(
+      (options.settingsPinnedSessionIds ?? []).filter(
+        (id): id is string => typeof id === "string" && id.trim().length > 0,
+      ),
+    );
+    pinnedSessionIdsRef.current = hydrated;
+    setPinnedSessionIds(hydrated);
+  }, [options.settingsLoaded, options.settingsPinnedSessionIds]);
+
+  const toggleSessionPin = useCallback((sessionId: string) => {
+    if (!sessionId) return;
+    pinnedSessionIdsHydratedRef.current = true;
+    const next = new Set(pinnedSessionIdsRef.current);
+    if (next.has(sessionId)) next.delete(sessionId);
+    else next.add(sessionId);
+    pinnedSessionIdsRef.current = next;
+    setPinnedSessionIds(next);
+    persistPinnedSessionIdsRef.current?.([...next]);
+  }, []);
 
   // ── 侧栏 Chats/项目分段：localStorage 首屏缓存 + settings.json 可靠落盘（与展开集合同策略） ──
 
@@ -494,6 +533,9 @@ export function useSidebarController(options: {
     setSearch,
     navTab,
     setNavTab,
+    pinnedSessionIds,
+    isSessionPinned: (sessionId) => pinnedSessionIds.has(sessionId),
+    toggleSessionPin,
     expandedProjectIds,
     isProjectCollapsed: (projectId) => !expandedProjectIds.has(projectId),
     toggleProject,

--- a/src/renderer/src/i18n/rendererCopy.en-US.ts
+++ b/src/renderer/src/i18n/rendererCopy.en-US.ts
@@ -2428,6 +2428,8 @@ export const enUS: Record<TranslationKey, string> = {
   "menu.closeAgent": "Close Agent",
   "menu.restartSession": "Restart Session",
   "menu.reloadSession": "Reload Session",
+  "menu.pinSession": "Pin Session",
+  "menu.unpinSession": "Unpin Session",
   "menu.copySession": "Copy Session",
   "menu.sessionProxy": "Session proxy",
   "menu.archiveSession": "Archive Session",

--- a/src/renderer/src/i18n/rendererCopy.zh-CN.ts
+++ b/src/renderer/src/i18n/rendererCopy.zh-CN.ts
@@ -2409,6 +2409,8 @@ export const zhCN = {
   "menu.closeAgent": "关闭 Agent",
   "menu.restartSession": "重启会话",
   "menu.reloadSession": "重新加载会话",
+  "menu.pinSession": "置顶会话",
+  "menu.unpinSession": "取消置顶",
   "menu.copySession": "复制会话",
   "menu.sessionProxy": "会话代理",
   "menu.archiveSession": "归档会话",

--- a/src/shared/pinnedSessions.ts
+++ b/src/shared/pinnedSessions.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalize persisted pinned SessionRecord ids at the settings boundary.
+ * Invalid and duplicate entries are ignored so a damaged settings file cannot
+ * break Sidebar rendering or produce unbounded duplicate state.
+ */
+export function normalizePinnedSessionIds(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const ids = new Set<string>();
+	for (const candidate of value) {
+		if (typeof candidate !== "string") continue;
+		const id = candidate.trim();
+		if (id) ids.add(id);
+	}
+	return [...ids];
+}

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -331,6 +331,11 @@ export type AppSettings = {
 	 * settings.json 作跨 renderer origin / dev 强杀的可靠恢复来源。缺省为 chats。
 	 */
 	sidebarNavTab?: "active" | "chats" | "projects";
+	/**
+	 * 侧栏中置顶的会话记录 id。SessionRecord.id 跨重启稳定；缺失或已删除的 id
+	 * 在展示时安全忽略，避免修改 pi 会话文件或把短生命周期 agentId 持久化。
+	 */
+	pinnedSessionIds?: string[];
 
 	// ── 扩展管理 ──
 	/**

--- a/tests/sessionPinning.test.mjs
+++ b/tests/sessionPinning.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import ts from "typescript";
+import vm from "node:vm";
+
+function transpile(filePath) {
+	return ts.transpileModule(readFileSync(filePath, "utf8"), {
+		compilerOptions: {
+			module: ts.ModuleKind.CommonJS,
+			target: ts.ScriptTarget.ES2022,
+		},
+	}).outputText;
+}
+
+function loadAgentListDisplay() {
+	const identitySandbox = { exports: {} };
+	vm.runInNewContext(transpile("src/shared/sessionIdentity.ts"), identitySandbox);
+	const pillsSandbox = { exports: {} };
+	vm.runInNewContext(transpile("src/renderer/src/sessionFilterPills.ts"), pillsSandbox);
+	const sandbox = {
+		exports: {},
+		require: (specifier) => {
+			if (specifier === "../../shared/sessionIdentity") return identitySandbox.exports;
+			if (specifier === "./sessionFilterPills") return pillsSandbox.exports;
+			throw new Error(`Unexpected import: ${specifier}`);
+		},
+	};
+	vm.runInNewContext(transpile("src/renderer/src/agentListDisplay.ts"), sandbox);
+	return sandbox.exports;
+}
+
+function loadPinnedSettingsPolicy() {
+	const sandbox = { exports: {} };
+	vm.runInNewContext(transpile("src/shared/pinnedSessions.ts"), sandbox);
+	return sandbox.exports;
+}
+
+function session(id, updatedAt) {
+	return {
+		id,
+		name: id,
+		filePath: `C:/sessions/${id}.jsonl`,
+		preview: "",
+		updatedAt,
+		messageCount: 1,
+		source: "pi",
+		environment: "native",
+	};
+}
+
+function childSessionIds(display) {
+	return display.children.map((child) =>
+		child.type === "session" ? child.session.id : `agent:${child.agent.id}`,
+	);
+}
+
+test("pinned sessions lead only their project list while both partitions keep time order", () => {
+	const { getProjectAgentSessionDisplay } = loadAgentListDisplay();
+	const display = getProjectAgentSessionDisplay({
+		agents: [],
+		sessions: [
+			session("new-unpinned", 40),
+			session("older-pinned", 10),
+			session("newer-pinned", 20),
+			session("old-unpinned", 5),
+		],
+		pinnedSessionIds: new Set(["older-pinned", "newer-pinned"]),
+		visibleChildCount: 3,
+	});
+
+	assert.deepEqual(Array.from(childSessionIds(display)), [
+		"newer-pinned",
+		"older-pinned",
+		"new-unpinned",
+		"old-unpinned",
+	]);
+	assert.deepEqual(
+		Array.from(display.visibleChildren, (child) => child.type === "session" && child.session.id),
+		["newer-pinned", "older-pinned", "new-unpinned"],
+	);
+});
+
+test("a pinned catalog session stays pinned when decorated by a running agent", () => {
+	const { getProjectAgentSessionDisplay } = loadAgentListDisplay();
+	const pinned = session("pinned-running", 1);
+	const display = getProjectAgentSessionDisplay({
+		agents: [{
+			id: "runtime-1",
+			projectId: "project-a",
+			cwd: "C:/project-a",
+			title: "Running",
+			status: "running",
+			sessionPath: pinned.filePath,
+			createdAt: 100,
+		}],
+		sessions: [session("new-history", 50), pinned],
+		pinnedSessionIds: new Set([pinned.id]),
+		visibleChildCount: 5,
+	});
+
+	assert.equal(display.children[0].type, "session");
+	assert.equal(display.children[0].session.id, pinned.id);
+	assert.equal(display.children[0].agent.id, "runtime-1");
+});
+
+test("unknown persisted ids are ignored without changing chronological order", () => {
+	const { getProjectAgentSessionDisplay } = loadAgentListDisplay();
+	const display = getProjectAgentSessionDisplay({
+		agents: [],
+		sessions: [session("older", 1), session("newer", 2)],
+		pinnedSessionIds: new Set(["deleted-session"]),
+	});
+	assert.deepEqual(Array.from(childSessionIds(display)), ["newer", "older"]);
+});
+
+test("persisted pin ids drop invalid values and duplicates", () => {
+	const { normalizePinnedSessionIds } = loadPinnedSettingsPolicy();
+	assert.deepEqual(
+		Array.from(normalizePinnedSessionIds([" session-a ", "", null, "session-a", "session-b", 7])),
+		["session-a", "session-b"],
+	);
+	assert.deepEqual(Array.from(normalizePinnedSessionIds("session-a")), []);
+});


### PR DESCRIPTION
## Summary
- add pin/unpin actions for stable catalog sessions in the project sidebar
- keep pinned sessions at the top of their owning project while preserving chronological order within each partition
- persist pin state in `settings.json` by `SessionRecord.id`, including when a historical session becomes active
- ignore transient agents, drafts, stale ids, and invalid persisted values

## Testing
- `node --test tests/sessionPinning.test.mjs tests/agentListDisplay.test.mjs tests/sessionSidebar.test.mjs tests/sidebarRuntimeBinding.test.mjs`
- `npm run typecheck`
- `npm run build`