### PR TITLE
fix: 修复 Windows 下启动 pi 进程弹出 CMD 控制台窗口

### DIFF
--- a/src/main/pi/PiProcess.ts
+++ b/src/main/pi/PiProcess.ts
@@ -470,7 +470,10 @@ export class PiProcess extends EventEmitter {
         stdio: ["pipe", "pipe", "pipe"],
         shell: invocation.shell,
         // env 已在上方合并安全门环境变量（PIDECK_SECURITY_CONFIG / PIDECK_SESSION_ID）
+        // Windows：PiDeck 是无控制台的 GUI 进程，spawn 的 cmd.exe 若不带 windowsHide，
+        // 系统会为它新建控制台窗口（用户表现为"跑东西时弹出 CMD 窗口"）。
         env,
+        windowsHide: true,
         windowsVerbatimArguments: invocation.windowsVerbatimArguments,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Windows 上每次 PiDeck 启动/重启 pi 进程（打开会话、模型报错重试、切换会话等）都会弹出一个 CMD 控制台窗口，且会停留到该 pi 进程退出。

根因在 `PiProcess` 通过 `cmd.exe /d /s /c ... pi.cmd --mode rpc ...` 启动 pi。PiDeck 主进程是无控制台的 Electron GUI 进程，而该处 `spawn()` 未设置 `windowsHide`（Node 默认为 false），Windows 会为没有继承控制台的 cmd.exe 子进程分配一个全新控制台，即用户看到的 CMD 窗口。

仓库内其他 spawn/execFile 位置均已设置 `windowsHide: true`（`PiLocator.ts` 三处、`PiProcess.ts` 中 genProcess 一处、taskkill / 通用命令执行 / reg query 等），唯独主 pi 进程这一处遗漏。

修复方式是给该 spawn 选项补上 `windowsHide: true`（一行代码 + 注释）。

## Checklist

- [x] I ran `npm run typecheck`.（本地已跑，通过）
- [x] I ran `npm run build`。（本地已跑，main/preload/renderer 均通过）
- [x] I added comments for non-obvious logic or state transitions.（注释说明 Windows 控制台分配行为）
- [x] I updated documentation if behavior changed.（无行为文档变化；行为变化仅为"不再弹窗"）

## Screenshots

无 UI 变化。修复前：每次 pi 进程 spawn 弹出黑色控制台窗口；修复后：无窗口。

Fixes #178