### PR TITLE
fix: 修复 Windows 下启动 pi 进程弹出 CMD 控制台窗口

### DIFF
--- a/src/main/pi/PiProcess.ts
+++ b/src/main/pi/PiProcess.ts
@@ -474,7 +474,9 @@ export class PiProcess extends EventEmitter {
         stdio: ["pipe", "pipe", "pipe"],
         shell: invocation.shell,
         // env 已在上方合并安全门环境变量（PIDECK_SECURITY_CONFIG / PIDECK_SESSION_ID）
+        // Windows：PiDeck 是无控制台的 GUI 进程，隐藏子进程窗口以免 cmd.exe 弹出控制台。
         env,
+        windowsHide: true,
         windowsVerbatimArguments: invocation.windowsVerbatimArguments,
       });
     } catch (error) {

--- a/tests/piProcessSecurityEnv.test.mjs
+++ b/tests/piProcessSecurityEnv.test.mjs
@@ -29,10 +29,10 @@ function loadWslPaths() {
  */
 function loadPiProcess() {
 	const wslPaths = loadWslPaths();
-	/** spawn 收到的 env/args；mockSpawn 被调用时写入 */
+	/** spawn 收到的 env/args/windowsHide；mockSpawn 被调用时写入 */
 	let captured = null;
 	const mockSpawn = (_command, args, opts) => {
-		captured = { env: opts?.env ?? null, args: args ?? null };
+		captured = { env: opts?.env ?? null, args: args ?? null, windowsHide: opts?.windowsHide };
 		// 返回一个最小 ChildProcess 形状：PiProcess 后续会 new PiRpcClient(proc.stdin/stdout)
 		// 并注册 stderr/error/exit 监听，全部用 stream + noop 满足。
 		return {
@@ -103,6 +103,19 @@ function loadPiProcess() {
 	vm.runInNewContext(transpile("src/main/pi/PiProcess.ts"), sandbox, { filename: "PiProcess.ts" });
 	return { PiProcess: sandbox.exports.PiProcess, mockLocator, getCaptured: () => captured };
 }
+
+test("Windows 下启动 pi 进程时隐藏 cmd.exe 控制台窗口", async () => {
+	const { PiProcess, mockLocator, getCaptured } = loadPiProcess();
+	const proc = new PiProcess(
+		"C:\\proj",
+		{ wslEnabled: true, wslDistro: "Ubuntu-24.04", wslUser: "root" },
+		mockLocator,
+	);
+
+	await proc.start(undefined, undefined, true);
+
+	assert.equal(getCaptured()?.windowsHide, true);
+});
 
 test("WSL 模式下 PIDECK_SESSION_ID（UUID 身份 key）原样注入，不经 Linux 路径转换", async () => {
 	// 回归：临时会话 deckSessionId 是新生成的 UUID（无 sessionPath 兜底），


### PR DESCRIPTION
## Summary

Windows 上，PiDeck 主进程通过 `cmd.exe` 启动 pi 时未隐藏子进程窗口，导致每次启动或重启 pi 都可能弹出控制台窗口。

本次修改：
- 在主 pi 进程的 `spawn()` 选项中设置 `windowsHide: true`。
- 保留现有环境变量和 `windowsVerbatimArguments` 行为。
- 在 `piProcessSecurityEnv.test.mjs` 中增加回归断言，验证启动参数会隐藏子进程窗口。

## Checklist

- [x] I ran `npm run typecheck`.
- [x] I ran `npm run build`.
- [x] I added comments for non-obvious logic or state transitions.
- [x] I updated documentation if behavior changed.（无需文档更新；仅修正 Windows 子进程窗口行为）

## Screenshots

无 UI 变化。

## Verification

- `node --test tests/piProcessSecurityEnv.test.mjs`（5 tests passed）
- `npm run typecheck`
- `npm run build`

Closes #178