### PR TITLE
feat: 支持请求体大小超限后的会话恢复

### DIFF
--- a/resources/extensions/pi-deck-request-size-recovery.ts
+++ b/resources/extensions/pi-deck-request-size-recovery.ts
@@ -1,0 +1,350 @@
+/**
+ * PiDeck Request Size Recovery Extension
+ *
+ * 背景：会话历史（完整请求体）超过中转网关的字节上限（如 nginx
+ * client_max_body_size）时，网关通常返回 413，也可能通过 400 或自定义错误
+ * 文案报告同一问题。此时后续请求与当前模型发起的压缩请求都可能失败。
+ *
+ * 方案（与上游维护者建议一致，见 ayuayue/PiDeck#185）：识别明确的请求体
+ * 大小超限错误后弹确认框，
+ * 用户同意则「用指定模型压缩」——临时切换到请求上限更大的模型执行压缩
+ * （AgentSession.compact 的摘要请求走当前会话模型），完成后自动切回原模型。
+ * 会话缩小后用户重新发送刚才失败的请求即可，死锁解除。
+ *
+ * 设计约束：
+ * - 纯扩展实现，不改 pi 核心逻辑
+ * - 默认零影响：仅 assistant + stopReason=error + 明确的请求体超限信号 +
+ *   hasUI（TUI/RPC）+ 不在冷却期才弹一次 confirm；无 UI 的模式完全静默
+ * - 候选模型只含已配置密钥的（hasConfiguredAuth），排除当前模型；
+ *   label 用 `provider/modelId`（解析安全，不依赖显示名）
+ * - RPC 模式 confirm 的取消会解析为 false（与「否」同义）；select 的取消
+ *   可能是 null/空串或框架层抛错（见 pi-deck-ask-question），两种都按放弃处理
+ * - 弹框后未成功跑压缩（拒绝/取消/切模型失败/无候选）进入 10 分钟冷却，
+ *   防止 pi 重试循环里的连续 413 刷屏弹框；压缩真正跑过（无论成败）则
+ *   重置冷却，允许下一次 413 再次提议
+ * - 恢复期间（切模型→压缩→切回）recoveryActive 置位，后续错误不再触发
+ * - 用户在恢复期间手动切模型（model_select）：收尾时若当前模型已不是
+ *   临时模型则不切回，尊重用户操作
+ *
+ * 与 pi-deck-retry-no-body 的分工：`413 status code (no body)` 仍由现有扩展
+ * 按瞬态故障处理；本扩展只处理状态码或文案明确表明请求体过大的错误，避免
+ * 同一次失败同时进入重试与压缩恢复流程。
+ *
+ * @packageDocumentation
+ */
+
+import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+// ---------------------------------------------------------------------------
+// 纯函数：请求体大小超限识别与候选模型构建（不依赖 pi API，便于独立测试）
+// ---------------------------------------------------------------------------
+
+/**
+ * 判断错误信息是否明确表示请求体超过网关字节上限。
+ *
+ * 413 本身即表示 Content Too Large，但明确排除 `(no body)`：该形态在部分
+ * 中转网关中属于瞬态故障，由 pi-deck-retry-no-body 负责。没有 413 时，只匹配
+ * request/payload/body/client_max_body_size 等明确的请求体大小语义。
+ * 实测形态（pi 0.84.4 经 formatProviderError 组合）：
+ * - `413 Payload Too Large: <html>…` —— nginx 错误页 body
+ * - `413 Request Entity Too Large` —— IIS 风格
+ * - `400 Bad Request: request body too large` —— 非标准 400 形态
+ * - `client intended to send too large body` —— nginx 错误日志形态
+ *
+ * @param errorMessage - assistant 消息的 errorMessage 字段
+ * @returns 是否为请求体大小超限错误
+ */
+const REQUEST_SIZE_LIMIT_PATTERNS: RegExp[] = [
+	/\b(?:request entity|payload|request body|request content)\s+too\s+large\b/i,
+	/\bclient intended to send too large body\b/i,
+	/\bclient_max_body_size\b/i,
+	/\bmaximum (?:request body|payload|request content) size (?:exceeded|limit)\b/i,
+	/\b(?:request body|payload|request content) size exceeds? (?:the )?(?:maximum|limit)\b/i,
+	/\brequest size exceeds? (?:the )?limit(?: of)? \d+(?:\.\d+)?\s*(?:bytes?|kb|mb|gb|kib|mib|gib)\b/i,
+];
+
+const NO_BODY_RESPONSE_PATTERN =
+	/(?:\(no body\)|no body\s*$|empty\s+response\s+body|no\s+response\s+body)/i;
+const TOKEN_LIMIT_PATTERN =
+	/\b(?:tokens?|context\s+(?:window|length)|maximum\s+context|prompt\s+(?:is\s+)?too\s+long)\b/i;
+const HTTP_413_PATTERN =
+	/(?:^\s*413(?:\s*$|\s*[:(-]|\s+(?:payload|request|content|status|error|response|entity)\b)|\b(?:http(?:\/\d(?:\.\d)?)?|status(?:\s+code)?|response(?:\s+status)?|error\s+code)\s*[:=]?\s*413\b|\(\s*413\s*\)\s*:)/i;
+
+export function isRequestSizeLimitError(errorMessage: string): boolean {
+	if (!errorMessage) return false;
+	if (NO_BODY_RESPONSE_PATTERN.test(errorMessage)) return false;
+	if (TOKEN_LIMIT_PATTERN.test(errorMessage)) return false;
+	if (HTTP_413_PATTERN.test(errorMessage)) return true;
+	return REQUEST_SIZE_LIMIT_PATTERNS.some((pattern) => pattern.test(errorMessage));
+}
+
+/** 候选模型输入（从 ModelRegistry 摘取的测试友好子集）。 */
+export interface RecoveryModelCandidate {
+	provider: string;
+	modelId: string;
+	/** 该模型 provider 是否已配置密钥（hasConfiguredAuth）。 */
+	authenticated: boolean;
+}
+
+/** 候选模型选项（label 即选项文本与唯一键）。 */
+export interface RecoveryModelOption {
+	provider: string;
+	modelId: string;
+	label: string;
+}
+
+/** 稳定模型唯一键：`provider/modelId`（provider 不含 `/`，modelId 可包含）。 */
+export function modelKey(provider: string, modelId: string): string {
+	return `${provider}/${modelId}`;
+}
+
+/** 尝试切回恢复流程开始前的模型；不需要恢复时返回 undefined。 */
+export async function attemptModelRestore<Model>(params: {
+	currentModel: { provider: string; id: string } | undefined;
+	temporaryModelKey: string | undefined;
+	originalModelKey: string | undefined;
+	findModel: (provider: string, modelId: string) => Model | undefined;
+	setModel: (model: Model) => Promise<boolean>;
+}): Promise<boolean | undefined> {
+	const { currentModel, temporaryModelKey, originalModelKey, findModel, setModel } = params;
+	if (!currentModel || !temporaryModelKey || !originalModelKey) return undefined;
+	if (modelKey(currentModel.provider, currentModel.id) !== temporaryModelKey) return undefined;
+
+	const separator = originalModelKey.indexOf("/");
+	if (separator < 1) return false;
+	const original = findModel(
+		originalModelKey.slice(0, separator),
+		originalModelKey.slice(separator + 1),
+	);
+	if (!original) return false;
+	try {
+		return await setModel(original);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * 从注册表摘取「换模型压缩」的候选列表。
+ *
+ * 规则：
+ * - 排除未配置密钥的模型（切过去 setModel 也会返回 false）
+ * - 排除当前模型（就是它 413 的）
+ * - 去重（同一 provider/modelId 不出现两次）
+ * - label 用 `provider/modelId`：解析安全、不依赖显示名
+ * - 按 label 字典序排序，保证弹框顺序稳定
+ *
+ * @param candidates - 从注册表摘取的模型列表
+ * @param current - 当前模型（将被排除），可为 undefined
+ * @returns 排序后的候选列表
+ */
+export function buildRecoveryModelOptions(
+	candidates: readonly RecoveryModelCandidate[],
+	current: { provider: string; modelId: string } | undefined,
+): RecoveryModelOption[] {
+	const options: RecoveryModelOption[] = [];
+	const seen = new Set<string>();
+	for (const candidate of candidates) {
+		if (!candidate.authenticated) continue;
+		if (current && candidate.provider === current.provider && candidate.modelId === current.modelId) continue;
+		const label = modelKey(candidate.provider, candidate.modelId);
+		if (seen.has(label)) continue;
+		seen.add(label);
+		options.push({ provider: candidate.provider, modelId: candidate.modelId, label });
+	}
+	options.sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
+	return options;
+}
+
+// ---------------------------------------------------------------------------
+// 扩展入口
+// ---------------------------------------------------------------------------
+
+/** 弹框后未成功跑压缩时的冷却时长：防止重试循环里的连续 413 刷屏弹框。 */
+const OFFER_COOLDOWN_MS = 10 * 60 * 1000;
+
+/**
+ * PiDeck 内置扩展：请求体大小超限恢复（用指定模型压缩）。
+ *
+ * 挂载 `message_end` 事件，只处理 assistant + stopReason=error + 明确的请求体超限错误。
+ * 流程：confirm → select 候选 → setModel（临时）→ ctx.compact（摘要请求
+ * 走临时模型）→ setModel（切回原模型）→ 结果通知。
+ */
+export default function (pi: ExtensionAPI): void {
+	let dialogPending = false; // 确认框已弹出未关闭
+	let recoveryActive = false; // 恢复进行中（切模型→压缩→切回）
+	let offerCooldownUntil = 0; // 早于该时间戳不再弹框
+	let tempModelKey: string | undefined; // 临时压缩模型唯一键
+	let originalModelKey: string | undefined; // 原模型唯一键
+
+	const setCooldown = (): void => {
+		offerCooldownUntil = Date.now() + OFFER_COOLDOWN_MS;
+	};
+
+	const notice = (content: string): void => {
+		pi.sendMessage(
+			{
+				customType: "pi-deck-request-size-recovery",
+				content,
+				display: true,
+			},
+			{ triggerTurn: false },
+		);
+	};
+
+	/** 收尾：按需切回原模型 → 发结果通知 → 重置冷却（压缩已真正跑过）。 */
+	async function finish(ctx: ExtensionContext, ok: boolean, failureDetail?: string): Promise<void> {
+		const tempKey = tempModelKey;
+		const restoreKey = originalModelKey;
+		tempModelKey = undefined;
+		originalModelKey = undefined;
+		recoveryActive = false;
+
+		// 仅当当前模型仍是临时压缩模型才切回：
+		// 用户在恢复期间手动切了模型，尊重其操作。
+		let restoreNote = "";
+		const restored = await attemptModelRestore({
+			currentModel: ctx.model,
+			temporaryModelKey: tempKey,
+			originalModelKey: restoreKey,
+			findModel: (provider, modelId) => ctx.modelRegistry.find(provider, modelId),
+			setModel: (model) => pi.setModel(model),
+		});
+		if (restored !== undefined) {
+			restoreNote = restored ? "已切回原模型。" : "切回原模型失败，请手动选择。";
+		}
+
+		if (ok) {
+			notice(`请求体超限恢复：压缩完成。${restoreNote}会话已缩小，请重新发送刚才失败的请求。`);
+		} else {
+			notice(`请求体超限恢复：压缩失败${failureDetail ? `（${failureDetail}）` : ""}。${restoreNote}可稍后重试，或新建会话。`);
+		}
+		// 压缩真正跑过，重置冷却：若下一个请求仍 413，允许再次提议（或换别的模型）
+		offerCooldownUntil = 0;
+	}
+
+	/** 执行一次完整恢复：确认 → 选择 → 切模型 → 压缩。 */
+	async function runRecovery(ctx: ExtensionContext): Promise<void> {
+		let confirmed = false;
+		try {
+			confirmed = await ctx.ui.confirm(
+				"请求体超过网关上限",
+				"会话历史太大，网关拒绝接收，当前模型压缩也可能超过同一上限。\n临时切换到请求上限更大的模型执行压缩，完成后自动切回原模型。继续吗？",
+			);
+		} catch {
+			confirmed = false; // RPC 模式取消可能由框架层抛出，按「否」处理
+		}
+		if (!confirmed) {
+			setCooldown();
+			return;
+		}
+
+		const available = ctx.modelRegistry.getAvailable();
+		const options = buildRecoveryModelOptions(
+			available.map((model) => ({
+				provider: model.provider,
+				modelId: model.id,
+				authenticated: ctx.modelRegistry.hasConfiguredAuth(model),
+			})),
+			ctx.model ? { provider: ctx.model.provider, modelId: ctx.model.id } : undefined,
+		);
+
+		if (options.length === 0) {
+			setCooldown();
+			notice("请求体超限恢复：没有其它已配置密钥的模型，无法换模型压缩。请新建会话，或为其它模型配置 API key。");
+			return;
+		}
+
+		let choice: string | undefined;
+		try {
+			choice = await ctx.ui.select(
+				"选择用于压缩的临时模型（按 provider/modelId 列出）",
+				options.map((option) => option.label),
+			);
+		} catch {
+			choice = undefined;
+		}
+		// RPC 模式取消可能是 null/空串或抛错（见 pi-deck-ask-question），按放弃处理
+		if (choice == null || choice === "") {
+			setCooldown();
+			return;
+		}
+		const option = options.find((candidate) => candidate.label === choice);
+		if (!option) {
+			setCooldown();
+			return;
+		}
+
+		const model = ctx.modelRegistry.find(option.provider, option.modelId);
+		if (!model) {
+			setCooldown();
+			notice(`请求体超限恢复：${option.label} 不在模型注册表中，已取消。`);
+			return;
+		}
+
+		// 切换前记录原模型（ctx.model 的 getter 是实时的，setModel 之后已是新模型）
+		const originalKey = ctx.model ? modelKey(ctx.model.provider, ctx.model.id) : undefined;
+
+		recoveryActive = true;
+		tempModelKey = modelKey(model.provider, model.id);
+		originalModelKey = originalKey;
+		const switched = await pi.setModel(model);
+		if (!switched) {
+			recoveryActive = false;
+			tempModelKey = undefined;
+			originalModelKey = undefined;
+			setCooldown();
+			notice(`请求体超限恢复：切换到 ${option.label} 失败。`);
+			return;
+		}
+
+		// 压缩摘要请求走当前会话模型，此时即临时压缩模型
+		ctx.compact({
+			onComplete: () => {
+				void finish(ctx, true);
+			},
+			onError: (error) => {
+				void finish(ctx, false, error.message);
+			},
+		});
+		// 注意：runRecovery 在此返回时恢复仍在进行（recoveryActive 由 finish 清除）。
+		// 外层 finally 只清 dialogPending，两者独立。
+	}
+
+	pi.on("message_end", (event, ctx) => {
+		// 只处理 assistant 的错误消息（user/toolResult/custom 消息直接透传）
+		const message = event.message;
+		if (message.role !== "assistant") return;
+		if (message.stopReason !== "error") return;
+		if (!message.errorMessage) return;
+		if (!isRequestSizeLimitError(message.errorMessage)) return;
+
+		// 防重入 + 无 UI 模式 + 冷却期
+		if (dialogPending || recoveryActive) return;
+		if (!ctx.hasUI) return;
+		if (Date.now() < offerCooldownUntil) return;
+
+		dialogPending = true;
+		void (async () => {
+			try {
+				await runRecovery(ctx);
+			} catch {
+				// 意外异常兜底：若已切换模型则切回原模型，重置状态并进入冷却，
+				// 防止同一路径立即再次弹框
+				await attemptModelRestore({
+					currentModel: ctx.model,
+					temporaryModelKey: tempModelKey,
+					originalModelKey,
+					findModel: (provider, modelId) => ctx.modelRegistry.find(provider, modelId),
+					setModel: (model) => pi.setModel(model),
+				});
+				recoveryActive = false;
+				tempModelKey = undefined;
+				originalModelKey = undefined;
+				setCooldown();
+			} finally {
+				dialogPending = false;
+			}
+		})();
+	});
+}

--- a/src/main/extensions/builtInExtensions.ts
+++ b/src/main/extensions/builtInExtensions.ts
@@ -6,6 +6,7 @@ import { basename, join } from "node:path";
  * 启动 RPC 时通过可重复的 `--extension/-e` 注入，避免污染用户全局 pi。
  */
 export const BUILT_IN_EXTENSIONS = [
+	"pi-deck-request-size-recovery.ts",
 	"pi-deck-ask-question.ts",
 	"pi-deck-goal-mode.ts",
 	"pi-deck-nul-redirect-fix.ts",

--- a/src/main/sessions/SessionRuntimeCoordinator.ts
+++ b/src/main/sessions/SessionRuntimeCoordinator.ts
@@ -323,6 +323,9 @@ export class SessionRuntimeCoordinator {
 		if (!agentId) return undefined;
 		const tab = this.agents.list().find((candidate) => candidate.id === agentId);
 		if (tab && !isTerminalAgent(tab)) return agentId;
+		// pi may emit an interactive recovery request immediately before reporting
+		// an error. Keep that runtime addressable until the user answers the request.
+		if (tab?.status === "error" && this.hasPendingUiRequest(sessionId, agentId)) return agentId;
 		// A terminal process cannot safely receive a delayed prompt result. Remove
 		// the binding even if its dispatch lease has not unwound yet, which makes
 		// that result fail closed instead of reviving a dead runtime association.
@@ -2075,6 +2078,13 @@ export class SessionRuntimeCoordinator {
 
 	private uiRequestKey(sessionId: string, requestId: string): string {
 		return `${sessionId}\u0000${requestId}`;
+	}
+
+	private hasPendingUiRequest(sessionId: string, agentId: string): boolean {
+		for (const pending of this.pendingUiRequests.values()) {
+			if (pending.sessionId === sessionId && pending.agentId === agentId) return true;
+		}
+		return false;
 	}
 
 	private clearPendingUiRequests(sessionId: string, agentId?: string): void {

--- a/src/renderer/src/atoms/session-atoms.ts
+++ b/src/renderer/src/atoms/session-atoms.ts
@@ -1083,7 +1083,7 @@ function applySessionRuntimeUiEvent(
     : current;
   if (
     (event.sourceChannel === "agents:state" || event.sourceChannel === "sessions:runtime") &&
-    (payload.status === "error" || payload.status === "closed")
+    payload.status === "closed"
   ) {
     return {
       agentId: event.agentId,
@@ -1525,8 +1525,7 @@ export const applySessionRuntimeEventAtom = atom(
       }
     }
 
-    const terminalEnvelope = !bindingChanged &&
-      (currentRuntime.status === "error" || currentRuntime.status === "closed");
+    const terminalEnvelope = !bindingChanged && currentRuntime.status === "closed";
     const nextUi = payload && !(terminalEnvelope && event.sourceChannel === "agents:ui-request")
       ? applySessionRuntimeUiEvent(
           get(sessionRuntimeUiByIdAtom)[event.sessionId],

--- a/src/renderer/src/components/overlays/SessionRuntimeUiOverlay.tsx
+++ b/src/renderer/src/components/overlays/SessionRuntimeUiOverlay.tsx
@@ -509,7 +509,6 @@ export function SessionRuntimeUiOverlay({ sessionId, runtime, ui, responder, onE
 		runtime &&
 		ui &&
 		runtime.status !== "detached" &&
-		runtime.status !== "error" &&
 		runtime.status !== "closed" &&
 		runtime.agentId === ui.agentId &&
 		runtime.runtimeGeneration === ui.runtimeGeneration,

--- a/tests/askUiStateMachine.test.mjs
+++ b/tests/askUiStateMachine.test.mjs
@@ -243,6 +243,12 @@ test("SessionRuntimeUiOverlay 使用提取的纯逻辑与语义字号 token", ()
 	assert.ok(guards && guards.length >= 4);
 });
 
+test("SessionRuntimeUiOverlay keeps recovery prompts visible after model errors", () => {
+	const source = readFileSync("src/renderer/src/components/overlays/SessionRuntimeUiOverlay.tsx", "utf8");
+	assert.doesNotMatch(source, /runtime\.status !== "error"/);
+	assert.match(source, /runtime\.status !== "closed"/);
+});
+
 test("Timeline 已清理死代码，安全卡在选项点击前调 hasTextSelection", () => {
 	const timeline = readFileSync("src/renderer/src/components/session/TimelineEventCards.tsx", "utf8");
 	const security = readFileSync("src/renderer/src/components/overlays/SecurityConfirmCard.tsx", "utf8");

--- a/tests/builtInExtensions.test.mjs
+++ b/tests/builtInExtensions.test.mjs
@@ -68,7 +68,8 @@ test("listActiveBuiltInExtensionPaths respects removedBuiltIn and missing files"
 		assert.equal(paths.length, 1);
 		assert.ok(String(paths[0]).endsWith("pi-deck-ask-question.ts"));
 		// 内置扩展清单随版本增长：ask/goal/nul-redirect/plan-mode/retry-no-body/security-gate/session-title/subagents/todo/vision
-		assert.equal(BUILT_IN_EXTENSIONS.length, 10);
+		// 内置扩展清单随版本增长：ask/goal/nul-redirect/plan-mode/request-size-recovery/retry-no-body/security-gate/session-title/subagents/todo/vision
+		assert.equal(BUILT_IN_EXTENSIONS.length, 11);
 		assert.ok(BUILT_IN_EXTENSIONS.includes("pi-deck-goal-mode.ts"));
 		assert.ok(BUILT_IN_EXTENSIONS.includes("pi-deck-session-title.ts"));
 	} finally {

--- a/tests/piDeckRequestSizeRecovery.test.mjs
+++ b/tests/piDeckRequestSizeRecovery.test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import ts from "typescript";
+
+/**
+ * 请求体大小超限恢复扩展的契约与纯函数测试。
+ *
+ * 通过 TypeScript transpile 移除扩展的 type-only pi 依赖，再直接测试实际导出。
+ */
+
+const extensionSource = readFileSync("resources/extensions/pi-deck-request-size-recovery.ts", "utf8");
+const compiledExtension = ts.transpileModule(extensionSource, {
+	compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+}).outputText;
+const extensionModule = await import(
+	`data:text/javascript;base64,${Buffer.from(compiledExtension).toString("base64")}`
+);
+const {
+	isRequestSizeLimitError,
+	buildRecoveryModelOptions,
+	modelKey,
+	attemptModelRestore,
+} = extensionModule;
+
+// =========================================================================
+// 纯函数：请求体大小超限识别
+// =========================================================================
+
+test("明确的请求体大小超限错误能够识别", () => {
+	for (const errorMessage of [
+		"413 Payload Too Large: <html><head><title>413</title></head><body>nginx</body></html>",
+		"413 Request Entity Too Large",
+		"unexpected status 413 from upstream gateway",
+		"HTTP 413: request entity too large",
+		"Provider error code: 413",
+		"openai-completions (413): payload too large",
+		"400 Bad Request: request body too large",
+		"Maximum request body size exceeded",
+		"request body size exceeds the maximum",
+		"request size exceeds the limit of 10 MB",
+		"client intended to send too large body",
+		"nginx client_max_body_size exceeded",
+	]) {
+		assert.equal(isRequestSizeLimitError(errorMessage), true, `应识别: ${errorMessage}`);
+	}
+});
+
+test("空响应与非请求体大小错误不识别", () => {
+	for (const errorMessage of [
+		"",
+		"413 (no body)",
+		"413 status code (no body)",
+		"HTTP 413: empty response body",
+		"HTTP 413: no response body",
+		"400 status code (no body)",
+		"500 status code (no body)",
+		"404: model is not found",
+		"429 Too Many Requests",
+		"401 invalid API key",
+		"4130 tokens used",
+		"413 tokens used",
+		"1413 tokens",
+		"maximum request size exceeded: 413 tokens",
+		"request size exceeds the maximum token count",
+		"prompt is too long: 213462 tokens > 200000 maximum",
+		"too many tokens",
+	]) {
+		assert.equal(isRequestSizeLimitError(errorMessage), false, `不应识别: ${errorMessage}`);
+	}
+});
+
+// =========================================================================
+// 纯函数：候选模型列表构建
+// =========================================================================
+
+test("候选列表排除未认证与当前模型，label 为 provider/modelId 形式", () => {
+	const options = buildRecoveryModelOptions(
+		[
+			{ provider: "openai", modelId: "gpt-5", authenticated: true },
+			{ provider: "anthropic", modelId: "claude-sonnet", authenticated: false },
+			{ provider: "qwen-x1", modelId: "qwen3-max", authenticated: true },
+			{ provider: "openai", modelId: "gpt-5", authenticated: true },
+			{ provider: "deepseek", modelId: "deepseek-v3", authenticated: true },
+		],
+		{ provider: "qwen-x1", modelId: "qwen3-max" },
+	);
+	assert.deepEqual(options.map((o) => o.label), ["deepseek/deepseek-v3", "openai/gpt-5"]);
+	assert.deepEqual(options[0], { provider: "deepseek", modelId: "deepseek-v3", label: "deepseek/deepseek-v3" });
+});
+
+test("current 为 undefined 时不排除任何模型", () => {
+	const options = buildRecoveryModelOptions(
+		[
+			{ provider: "a", modelId: "m2", authenticated: true },
+			{ provider: "a", modelId: "m1", authenticated: true },
+		],
+		undefined,
+	);
+	assert.deepEqual(options.map((o) => o.label), ["a/m1", "a/m2"]);
+});
+
+test("全部候选被排除时返回空数组", () => {
+	const options = buildRecoveryModelOptions(
+		[
+			{ provider: "openai", modelId: "gpt-5", authenticated: true },
+			{ provider: "anthropic", modelId: "claude", authenticated: false },
+		],
+		{ provider: "openai", modelId: "gpt-5" },
+	);
+	assert.deepEqual(options, []);
+});
+
+test("选项按 label 字典序稳定排序", () => {
+	const options = buildRecoveryModelOptions(
+		[
+			{ provider: "zeta", modelId: "z1", authenticated: true },
+			{ provider: "alpha", modelId: "a1", authenticated: true },
+			{ provider: "mid", modelId: "m1", authenticated: true },
+		],
+		undefined,
+	);
+	assert.deepEqual(options.map((o) => o.label), ["alpha/a1", "mid/m1", "zeta/z1"]);
+});
+
+test("modelKey 为 provider/modelId 拼接", () => {
+	assert.equal(modelKey("qwen-x1", "qwen3-max"), "qwen-x1/qwen3-max");
+});
+
+test("切回原模型抛错时返回失败而不是产生未处理拒绝", async () => {
+	const original = { provider: "origin", id: "small" };
+	const temporary = { provider: "backup", id: "large" };
+	const restored = await attemptModelRestore({
+		currentModel: temporary,
+		temporaryModelKey: modelKey(temporary.provider, temporary.id),
+		originalModelKey: modelKey(original.provider, original.id),
+		findModel: (provider, modelId) =>
+			provider === original.provider && modelId === original.id ? original : undefined,
+		setModel: async () => {
+			throw new Error("restore failed");
+		},
+	});
+	assert.equal(restored, false);
+});
+
+// =========================================================================
+// 契约：扩展源码结构与注册
+// =========================================================================
+
+const builtInsSource = readFileSync("src/main/extensions/builtInExtensions.ts", "utf8");
+
+test("扩展识别请求体大小超限并走 confirm → select → setModel → compact 流程", () => {
+	assert.match(extensionSource, /pi\.on\("message_end"/);
+	assert.match(extensionSource, /export function isRequestSizeLimitError/);
+	assert.match(extensionSource, /export function buildRecoveryModelOptions/);
+	assert.match(extensionSource, /message\.role !== "assistant"/);
+	assert.match(extensionSource, /message\.stopReason !== "error"/);
+	assert.match(extensionSource, /isRequestSizeLimitError\(message\.errorMessage\)/);
+	// 守卫：防重入 + hasUI + 冷却
+	assert.match(extensionSource, /dialogPending \|\| recoveryActive/);
+	assert.match(extensionSource, /ctx\.hasUI/);
+	assert.match(extensionSource, /offerCooldownUntil/);
+	// 恢复流程：confirm → select → 注册表 → setModel → compact
+	assert.match(extensionSource, /ctx\.ui\.confirm\(/);
+	assert.match(extensionSource, /ctx\.ui\.select\(/);
+	assert.match(extensionSource, /ctx\.modelRegistry\.hasConfiguredAuth\(/);
+	assert.match(extensionSource, /ctx\.modelRegistry\.find\(/);
+	assert.match(extensionSource, /pi\.setModel\(/);
+	assert.match(extensionSource, /ctx\.compact\(\{[\s\S]*?onComplete[\s\S]*?onError/);
+	// 摘要请求走当前会话模型：必须先 setModel 再 compact
+	const setModelIndex = extensionSource.indexOf("pi.setModel(model)");
+	const compactIndex = extensionSource.indexOf("ctx.compact({");
+	assert.ok(setModelIndex !== -1 && compactIndex !== -1 && setModelIndex < compactIndex);
+});
+
+test("扩展源码保留请求体错误与冷却期契约", () => {
+	// 413 必须出现在明确的 HTTP 状态语境中，不能把普通数字当成状态码
+	assert.match(extensionSource, /status\(\?:\\s\+code\)\?/);
+	assert.match(extensionSource, /response\(\?:\\s\+status\)\?/);
+	assert.match(extensionSource, /NO_BODY_RESPONSE_PATTERN/);
+	assert.match(extensionSource, /client_max_body_size/);
+	// 10 分钟冷却
+	assert.match(extensionSource, /OFFER_COOLDOWN_MS = 10 \* 60 \* 1000/);
+});
+
+test("正常收尾与异常兜底都使用可控的模型恢复函数", () => {
+	assert.equal(extensionSource.match(/await attemptModelRestore\(/g)?.length, 2);
+	assert.doesNotMatch(extensionSource, /void pi\.setModel\(original\)/);
+});
+
+test("扩展已注册进 BUILT_IN_EXTENSIONS 白名单", () => {
+	assert.match(builtInsSource, /"pi-deck-request-size-recovery\.ts"/);
+});

--- a/tests/sessionRuntimeCoordinator.test.mjs
+++ b/tests/sessionRuntimeCoordinator.test.mjs
@@ -876,6 +876,48 @@ test("Session UI response requires the current binding, generation, and pending 
   assert.equal(harness.calls.uiResponse, 1);
 });
 
+test("error runtime keeps its binding until the pending Session UI request is answered", async () => {
+  const { SessionRuntimeCoordinator } = loadCoordinator();
+  const harness = createHarness({
+    tabs: [{ id: "agent-a", status: "idle", createdAt: 1 }],
+  });
+  const coordinator = new SessionRuntimeCoordinator(
+    harness.catalog,
+    harness.agents,
+    harness.sender,
+  );
+  const runtimeGeneration = coordinator.bindExistingAgent("session-1", "agent-a");
+  coordinator.observeRuntimeEvent({
+    sessionId: "session-1",
+    agentId: "agent-a",
+    runtimeGeneration,
+    sourceChannel: "agents:ui-request",
+    payload: {
+      agentId: "agent-a",
+      requestId: "request-ui",
+      method: "confirm",
+      title: "Continue?",
+    },
+  });
+  harness.tabs[0].status = "error";
+
+  assert.deepEqual(JSON.parse(JSON.stringify(coordinator.getTarget("session-1"))), {
+    sessionId: "session-1",
+    agentId: "agent-a",
+    runtimeGeneration,
+  });
+  await coordinator.respondToUi({
+    sessionId: "session-1",
+    requestId: "request-ui",
+    agentId: "agent-a",
+    runtimeGeneration,
+    response: { confirmed: true },
+  });
+
+  assert.equal(harness.calls.uiResponse, 1);
+  assert.equal(coordinator.getTarget("session-1"), undefined);
+});
+
 test("batch Ask Question is accepted by the Session UI response gate", async () => {
   const { SessionRuntimeCoordinator } = loadCoordinator();
   const harness = createHarness({

--- a/tests/sessionRuntimeUi.test.mjs
+++ b/tests/sessionRuntimeUi.test.mjs
@@ -171,10 +171,10 @@ test("renderer claim rejects stale generation and duplicate UI responses", () =>
   assert.equal(duplicate, false);
 });
 
-test("terminal runtime states clear all UI and reject same-generation UI revival", () => {
+test("closed runtime state clears all UI and rejects same-generation UI revival", () => {
   const atoms = loadAtoms();
 
-  for (const status of ["error", "closed"]) {
+  for (const status of ["closed"]) {
     const store = createStore();
     store.set(atoms.applySessionRuntimeEventAtom, event());
     store.set(atoms.claimSessionRuntimeUiResponseAtom, {
@@ -240,6 +240,29 @@ test("terminal runtime states clear all UI and reject same-generation UI revival
     assert.equal(ui.notification, undefined);
     assert.equal(ui.editorText, undefined);
   }
+});
+
+test("model error keeps same-generation UI requests available for recovery", () => {
+  const atoms = loadAtoms();
+  const store = createStore();
+  store.set(atoms.applySessionRuntimeEventAtom, event());
+  store.set(atoms.applySessionRuntimeEventAtom, event({
+    sourceChannel: "agents:state",
+    payload: { id: "agent-a", status: "error" },
+  }));
+  store.set(atoms.applySessionRuntimeEventAtom, event({
+    payload: {
+      agentId: "agent-a",
+      requestId: "recovery-request",
+      method: "confirm",
+      title: "Recover from the model error?",
+    },
+  }));
+
+  const ui = store.get(atoms.sessionRuntimeUiByIdAtom)["session-a"];
+  assert.equal(store.get(atoms.sessionRuntimeByIdAtom)["session-a"].status, "error");
+  assert.equal(ui.requests["request-a"].status, "pending");
+  assert.equal(ui.requests["recovery-request"].status, "pending");
 });
 
 test("renderer rollback restores only the current responding envelope", () => {


### PR DESCRIPTION
## Summary

当会话历史超过网关请求体大小限制时，HTTP 413 或同类错误会使当前请求失败，后续压缩也可能继续使用同一模型并再次触发限制。

本次修改：
- 新增内置请求体超限恢复扩展，识别 HTTP 413 及明确的同类网关错误。
- 由用户选择已配置的临时模型执行会话压缩，完成后自动恢复原模型。
- 在 Agent 进入错误状态后保留待处理的恢复交互，同时维持已关闭运行时的原有清理行为。
- 排除无响应体、上下文窗口、限流和认证等不属于请求体大小限制的错误。

## Checklist

- [x] I ran `npm run typecheck`.
- [x] I ran `npm run build`.
- [x] I added comments for non-obvious logic or state transitions.
- [x] I updated documentation if behavior changed.（无需文档更新；该功能复用现有运行时确认和模型选择交互）

## Screenshots

无新增 UI；复用现有运行时确认和模型选择界面。

## Verification

- `node --test tests/piDeckRequestSizeRecovery.test.mjs tests/askUiStateMachine.test.mjs tests/builtInExtensions.test.mjs tests/sessionRuntimeCoordinator.test.mjs tests/sessionRuntimeUi.test.mjs`（99 tests passed）
- `npm run typecheck`
- `npm run build`
- `npm test`（功能分支上 4,132 passed；2 个失败来自 pi-ai catalog 产物校验。此后上游 `dev` 已更新相关 catalog 文件，本 PR 未修改该部分）
- PiDeck 0.7.3 人工验证：使用本地 nginx 风格 413 响应触发恢复流程；错误后恢复提示保持可操作，确认后可选择临时模型完成压缩，并自动恢复原模型。

Closes #185