### PR TITLE
fix: WSL 内 pi 检测不到（nvm/fnm 等版本管理器场景）

### DIFF
--- a/src/main/health/EnvironmentDoctor.ts
+++ b/src/main/health/EnvironmentDoctor.ts
@@ -118,6 +118,8 @@ export class EnvironmentDoctor {
 						...pi,
 						// pi 命令/搜索目录可能含 home 路径，统一脱敏；version 是版本号，不含隐私但同样过长时截断
 						command: pi.command ? maskPath(pi.command) : pi.command,
+						// WSL 解析出的 Linux 绝对路径带用户名，与 command 同级处理
+						piPath: pi.piPath ? maskPath(pi.piPath) : pi.piPath,
 						version: pi.version ? truncateText(pi.version, 80) : pi.version,
 						error: pi.error ? redactSecrets(maskPath(pi.error)) : pi.error,
 						searchedDirs: pi.searchedDirs.map((dir) => maskPath(dir)),

--- a/src/main/ipc/systemIpc.ts
+++ b/src/main/ipc/systemIpc.ts
@@ -41,7 +41,7 @@ import { getProcessSnapshot } from "../process/ProcessMonitor";
 import { buildDshHostMonitorRow, isDshHostMonitorId } from "../process/dshHostMonitor";
 import type { AgentProcessMetric, DiagnosticsSnapshot, ProcessMetricsSnapshot } from "../../shared/types";
 import type { DiagnosticsMonitor } from "../diagnostics/DiagnosticsMonitor";
-import { getWslExe } from "../wsl/wslExe";
+import { getWslExe, decodeWslOutput, parseWslDistroList } from "../wsl/wslExe";
 import { listWebNetworkAddresses } from "../web/WebNetwork";
 import { toggleMainWindowDevTools } from "../devTools";
 import {
@@ -213,6 +213,14 @@ function asConfigProxyMode(raw: unknown): ConfigProxyMode {
 	return raw === "pi" || raw === "desktop" || raw === "off" ? raw : "follow";
 }
 
+/**
+ * WSL 发行版名 / 用户名的边界校验：只允许安全字符、限长，且不得以 `-` 开头。
+ * 两者会以数组形式传给 wsl.exe 的 `-d` / `-u`，以 `-` 开头的值会被当成额外选项解析。
+ */
+function isWslName(value: string): boolean {
+	return /^[A-Za-z0-9._][A-Za-z0-9._-]{0,63}$/.test(value);
+}
+
 export function registerSystemIpc(deps: SystemIpcDeps): void {
 	const {
 		piLocator,
@@ -285,14 +293,23 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 
 	// ── Pi 检测 ──────────────────────────────────────────────────────
 
-	ipcMain.handle(ipcChannels.piCheck, async () => {
+	ipcMain.handle(ipcChannels.piCheck, async (_event, force?: unknown) => {
 		const settings = settingsStore.get();
-		const status = await piLocator.check(settings.customPiPath, settings.wslEnabled, settings.wslDistro, settings.wslUser);
+		// 渲染层输入不可信：只认布尔 true，其他一律当非强制重检
+		const forceWslProbe = force === true;
+		const status = await piLocator.check(
+			settings.customPiPath,
+			settings.wslEnabled,
+			settings.wslDistro,
+			settings.wslUser,
+			{ forceWslProbe },
+		);
 		void appLogger.info("pi", "Pi check completed", {
 			installed: status.installed,
 			version: status.version,
 			command: status.command,
 			error: status.error,
+			forceWslProbe,
 		});
 		return status;
 	});
@@ -451,49 +468,49 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 		if (process.platform !== "win32") return [] as string[];
 		try {
 			const { execFile } = await import("node:child_process");
-			return new Promise<string[]>((resolve) => {
-				execFile(wslExePath, ["-l", "-q"], { encoding: "utf8", timeout: 10_000, windowsHide: true, shell: wslShell },
+			return await new Promise<string[]>((resolve) => {
+				// wsl.exe 在 Windows 10 1903+ 以 UTF-16LE 输出；按 utf8 解码会得到字符夹 NUL 的乱码，
+				// 旧实现的 `!includes("\x00")` 过滤会把全部行丢掉，表现为发行版下拉框永远为空。
+				execFile(wslExePath, ["-l", "-q"], { encoding: "buffer", timeout: 10_000, windowsHide: true, shell: wslShell },
 					(err, stdout) => {
 						if (err) { resolve([]); return; }
-						const distros = stdout.split(/\r?\n/)
-							.map((s) => s.trim())
-							.filter((s) => s.length > 0 && !s.includes("\\") && !s.includes("\x00"));
-						resolve(distros);
+						resolve(parseWslDistroList(stdout));
 					});
 			});
 		} catch { return [] as string[]; }
 	});
 
-	ipcMain.handle(ipcChannels.wslValidateConnection, async (_event, distro: string, user: string) => {
+	ipcMain.handle(ipcChannels.wslValidateConnection, async (_event, distro: unknown, user: unknown) => {
+		// 边界校验：渲染层输入不可信，distro/user 只允许安全字符且限长（会拼进子进程参数数组）。
+		if (
+			typeof distro !== "string" ||
+			typeof user !== "string" ||
+			!isWslName(distro) ||
+			!isWslName(user)
+		) {
+			return { ok: false, whoami: "", piVersion: "", piPath: "", error: mainCopy("wsl.connectionFailed") };
+		}
 		if (process.platform !== "win32") {
-			return { ok: false, whoami: "", piVersion: "", error: mainCopy("wsl.windowsOnly") };
+			return { ok: false, whoami: "", piVersion: "", piPath: "", error: mainCopy("wsl.windowsOnly") };
 		}
 		try {
 			const { execFile } = await import("node:child_process");
 			const whoami = await new Promise<string>((resolve, reject) => {
 				execFile(wslExePath, ["-d", distro, "-u", user, "whoami"],
-					{ encoding: "utf8", timeout: 10_000, windowsHide: true, shell: wslShell },
+					{ encoding: "buffer", timeout: 10_000, windowsHide: true, shell: wslShell },
 					(err, stdout) => {
 						if (err) { reject(err); return; }
-						resolve(stdout.trim());
+						resolve(decodeWslOutput(stdout).trim());
 					});
 			});
-			let piVersion = "";
-			try {
-				piVersion = await new Promise<string>((resolve, reject) => {
-					execFile(wslExePath, ["-d", distro, "-u", user, "pi", "--version"],
-						{ encoding: "utf8", timeout: 10_000, windowsHide: true, shell: wslShell },
-						(err, stdout) => {
-							if (err) { reject(err); return; }
-							resolve(stdout.trim());
-						});
-				});
-			} catch { /* pi 未安装，piVersion 保持空 */ }
+			// 与 agent 启动共用同一探测结果（强制重探）：用户可能刚在 WSL 里装完 pi 就来点验证。
+			const pi = await piLocator.checkWslInstallation(distro, user, { force: true });
 			return {
 				ok: true,
 				whoami,
-				piVersion,
-				error: piVersion ? "" : mainCopy("wsl.piNotInstalled"),
+				piVersion: pi.installed ? (pi.version ?? "") : "",
+				piPath: pi.installed ? (pi.piPath ?? "") : "",
+				error: pi.installed ? "" : mainCopy("wsl.piNotInstalled"),
 			};
 		} catch (err) {
 			void appLogger.warn("wsl", "WSL connection validation failed", {
@@ -505,6 +522,7 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
 				ok: false,
 				whoami: "",
 				piVersion: "",
+				piPath: "",
 				error: mainCopy("wsl.connectionFailed"),
 			};
 		}

--- a/src/main/pi/PiLocator.ts
+++ b/src/main/pi/PiLocator.ts
@@ -4,12 +4,33 @@ import { delimiter, dirname, extname, join } from "node:path";
 import { app } from "electron";
 import type { AppSettings, PiInstallStatus } from "../../shared/types";
 import type { MainProcessTranslationKey } from "../../shared/i18n/mainProcessCopy";
+import {
+  WSL_PI_NEGATIVE_CACHE_TTL_MS,
+  WSL_PI_PROBE_TIMEOUT_MS,
+  buildWslCommandMarker,
+  buildWslPiExecArgs,
+  buildWslPiProbeScript,
+  isWslInteropPath,
+  parseWslCommandMarker,
+  parseWslPiProbeOutput,
+  type WslPiProbeResult,
+} from "../wsl/wslPiProbe";
+import { decodeWslOutput } from "../wsl/wslExe";
 
-/** 进程级 WSL `which pi` 结果：字符串 = 可用的 wsl:// 标记；null = 已探测且未找到。 */
-type WslWhichCacheValue = string | null;
+/**
+ * 进程级 WSL pi 探测缓存。
+ * - command：`wsl://<distro>/<user>/<pi 绝对路径>` 标记；null = 已探测且未找到（负缓存）。
+ * - nodeBinDir：与该 pi 配套的 node bin 目录；启动时前置注入 PATH，供 `#!/usr/bin/env node` 使用。
+ * - at：写入时间。负缓存按 TTL 过期，避免「用户装完 pi 不重启应用就永远检测不到」。
+ */
+type WslCommandCacheEntry = {
+  command: string | null;
+  nodeBinDir: string;
+  at: number;
+};
 
-const wslCommandCache = new Map<string, WslWhichCacheValue>();
-const wslCommandInflight = new Map<string, Promise<WslWhichCacheValue>>();
+const wslCommandCache = new Map<string, WslCommandCacheEntry>();
+const wslCommandInflight = new Map<string, Promise<string | null>>();
 
 function wslCommandCacheKey(distro: string, user: string): string {
   return `${distro}\0${user}`;
@@ -71,10 +92,11 @@ export class PiLocator {
     if (wslEnabled && process.platform === "win32" && wslDistro && wslUser) {
       const wslCustomPath = this.toWslCustomPath(normalizedCustomPath, wslEnabled, wslDistro, wslUser);
       if (wslCustomPath) return wslCustomPath;
-      // 热路径只读缓存：同步 `wsl.exe which pi` 最多卡 8 秒，会把关窗/设置点死。
-      // 未预热时先回退 "pi"（可能落到 Windows shim）；warmWslCommand 完成后下次解析才用 wsl://。
+      // 热路径只读缓存：同步 WSL 探测会把关窗/设置点死。
+      // 即使尚未预热或探测失败，也必须保留 WSL 边界；返回裸 `pi` 的 WSL 标记，
+      // 不能回退为 Windows 的 `pi`，否则 WSL 配置下会静默执行宿主机 pi。
       const wslCommand = this.peekCachedWslCommand(wslDistro, wslUser);
-      if (wslCommand) return wslCommand;
+      return wslCommand ?? buildWslCommandMarker(wslDistro, wslUser, "pi");
     }
     // 用户手动指定路径优先，适用于 npm/pnpm/yarn 全局安装、nvm/volta/asdf/mise 等极端情况。
     // 旧版本可能已保存 pi.ps1；Windows 现在不再调用 PowerShell shim，遇到时忽略并回退自动检测。
@@ -97,17 +119,45 @@ export class PiLocator {
   }
 
   /**
-   * 启动/设置变更时异步探测 WSL 内的 `pi`，结果写入进程级缓存。
-   * 热路径 `resolveCommand` 只读缓存，避免同步 `execFileSync` 卡住主进程。
+   * 启动/设置变更时异步探测 WSL 内的 pi，结果写入进程级缓存。
+   * 热路径 `resolveCommand` 只读缓存，避免同步子进程调用卡住主进程。
    * 多次调用同一 distro/user 会合并为一次 in-flight 探测。
+   *
+   * `force` 给用户显式重检（设置页「检测环境」/ 保存 WSL 配置 / WSL 连接验证）：
+   * 忽略正、负缓存重新探测，否则负缓存 TTL 内点按钮不会有任何变化。
    */
-  async warmWslCommand(distro?: string, user?: string): Promise<string | undefined> {
+  async warmWslCommand(
+    distro?: string,
+    user?: string,
+    options?: { force?: boolean },
+  ): Promise<string | undefined> {
     if (process.platform !== "win32" || !distro || !user) return undefined;
-    const cached = wslCommandCache.get(wslCommandCacheKey(distro, user));
-    // null 是负缓存（已探测且没有 pi），不能当成未命中再打 which。
-    if (cached !== undefined) return cached ?? undefined;
+    const key = wslCommandCacheKey(distro, user);
+    if (options?.force) wslCommandCache.delete(key);
+    else {
+      const cached = this.readWslCache(key);
+      // null 是负缓存（已探测且没有 pi），不能当成未命中再打一轮探测。
+      if (cached) return cached.command ?? undefined;
+    }
     const probed = await this.probeWslCommand(distro, user);
     return probed ?? undefined;
+  }
+
+  /**
+   * 读缓存并套用负缓存 TTL。
+   * undefined = 未命中或负缓存已过期（需重探）；有对象 = 命中（含「确认没装」的 null）。
+   *
+   * 正缓存不设 TTL：热路径上过期会回退到宿主机 pi（比多等一次探测危险得多）；
+   * 版本管理器切版本/卸载等失效场景由 `force`（设置变更、显式重检）覆盖。
+   */
+  private readWslCache(key: string): WslCommandCacheEntry | undefined {
+    const cached = wslCommandCache.get(key);
+    if (!cached) return undefined;
+    if (cached.command === null && Date.now() - cached.at > WSL_PI_NEGATIVE_CACHE_TTL_MS) {
+      wslCommandCache.delete(key);
+      return undefined;
+    }
+    return cached;
   }
 
   getSearchDirs() {
@@ -244,20 +294,21 @@ export class PiLocator {
   }
 
   createInvocation(command: string, args: string[], options: { wslCwd?: string } = {}): PiCommandInvocation {
-    // WSL 模式：command 为 "wsl://<distro>/<user>/pi" 形式的标记
+    // WSL 模式：command 为 "wsl://<distro>/<user>/<pi 绝对路径>" 形式的标记
     if (command.startsWith("wsl://")) {
       const parsed = this.parseWslUrl(command);
       if (!parsed) return { command, args, shell: false };
       const { distro, user, piCommand } = parsed;
       const wslExe = this.resolveWslExe();
-      const wslArgs = [
-        "-d", distro,
-        "-u", user,
-        ...(options.wslCwd ? ["--cd", options.wslCwd] : []),
+      // 与 checkWslCommand 共用 buildWslPiExecArgs：探测通过即意味着能启动。
+      const wslArgs = buildWslPiExecArgs({
+        distro,
+        user,
         piCommand,
-        ...args,
-      ];
-      console.log('[PiLocator] WSL invocation:', wslExe.command, wslArgs.join(' '), 'shell:', wslExe.shell);
+        nodeBinDir: this.peekCachedWslNodeBinDir(distro, user, piCommand),
+        wslCwd: options.wslCwd,
+        args,
+      });
       return {
         command: wslExe.command,
         args: wslArgs,
@@ -354,7 +405,13 @@ export class PiLocator {
     return this.runCheck(command, []);
   }
 
-  async check(customPath?: string, wslEnabled?: boolean, wslDistro?: string, wslUser?: string): Promise<PiInstallStatus> {
+  async check(
+    customPath?: string,
+    wslEnabled?: boolean,
+    wslDistro?: string,
+    wslUser?: string,
+    options?: { forceWslProbe?: boolean },
+  ): Promise<PiInstallStatus> {
     const normalizedCustomPath = this.normalizeCustomPath(customPath);
     if (
       normalizedCustomPath &&
@@ -363,9 +420,9 @@ export class PiLocator {
     ) {
       return this.unsupportedPowerShellStatus(normalizedCustomPath, this.getSearchDirs());
     }
-    // 设置页检测可以等 WSL which：缓存未命中时先异步探测，再 resolve，避免热路径同步 which。
+    // 设置页检测可以等 WSL 探测：缓存未命中时先异步探测，再 resolve，避免热路径同步子进程。
     if (wslEnabled && process.platform === "win32" && wslDistro && wslUser) {
-      await this.warmWslCommand(wslDistro, wslUser);
+      await this.warmWslCommand(wslDistro, wslUser, { force: options?.forceWslProbe });
     }
     const command = this.resolveCommand(customPath, wslEnabled, wslDistro, wslUser);
     const searchedDirs = this.getSearchDirs();
@@ -382,6 +439,32 @@ export class PiLocator {
     }
 
     return this.runCheck(command, searchedDirs);
+  }
+
+  /**
+   * 专给设置页「WSL 连接验证」用的 WSL pi 检测：强制重探 + 返回解析出的 Linux 绝对路径。
+   *
+   * 不复用 `check()` 是因为它未命中时会回退到宿主机候选（Windows pi），
+   * 验证场景要的是「这个 distro + 这个用户里到底有没有能跑的 pi」。
+   */
+  async checkWslInstallation(
+    distro: string,
+    user: string,
+    options?: { force?: boolean },
+  ): Promise<PiInstallStatus> {
+    if (process.platform !== "win32" || !distro || !user) {
+      return { installed: false, searchedDirs: [] };
+    }
+    const marker = await this.warmWslCommand(distro, user, options);
+    if (!marker) return { installed: false, searchedDirs: [] };
+    const parsed = this.parseWslUrl(marker);
+    if (!parsed) return { installed: false, searchedDirs: [] };
+    const status = await this.checkWslCommand(parsed.distro, parsed.user, parsed.piCommand);
+    return {
+      ...status,
+      command: `wsl -d ${parsed.distro} -u ${parsed.user} ${parsed.piCommand}`,
+      piPath: parsed.piCommand,
+    };
   }
 
   /**
@@ -440,11 +523,12 @@ export class PiLocator {
       process.platform !== "win32" ||
       !wslDistro ||
       !wslUser ||
-      !command.startsWith("/")
+      !command.startsWith("/") ||
+      isWslInteropPath(command)
     ) {
       return null;
     }
-    return `wsl://${wslDistro}/${wslUser}/${command}`;
+    return buildWslCommandMarker(wslDistro, wslUser, command);
   }
 
   private unsupportedPowerShellStatus(
@@ -510,14 +594,6 @@ export class PiLocator {
   }
 
   /**
-   * 尝试在 WSL 中检测 pi 是否可用。
-   * 返回 "wsl://<distro>/<user>/pi" 标记字符串，供 resolveCommand/createInvocation 识别。
-   */
-  /**
-   * wsl.exe 完整路径。32 位进程在 64 位 Windows 上访问 System32 会被文件系统重定向到
-   * SysWOW64，而 wsl.exe 仅存在于真实 System32 中。使用 Sysnative 别名绕过重定向。
-   */
-  /**
    * wsl.exe 完整路径（优先绝对路径，fopen 失败时回退到 PATH）。
    * 32 位进程在 64 位 Windows 上访问 System32 会被文件系统重定向，
    * Sysnative 别名可绕过；若均不可用则通过 shell PATH 查找。
@@ -533,9 +609,10 @@ export class PiLocator {
       console.log('[PiLocator] resolveWslExe candidate:', candidate, 'exists:', ok);
       if (ok) return { command: candidate, shell: false };
     }
-    // 绝对路径均不存在：通过 cmd.exe PATH 查找 wsl.exe
-    console.log('[PiLocator] resolveWslExe fallback: shell mode with "wsl"');
-    return { command: "wsl", shell: true };
+    // 绝对路径均不存在：让 CreateProcess/Node 直接通过 PATH 查找 wsl.exe。
+    // 不能打开 shell：distro/user/cwd 都来自设置，shell fallback 会引入命令注入。
+    console.log('[PiLocator] resolveWslExe fallback: PATH lookup with shell disabled');
+    return { command: "wsl", shell: false };
   }
   /** @deprecated 使用 resolveWslExe() 代替，支持 PATH 回退 */
   private get wslExePath(): string {
@@ -543,80 +620,159 @@ export class PiLocator {
   }
 
   /**
-   * 解析 "wsl://<distro>/<user>/<piCommand>" 格式的 URL。
-   * 使用正则代替 .split("/") 避免 wsl:// 的双斜杠产生空字符串元素导致解析错位。
+   * 解析 "wsl://<distro>/<user>/<piCommand>" 格式的标记。
+   * piCommand 现在是绝对 Linux 路径（带斜杠），解析规则集中在 wslPiProbe，与构造侧对称。
    */
   private parseWslUrl(url: string): { distro: string; user: string; piCommand: string } | null {
-    const match = url.match(/^wsl:\/\/([^/]+)\/([^/]+)\/(.+)$/);
-    if (!match) return null;
-    return { distro: match[1], user: match[2], piCommand: match[3] };
+    return parseWslCommandMarker(url);
   }
 
   private peekCachedWslCommand(distro: string, user: string): string | undefined {
-    const cached = wslCommandCache.get(wslCommandCacheKey(distro, user));
-    return cached ?? undefined;
+    return this.readWslCache(wslCommandCacheKey(distro, user))?.command ?? undefined;
   }
 
   /**
-   * 异步 `wsl.exe which pi`。成功写入 `wsl://distro/user/pi`，失败写入 null（负缓存，避免反复探测）。
-   * 禁止回到 execFileSync：8s 超时会把 Electron 主进程事件循环堵住。
+   * 取探测阶段拿到的 node bin 目录。
+   * 只在标记与缓存命中的是同一个 pi 时才套用：用户手动指定的路径（如另一个 node 版本
+   * 下的 pi）不得继承探测缓存，否则会把错的 node 前置到 PATH。
+   * 未命中时返回 undefined，由 buildWslPiExecArgs 从 pi 绝对路径推导同目录。
    */
-  private probeWslCommand(distro: string, user: string): Promise<WslWhichCacheValue> {
+  private peekCachedWslNodeBinDir(
+    distro: string,
+    user: string,
+    piCommand: string,
+  ): string | undefined {
+    const entry = this.readWslCache(wslCommandCacheKey(distro, user));
+    if (!entry?.command) return undefined;
+    if (entry.command !== buildWslCommandMarker(distro, user, piCommand)) return undefined;
+    return entry.nodeBinDir || undefined;
+  }
+
+  /**
+   * 异步探测 WSL 内的 pi，结果写入进程级缓存（含负缓存）。
+   *
+   * 不能用 `which pi`：wsl.exe 不带登录/交互标记跑命令，nvm/fnm 等写在 `~/.bashrc`
+   * 交互守卫之后的 PATH 注入不会生效，必然找不到。探测改走 `wslPiProbe` 分层脚本，
+   * 并缓存**绝对路径 + node bin 目录**，使「探测结果」与「启动参数」同源。
+   * 禁止回到 execFileSync：超时会把 Electron 主进程事件循环堵住。
+   */
+  private probeWslCommand(distro: string, user: string): Promise<string | null> {
     const key = wslCommandCacheKey(distro, user);
-    const cached = wslCommandCache.get(key);
-    if (cached !== undefined) return Promise.resolve(cached);
+    const cached = this.readWslCache(key);
+    if (cached) return Promise.resolve(cached.command);
     const inflight = wslCommandInflight.get(key);
     if (inflight) return inflight;
 
-    const task = new Promise<WslWhichCacheValue>((resolve) => {
-      const wslExe = this.resolveWslExe();
-      const wslArgs = ["-d", distro, "-u", user, "which", "pi"];
-      execFile(wslExe.command, wslArgs, {
-        encoding: "utf8",
-        timeout: 8_000,
-        windowsHide: true,
-        shell: wslExe.shell,
-      }, (error, stdout) => {
-        if (error) {
-          resolve(null);
-          return;
-        }
-        const result = String(stdout ?? "").trim();
-        if (result && result.length > 0 && !result.includes("not found")) {
-          resolve(`wsl://${distro}/${user}/pi`);
-          return;
-        }
-        resolve(null);
+    const task = this.runWslPiProbe(distro, user)
+      .then((result) => {
+        const command = result ? buildWslCommandMarker(distro, user, result.piPath) : null;
+        wslCommandCache.set(key, {
+          command,
+          nodeBinDir: result?.nodeBinDir ?? "",
+          at: Date.now(),
+        });
+        return command;
+      })
+      .finally(() => {
+        wslCommandInflight.delete(key);
       });
-    }).then((value) => {
-      wslCommandCache.set(key, value);
-      wslCommandInflight.delete(key);
-      return value;
-    });
 
     wslCommandInflight.set(key, task);
     return task;
   }
 
+  /**
+   * 跑一次探测脚本。优先 `/bin/bash -lic`（交互登录 shell，PATH 含版本管理器注入）；
+   * 只有 spawn 本身失败（如 distro 里没有 bash）才降级到 `/bin/sh -c`，
+   * 后者仍覆盖已知安装目录 glob 与包管理器 prefix。
+   * 「脚本跑通但没找到」不重试，避免未装 pi 的用户白等一轮 WSL 往返。
+   */
+  private async runWslPiProbe(distro: string, user: string): Promise<WslPiProbeResult | null> {
+    const script = buildWslPiProbeScript();
+    const shells: Array<{ shell: string; flags: string[] }> = [
+      { shell: "/bin/bash", flags: ["-lic"] },
+      { shell: "/bin/sh", flags: ["-c"] },
+    ];
+    for (const candidate of shells) {
+      const output = await this.execWslProbe(distro, user, candidate.shell, candidate.flags, script);
+      if (output === null) continue;
+      return parseWslPiProbeOutput(output);
+    }
+    return null;
+  }
+
+  /** 执行探测脚本；返回 null 表示 spawn/执行失败（区别于「跑通但没找到」的空输出）。 */
+  private execWslProbe(
+    distro: string,
+    user: string,
+    shell: string,
+    flags: string[],
+    script: string,
+  ): Promise<string | null> {
+    const wslExe = this.resolveWslExe();
+    return new Promise((resolve) => {
+      const child = execFile(
+        wslExe.command,
+        ["-d", distro, "-u", user, "-e", shell, ...flags, script],
+        {
+          // Keep bytes until decodeWslOutput; wsl.exe may emit UTF-16LE on
+          // older Windows builds and decoding as UTF-8 first loses non-ASCII paths.
+          encoding: "buffer",
+          timeout: WSL_PI_PROBE_TIMEOUT_MS,
+          windowsHide: true,
+          shell: wslExe.shell,
+          maxBuffer: 8 * 1024 * 1024,
+        },
+        (error, stdout) => {
+          if (error) {
+            // 不区分错误类型：调用端会降级到 /bin/sh 重试，最终只是「未检测到」。
+            // 但必须留痕，否则只能从 UI 的「未检测到」倒推是 WSL 探测链哪一环挂了。
+            console.error("[PiLocator] WSL pi probe failed", { shell, error: error.message });
+            resolve(null);
+            return;
+          }
+          resolve(decodeWslOutput(stdout));
+        },
+      );
+      // stdin 必须关：交互 shell 的 rc 里一句 `read` 就能把探测挂到超时。
+      child.stdin?.end();
+    });
+  }
+
+  /**
+   * 在 WSL 里验证一个已解析的 pi 命令。
+   * 参数组装必须与 createInvocation 同函数（buildWslPiExecArgs）：
+   * 否则会出现「--version 能跑但启动失败」或反过来的不对称，用户看到的就是「检测不到 / 启动不了」。
+   */
   private checkWslCommand(distro: string, user: string, piCommand: string): Promise<PiInstallStatus> {
     return new Promise(resolve => {
       const wslExe = this.resolveWslExe();
-      const wslArgs = ["-d", distro, "-u", user, piCommand, "--version"];
-      execFile(wslExe.command, wslArgs, {
+      const wslArgs = buildWslPiExecArgs({
+        distro,
+        user,
+        piCommand,
+        nodeBinDir: this.peekCachedWslNodeBinDir(distro, user, piCommand),
+        args: ["--version"],
+      });
+      const child = execFile(wslExe.command, wslArgs, {
         env: this.createProcessEnv(undefined, undefined, { distro, user, piCommand }),
         shell: wslExe.shell,
         windowsHide: true,
-        timeout: 8_000,
-        encoding: "utf8",
+        timeout: WSL_PI_PROBE_TIMEOUT_MS,
+        // Decode the raw bytes ourselves so UTF-16LE output is not corrupted
+        // before decodeWslOutput gets a chance to inspect it.
+        encoding: "buffer",
       }, (error, stdout, stderr) => {
         if (error) {
-          const raw = stderr?.trim() || this.cleanExecError(error.message);
-          console.error("[PiLocator] WSL pi CLI check failed", { error: raw });
+          const raw = decodeWslOutput(stderr).trim() || this.cleanExecError(error.message);
+          console.error("[PiLocator] WSL pi CLI check failed", { piCommand, error: raw });
           resolve({ installed: false, searchedDirs: [], error: this.translate("mainPi.checkFailed") });
           return;
         }
-        resolve({ installed: true, command: `wsl -d ${distro} -u ${user} ${piCommand}`, version: stdout.trim(), searchedDirs: [] });
+        resolve({ installed: true, command: `wsl -d ${distro} -u ${user} ${piCommand}`, version: decodeWslOutput(stdout).trim(), searchedDirs: [] });
       });
+      // pi 的 RPC 模式靠 stdin 通信，但 --version 不需要；提前关闭避免子进程等输入。
+      child.stdin?.end();
     });
   }
 

--- a/src/main/wsl/wslExe.ts
+++ b/src/main/wsl/wslExe.ts
@@ -9,6 +9,35 @@ import { existsSync } from "node:fs";
 
 let resolved: { command: string; shell: boolean } | null = null;
 
+/**
+ * 解码 wsl.exe 的 stdout。
+ * Windows 10 1903+ 的 wsl.exe 以 UTF-16LE 输出（`wsl -l -q` 尤其明显），
+ * 按 utf8 解码会得到字符间夹 NUL 的乱码，过滤后列表恒为空 —— 表现为设置页发行版下拉框空白。
+ * 这里按 BOM / NUL 特征判定 UTF-16LE，其余按 UTF-8，并剥掉残留 NUL。
+ */
+export function decodeWslOutput(raw: Buffer | string): string {
+	const buffer = Buffer.isBuffer(raw) ? raw : Buffer.from(String(raw ?? ""), "utf8");
+	if (buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe) {
+		return buffer.subarray(2).toString("utf16le").replace(/\0/g, "");
+	}
+	// 无 BOM 但呈「ASCII + NUL」交替特征：同样是 UTF-16LE
+	if (buffer.length >= 4 && buffer[1] === 0x00 && buffer[3] === 0x00) {
+		return buffer.toString("utf16le").replace(/\0/g, "").replace(/^\ufeff/, "");
+	}
+	return buffer.toString("utf8").replace(/\0/g, "");
+}
+
+/**
+ * 解析 `wsl -l -q` 输出为发行版名列表。
+ * 过滤空行与含反斜杠的历史输出（旧版本会带 `\` 标记默认发行版）。
+ */
+export function parseWslDistroList(raw: Buffer | string): string[] {
+	return decodeWslOutput(raw)
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.includes("\\"));
+}
+
 export function getWslExe(): { command: string; shell: boolean } {
 	if (resolved) return resolved;
 	const root = process.env.SystemRoot || "C:\\Windows";
@@ -21,6 +50,9 @@ export function getWslExe(): { command: string; shell: boolean } {
 			return resolved;
 		}
 	}
-	resolved = { command: "wsl", shell: true };
+	// `execFile` can resolve a bare executable through PATH without a shell. Keeping
+	// shell=false is important here: distro/user values are settings data, and a
+	// shell fallback would turn characters such as `&` or `|` into command syntax.
+	resolved = { command: "wsl", shell: false };
 	return resolved;
 }

--- a/src/main/wsl/wslPiProbe.ts
+++ b/src/main/wsl/wslPiProbe.ts
@@ -1,0 +1,222 @@
+/**
+ * WSL 内 pi 的探测与启动参数拼装（纯函数层，无 Electron / 子进程依赖，可单测）。
+ *
+ * 为什么需要这一层：`wsl.exe -d D -u U <cmd>` 用的是**非登录、非交互** shell，
+ * nvm / fnm / volta / asdf / mise 的 PATH 注入写在 `~/.bashrc` 的交互守卫之后
+ * （Ubuntu 默认 `.bashrc` 开头就 `case $- in *i*) ... *) return`），
+ * 所以这类 shell 里 `which pi` 必然为空 —— 表现为「WSL 里能用 pi，PiDeck 说未检测到」。
+ * 即便拿到绝对路径，pi 的 shebang 是 `#!/usr/bin/env node`，node 不在 PATH 时仍会失败。
+ *
+ * 因此本模块约定两件事，探测与启动必须共用：
+ * 1. 探测分三层：交互登录 shell 的 PATH → 已知安装目录 glob → 包管理器 prefix；
+ * 2. 启动统一走 `-e /usr/bin/env PATH=<node bin>:<系统目录> <pi 绝对路径>`，
+ *    既绕开 shell rc 依赖，也绕开 wsl.exe 不带 `-e` 时把参数拼成命令行二次解析的引号坑。
+ */
+
+/** 探测超时：冷启动 WSL VM 时 `wsl.exe` 首条命令可能很慢，8s 明显不够。 */
+export const WSL_PI_PROBE_TIMEOUT_MS = 20_000;
+/** 负缓存有效期：用户「装完 pi 不重启应用」也要能在一个 TTL 内自动恢复。 */
+export const WSL_PI_NEGATIVE_CACHE_TTL_MS = 60_000;
+
+/** WSL 默认非登录 shell 的系统 bin，保证 git / sh / coreutils 仍能找到。 */
+export const WSL_PI_BASE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+export type WslPiProbeResult = {
+	/** pi 可执行文件（或 npm shim）的 Linux 绝对路径。 */
+	piPath: string;
+	/** 与该 pi 配套的 node 所在目录；启动时前置注入 PATH，供 `env node` shebang 使用。 */
+	nodeBinDir: string;
+};
+
+/**
+ * 已知的 Linux 侧安装位置，按优先级排列（版本管理器 → 包管理器 → 系统目录）。
+ * `$HOME` / `$PNPM_HOME` 与 `*` 由 WSL 内的 shell 展开，因此列表里保留原始写法。
+ */
+export const WSL_PI_CANDIDATE_DIRS: readonly string[] = [
+	"$HOME/.nvm/versions/node/*/bin",
+	"$HOME/.fnm/node-versions/*/installation/bin",
+	"$HOME/.local/share/fnm/node-versions/*/installation/bin",
+	"$HOME/.fnm/aliases/default/bin",
+	"$HOME/.local/share/fnm/aliases/default/bin",
+	"$HOME/.volta/bin",
+	"$HOME/.asdf/shims",
+	"$HOME/.local/share/mise/shims",
+	"$HOME/.local/share/mise/installs/node/*/bin",
+	"$HOME/.npm-global/bin",
+	"$PNPM_HOME",
+	"$HOME/.local/share/pnpm",
+	"$HOME/.yarn/bin",
+	"$HOME/.config/yarn/global/node_modules/.bin",
+	"$HOME/.bun/bin",
+	"$HOME/.deno/bin",
+	"$HOME/.cargo/bin",
+	"$HOME/.local/bin",
+	"$HOME/bin",
+	"/usr/local/bin",
+	"/usr/bin",
+	"/bin",
+	"/opt/homebrew/bin",
+	"/home/linuxbrew/.linuxbrew/bin",
+];
+
+/** 探测脚本输出的键名；rc 噪音（PROMPT_COMMAND、欢迎语）靠它过滤。 */
+const PI_KEY = "PIDECK_PI=";
+const NODE_BIN_KEY = "PIDECK_NODE_BIN=";
+
+function isAbsoluteLinuxPath(value: string): boolean {
+	return value.startsWith("/");
+}
+
+function quoteProbeCandidate(dir: string): string {
+	// Keep the wildcard unquoted so pathname expansion still happens, but quote
+	// HOME/PNPM_HOME themselves. Linux home directories are allowed to contain
+	// spaces, and the old `for _d in $HOME/...` split those paths into fragments.
+	if (dir.startsWith("$HOME/")) return `"$HOME"/${dir.slice("$HOME/".length)}/pi`;
+	if (dir === "$PNPM_HOME") return `"$PNPM_HOME"/pi`;
+	const value = `${dir}/pi`;
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * WSL interop 命中：`appendWindowsPath=true` 时 Linux PATH 会带上 `/mnt/c/...`，
+ * 那里找到的是 Windows 侧 pi.cmd shim，不是 distro 内的 Linux 安装，不能当 WSL pi 用。
+ */
+export function isWslInteropPath(path: string): boolean {
+	return /^\/mnt\/[A-Za-z](\/|$)/i.test(path);
+}
+
+/**
+ * 生成一次往返完成探测的 POSIX sh 脚本。
+ * 命中即 `exit 0` 并打印 `PIDECK_PI=` / `PIDECK_NODE_BIN=`；未命中打印 `PIDECK_MISS=1` 且仍 exit 0，
+ * 这样「脚本跑通但没装 pi」与「bash 不存在 / spawn 失败」在调用端可区分。
+ */
+export function buildWslPiProbeScript(extraCandidateDirs: readonly string[] = []): string {
+	const candidateDirs = [...WSL_PI_CANDIDATE_DIRS, ...extraCandidateDirs].filter(Boolean);
+	const candidateList = candidateDirs.map(quoteProbeCandidate).join(" ");
+	return [
+		"_pideck_emit() {",
+		// 必须是绝对路径、可执行、且不是 Windows interop shim
+		'  case "$1" in /*) ;; *) return 1 ;; esac',
+		'  case "$1" in /mnt/*) return 1 ;; esac',
+		'  [ -x "$1" ] || return 1',
+		'  _bin="$2"',
+		'  [ -n "$_bin" ] || _bin=$(dirname "$1")',
+		'  printf \'PIDECK_PI=%s\\n\' "$1"',
+		'  printf \'PIDECK_NODE_BIN=%s\\n\' "$_bin"',
+		"  exit 0",
+		"}",
+		// L1：交互登录 shell 已 source nvm/fnm 初始化，覆盖用户自定义安装位置
+		'_p=$(command -v pi 2>/dev/null)',
+		'_n=$(command -v node 2>/dev/null)',
+		'_nb=""',
+		'if [ -n "$_n" ]; then _rn=$(readlink -f "$_n" 2>/dev/null); [ -n "$_rn" ] && _nb=$(dirname "$_rn"); fi',
+		// fnm/nvm 的 /run/user/.../fnm_multishells 目录随 shell 退出失效，改用稳定的 installation/bin
+		'case "$_p" in /run/user/*) if [ -n "$_nb" ] && [ -x "$_nb/pi" ]; then _p="$_nb/pi"; fi ;; esac',
+		// command -v may return a symlink (including a symlink into /mnt/c). Resolve it
+		// before the interop check and cache the executable path, not the link name.
+		'_rp=$(readlink -f "$_p" 2>/dev/null); [ -n "$_rp" ] && _p="$_rp"',
+		'_pideck_emit "$_p" "$_nb"',
+		// L2：已知安装目录（不依赖任何 shell rc）。先筛可执行再解符号链接，避免为不存在的候选白跑 fork。
+		`for _d in ${candidateList}; do`,
+		'  [ -x "$_d" ] || continue',
+		// Keep the candidate's bin directory for the shebang Node lookup. The
+		// resolved target is often cli.js under node_modules, not beside node.
+		'  _db=$(dirname "$_d")',
+		'  _rd=$(readlink -f "$_d" 2>/dev/null)',
+		'  [ -n "$_rd" ] && _d="$_rd"',
+		'  case "$_d" in /mnt/*) continue ;; esac',
+		'  _pideck_emit "$_d" "$_db"',
+		"done",
+		// L3：问包管理器要全局 prefix（仅在 L1/L2 全落空时才会付出这点开销）
+		'if command -v npm >/dev/null 2>&1; then _x=$(npm config get prefix 2>/dev/null); [ -n "$_x" ] && _pideck_emit "$_x/bin/pi" "$_x/bin"; fi',
+		'if command -v mise >/dev/null 2>&1; then for _x in $(mise bin-paths 2>/dev/null); do _pideck_emit "$_x/pi" "$_x"; done; fi',
+		'if command -v volta >/dev/null 2>&1; then _x=$(volta which pi 2>/dev/null); [ -n "$_x" ] && _pideck_emit "$_x" ""; fi',
+		'if command -v asdf >/dev/null 2>&1; then _x=$(asdf which pi 2>/dev/null); [ -n "$_x" ] && _pideck_emit "$_x" ""; fi',
+		'printf "PIDECK_MISS=1\\n"',
+		"exit 0",
+	].join("\n");
+}
+
+/**
+ * 解析探测脚本输出。
+ * 容忍 rc 噪音与 GBK/UTF-16 混排：只认 `PIDECK_PI=` / `PIDECK_NODE_BIN=` 两种行，取最后一次。
+ * node bin 缺失时回退到 pi 自身所在目录（nvm/fnm/volta/mise 的全局 bin 与 node 同目录）。
+ */
+export function parseWslPiProbeOutput(stdout: string): WslPiProbeResult | null {
+	let piPath = "";
+	let nodeBinDir = "";
+	for (const rawLine of String(stdout ?? "").split(/\r?\n/)) {
+		const line = rawLine.replace(/\0/g, "").trim();
+		if (line.startsWith(PI_KEY)) piPath = line.slice(PI_KEY.length);
+		else if (line.startsWith(NODE_BIN_KEY)) nodeBinDir = line.slice(NODE_BIN_KEY.length);
+	}
+	if (!isAbsoluteLinuxPath(piPath) || isWslInteropPath(piPath)) return null;
+	if (!isAbsoluteLinuxPath(nodeBinDir) || isWslInteropPath(nodeBinDir)) {
+		nodeBinDir = piPath.slice(0, piPath.lastIndexOf("/")) || "/";
+	}
+	return { piPath, nodeBinDir };
+}
+
+export type WslPiExecArgsInput = {
+	distro: string;
+	user: string;
+	/** `wsl://` 标记里的命令段：绝对 Linux 路径，或裸命令名 `pi`。 */
+	piCommand: string;
+	/** 与 pi 配套的 node bin 目录；缺省时从 piCommand 推导。 */
+	nodeBinDir?: string;
+	/** 已转换好的 Linux 工作目录（`--cd`）。 */
+	wslCwd?: string;
+	args: readonly string[];
+};
+
+/**
+ * 组装 `wsl.exe` 的参数数组 —— 探测（`--version`）与启动（RPC）共用同一个函数，
+ * 杜绝「检测得到、启动失败」这类不对称失败。
+ *
+ * 绝对路径分支：`-e /usr/bin/env PATH=<nodeBin>:<系统目录> <pi> <args…>`
+ * - `-e` 让 wsl.exe 直接 exec，不把参数交给默认 shell 二次解析（空格/引号安全）；
+ * - 注入 PATH 让 `#!/usr/bin/env node` 找得到 node。
+ * 裸命令名分支：保持历史行为，不注入 PATH（否则会覆盖掉用户 distro 里的完整环境）。
+ */
+export function buildWslPiExecArgs(input: WslPiExecArgsInput): string[] {
+	const args = ["-d", input.distro, "-u", input.user];
+	if (input.wslCwd) args.push("--cd", input.wslCwd);
+
+	if (!isAbsoluteLinuxPath(input.piCommand)) {
+		return [...args, input.piCommand, ...input.args];
+	}
+
+	const candidate = input.nodeBinDir ?? "";
+	const nodeBinDir =
+		isAbsoluteLinuxPath(candidate) && !isWslInteropPath(candidate)
+			? candidate
+			: input.piCommand.slice(0, input.piCommand.lastIndexOf("/")) || "/";
+	const pathValue = nodeBinDir === "/" ? WSL_PI_BASE_PATH : `${nodeBinDir}:${WSL_PI_BASE_PATH}`;
+	return [...args, "-e", "/usr/bin/env", `PATH=${pathValue}`, input.piCommand, ...input.args];
+}
+
+export type ParsedWslCommandMarker = {
+	distro: string;
+	user: string;
+	piCommand: string;
+};
+
+/**
+ * 解析 `wsl://<distro>/<user>/<piCommand>` 标记。
+ * 用正则而非 split("/")：命令段本身带斜杠（绝对 Linux 路径），且 `wsl://` 的双斜杠不能产生空元素。
+ */
+export function parseWslCommandMarker(url: string): ParsedWslCommandMarker | null {
+	const match = /^wsl:\/\/([^/\r\n]+)\/([^/\r\n]+)\/([^\r\n]+)$/.exec(url);
+	if (!match) return null;
+	const [, distro, user, piCommand] = match;
+	// Only the generated bare command or an absolute Linux path is valid. This
+	// prevents a corrupted setting such as `wsl://D/U/-e` from becoming another
+	// wsl.exe option, and keeps /mnt/c host shims out of the WSL path.
+	if (piCommand !== "pi" && (!isAbsoluteLinuxPath(piCommand) || isWslInteropPath(piCommand))) return null;
+	return { distro, user, piCommand };
+}
+
+/** 构造 `wsl://` 标记；piPath 以 `/` 开头时保留双斜杠，与 parseWslCommandMarker 对称。 */
+export function buildWslCommandMarker(distro: string, user: string, piCommand: string): string {
+	return `wsl://${distro}/${user}/${piCommand}`;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -96,6 +96,7 @@ import type {
 	PiExtensionListResult,
 	PiInstallStatus,
 	PiInstallExecResult,
+	WslConnectionValidation,
 	NpmAvailabilityResult,
 	PasteFileWriteInput,
 	PasteFileWriteResult,
@@ -1136,8 +1137,12 @@ const api = {
 			) as Promise<void>,
 	},
 	pi: {
-		check: () =>
-			ipcRenderer.invoke(ipcChannels.piCheck) as Promise<PiInstallStatus>,
+		/**
+		 * 检测 pi 环境。`force` = 忽略 WSL 探测缓存重新扫描，
+		 * 用于用户显式点「检测环境」或刚改过 WSL 配置（否则负缓存 TTL 内看不到新装好的 pi）。
+		 */
+		check: (force?: boolean) =>
+			ipcRenderer.invoke(ipcChannels.piCheck, force === true) as Promise<PiInstallStatus>,
 		/** 验证用户手动输入的 pi 路径，通过后主进程会自动保存到 settings.customPiPath */
 		checkCustom: (customPath: string) =>
 			ipcRenderer.invoke(
@@ -1162,12 +1167,7 @@ const api = {
 			ipcRenderer.invoke(ipcChannels.wslListDistros) as Promise<string[]>,
 		/** 验证 WSL 连接：检查 distro + user 是否可达，以及 pi 是否已安装 */
 		validateConnection: (distro: string, user: string) =>
-			ipcRenderer.invoke(ipcChannels.wslValidateConnection, distro, user) as Promise<{
-				ok: boolean;
-				whoami: string;
-				piVersion: string;
-				error: string;
-			}>,
+			ipcRenderer.invoke(ipcChannels.wslValidateConnection, distro, user) as Promise<WslConnectionValidation>,
 	},
 	system: {
 		/** 进程监控：拉取 Electron 各进程 + pi agent 子进程内存/CPU 快照 */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2706,7 +2706,8 @@ export function App() {
       }
       // WSL/Windows pi 源切换：重新检测 pi 环境、刷新项目和会话列表
       if ("wslEnabled" in patch || "wslDistro" in patch || "wslUser" in patch) {
-        void api.pi.check().then((next) => setPiStatus(next)).catch(() => undefined);
+        // WSL 配置变更后强制重探：否则切换 distro/用户名仍会命中旧的 wsl:// 绝对路径缓存
+        void api.pi.check(true).then((next) => setPiStatus(next)).catch(() => undefined);
         void api.projects.list().then(setProjects).catch(() => undefined);
         if (activeProjectId) {
           void refreshProjectSessions(activeProjectId, true).catch(() => undefined);

--- a/src/renderer/src/components/app/settings/DevTab.tsx
+++ b/src/renderer/src/components/app/settings/DevTab.tsx
@@ -5,6 +5,7 @@ import type {
   PiCliUpdateResult,
   PiInstallStatus,
   PiUpdateCheckResult,
+  WslConnectionValidation,
 } from "../../../../../shared/types";
 import { t } from "../../../i18n";
 import { desktopApi } from "../../../desktopApi";
@@ -87,12 +88,7 @@ export const DevTab = memo(function DevTab(props: DevTabProps) {
   const [wslDistrosLoading, setWslDistrosLoading] = useState(false);
   const [wslDistrosAttempted, setWslDistrosAttempted] = useState(false);
   const [wslValidating, setWslValidating] = useState(false);
-  const [wslValidation, setWslValidation] = useState<{
-    ok: boolean;
-    whoami: string;
-    piVersion: string;
-    error: string;
-  } | null>(null);
+  const [wslValidation, setWslValidation] = useState<WslConnectionValidation | null>(null);
   // WSL 发行版列表懒加载（仅 Windows + WSL 开启时拉取，无论成败只拉一次）
   useEffect(() => {
     const isWin = props.appInfo.platform === "win32";
@@ -112,7 +108,7 @@ export const DevTab = memo(function DevTab(props: DevTabProps) {
 
   const handleValidateWslUser = async () => {
     if (!window.piDesktop.wsl) {
-      setWslValidation({ ok: false, whoami: "", piVersion: "", error: t("settings.wsl.apiUnavailable") });
+      setWslValidation({ ok: false, whoami: "", piVersion: "", piPath: "", error: t("settings.wsl.apiUnavailable") });
       return;
     }
     setWslValidating(true);
@@ -126,7 +122,7 @@ export const DevTab = memo(function DevTab(props: DevTabProps) {
       }
     } catch (err) {
       console.error("[Settings] WSL validation failed", err);
-      setWslValidation({ ok: false, whoami: "", piVersion: "", error: t("settings.wsl.validationFailed") });
+      setWslValidation({ ok: false, whoami: "", piVersion: "", piPath: "", error: t("settings.wsl.validationFailed") });
     } finally {
       setWslValidating(false);
     }
@@ -308,9 +304,17 @@ export const DevTab = memo(function DevTab(props: DevTabProps) {
                           })}
                         </small>
                         {wslValidation.piVersion ? (
-                          <small className="setting-status success">
-                            {t("settings.wsl.piDetected", { version: wslValidation.piVersion })}
-                          </small>
+                          <>
+                            <small className="setting-status success">
+                              {t("settings.wsl.piDetected", { version: wslValidation.piVersion })}
+                            </small>
+                            {/* 展示解析到的 Linux 绝对路径：nvm/fnm 场景下用户需要能核对版本目录 */}
+                            {wslValidation.piPath && (
+                              <small className="setting-status info">
+                                {t("settings.wsl.piPath", { path: wslValidation.piPath })}
+                              </small>
+                            )}
+                          </>
                         ) : (
                           <small className="setting-status warning">
                             {wslValidation.error || t("settings.wsl.piNotInstalled")}

--- a/src/renderer/src/hooks/usePiUpdate.ts
+++ b/src/renderer/src/hooks/usePiUpdate.ts
@@ -97,7 +97,8 @@ export function usePiUpdate(options: UsePiUpdateOptions) {
       setPiChecking(true);
       setEnvironmentDialog(true);
       try {
-        const next = await api.pi.check();
+        // manual = 用户点「检测环境」，忽略 WSL 探测缓存重新扫描；startup 沿用启动预热结果
+        const next = await api.pi.check(source === "manual");
         setPiStatus(next);
         // 检测结果缓存（含未检测到的清除）；startup 额外标记 piEnvironmentChecked
         const saved = await persistPiInstall(next);
@@ -120,7 +121,8 @@ export function usePiUpdate(options: UsePiUpdateOptions) {
     setPiChecking(true);
     setCustomPathResult(null);
     try {
-      const next = await api.pi.check();
+      // 设置页的显式重检：强制重探 WSL，否则刚装完 pi 的用户要等负缓存过期
+      const next = await api.pi.check(true);
       setPiStatus(next);
       if (next.installed) {
         const saved = await api.settings.update({
@@ -193,7 +195,8 @@ export function usePiUpdate(options: UsePiUpdateOptions) {
     setCustomPiPath("");
     setCustomPathResult(null);
     showToast(t("app.piPathCleared"));
-    const status = await api.pi.check();
+    // 路径已变：清掉 WSL 探测缓存重新解析
+    const status = await api.pi.check(true);
     setPiStatus(status);
   }, [api, setPiStatus, setSettings]);
 

--- a/src/renderer/src/i18n/rendererCopy.en-US.ts
+++ b/src/renderer/src/i18n/rendererCopy.en-US.ts
@@ -3086,7 +3086,7 @@ export const enUS: Record<TranslationKey, string> = {
   "settings.customPiPath": "Custom pi path",
   "settings.customPiPathValid": "Validation passed: {version}",
   "settings.customPiPathHint":
-    "Supports quoted paths, double backslashes, and extensionless paths. The path is normalized and validated before saving.",
+    "Supports quoted paths, double backslashes, and extensionless paths. The path is normalized and validated before saving. In WSL mode, enter an absolute Linux path (e.g. /home/user/.nvm/versions/node/v22/bin/pi).",
   "settings.debug": "Debug",
   "settings.desktopProxy": "Desktop proxy",
   "settings.desktopProxyDesc":
@@ -3183,7 +3183,9 @@ export const enUS: Record<TranslationKey, string> = {
   "settings.wsl.detectingDistros": "Detecting installed distros…",
   "settings.wsl.validationOk": "User {user} is reachable in {distro}",
   "settings.wsl.piDetected": "pi CLI installed: {version}",
-  "settings.wsl.piNotInstalled": "pi CLI not installed, run npm i -g @earendil-works/pi-coding-agent in WSL",
+  "settings.wsl.piNotInstalled":
+    "pi CLI was not detected. If it came from nvm/fnm/volta or another version manager, set the absolute Linux path in \"Custom pi path\" below (e.g. /home/user/.nvm/versions/node/v22/bin/pi); otherwise run npm i -g @earendil-works/pi-coding-agent inside WSL",
+  "settings.wsl.piPath": "Resolved path: {path}",
   "settings.wsl.apiUnavailable": "The WSL API is not ready. Restart PiDeck and try again.",
   "settings.wsl.validationFailed": "Failed to validate the WSL connection. Try again later.",
   "settings.piUpdateSection": "Pi CLI Update",

--- a/src/renderer/src/i18n/rendererCopy.zh-CN.ts
+++ b/src/renderer/src/i18n/rendererCopy.zh-CN.ts
@@ -3061,7 +3061,7 @@ export const zhCN = {
   "settings.customPiPath": "自定义 pi 路径",
   "settings.customPiPathValid": "校验通过：{version}",
   "settings.customPiPathHint":
-    "支持带引号、双反斜杠和无扩展名路径；保存前会自动归一化并校验。",
+    "支持带引号、双反斜杠和无扩展名路径；保存前会自动归一化并校验。WSL 模式下请填 Linux 绝对路径（如 /home/user/.nvm/versions/node/v22/bin/pi）。",
   "settings.debug": "调试",
   "settings.desktopProxy": "桌面端代理",
   "settings.desktopProxyDesc": "用于模型拉取、模型测试等桌面自身请求",
@@ -3154,7 +3154,9 @@ export const zhCN = {
   "settings.wsl.detectingDistros": "正在检测已安装的发行版…",
   "settings.wsl.validationOk": "用户 {user} 在 {distro} 中可用",
   "settings.wsl.piDetected": "pi CLI 已安装：{version}",
-  "settings.wsl.piNotInstalled": "pi CLI 未安装，请在 WSL 中运行 npm i -g @earendil-works/pi-coding-agent",
+  "settings.wsl.piNotInstalled":
+    "pi CLI 未安装。若用 nvm/fnm/volta 等版本管理器安装，请在下方「自定义 pi 路径」填写 WSL 内的绝对路径（如 /home/user/.nvm/versions/node/v22/bin/pi）；或在 WSL 中运行 npm i -g @earendil-works/pi-coding-agent",
+  "settings.wsl.piPath": "解析路径：{path}",
   "settings.wsl.apiUnavailable": "WSL API 未就绪，请重启应用后再试",
   "settings.wsl.validationFailed": "WSL 连接验证失败，请稍后重试",
   "settings.piUpdateSection": "Pi CLI 更新",

--- a/src/renderer/src/previewApi.ts
+++ b/src/renderer/src/previewApi.ts
@@ -838,6 +838,7 @@ export function createPreviewApi(): PiDesktopApi {
 				ok: true,
 				whoami: "preview",
 				piVersion: "preview",
+				piPath: "/usr/local/bin/pi",
 				error: "",
 			}),
 		},

--- a/src/shared/i18n/mainProcessCopy.ts
+++ b/src/shared/i18n/mainProcessCopy.ts
@@ -42,7 +42,8 @@ export const mainProcessZhCN = {
 	"update.downloadFailed": "更新包下载失败，请稍后重试。",
 	"update.openFailed": "无法打开更新包，请手动打开下载目录。",
 	"wsl.windowsOnly": "WSL 仅在 Windows 上可用。",
-	"wsl.piNotInstalled": "未检测到 pi CLI。请在 WSL 中运行 npm i -g @earendil-works/pi-coding-agent。",
+	"wsl.piNotInstalled":
+		"未检测到 pi CLI。若用 nvm/fnm/volta 等版本管理器安装，请在「自定义 pi 路径」填写 WSL 内的绝对路径（如 /home/user/.nvm/versions/node/v22/bin/pi）；或在 WSL 中运行 npm i -g @earendil-works/pi-coding-agent。",
 	"wsl.connectionFailed": "无法连接到所选 WSL 发行版和用户，请检查配置后重试。",
 	"webService.invalidPort": "Web 服务端口必须是 1 到 65535 之间的整数。",
 	"webService.startFailed": "Web 服务启动失败，请检查主机和端口设置后重试。",
@@ -261,7 +262,8 @@ export const mainProcessEnUS: Record<MainProcessTranslationKey, string> = {
 	"update.downloadFailed": "Failed to download the update package. Try again later.",
 	"update.openFailed": "Could not open the update package. Open the download folder manually.",
 	"wsl.windowsOnly": "WSL is available only on Windows.",
-	"wsl.piNotInstalled": "pi CLI was not detected. Run npm i -g @earendil-works/pi-coding-agent in WSL.",
+	"wsl.piNotInstalled":
+		"pi CLI was not detected. If it was installed by nvm/fnm/volta or another version manager, set the absolute Linux path in \"Custom pi path\" (e.g. /home/user/.nvm/versions/node/v22/bin/pi); otherwise run npm i -g @earendil-works/pi-coding-agent inside WSL.",
 	"wsl.connectionFailed": "Could not connect to the selected WSL distribution and user. Check the settings and try again.",
 	"webService.invalidPort": "The web service port must be an integer from 1 to 65535.",
 	"webService.startFailed": "Failed to start the web service. Check the host and port settings and try again.",

--- a/src/shared/types/app.ts
+++ b/src/shared/types/app.ts
@@ -14,6 +14,23 @@ export type PiInstallStatus = {
 	version?: string;
 	searchedDirs: string[];
 	error?: string;
+	/**
+	 * WSL 模式下解析出的 Linux 绝对路径（如 /home/dev/.nvm/versions/node/v22/bin/pi）。
+	 * `command` 是给人看的 `wsl -d … -u … <path>` 形式，本字段留给设置页做可复制的诊断信息。
+	 */
+	piPath?: string;
+};
+
+/**
+ * 设置页「验证并保存」的 WSL 连接结果。
+ * piVersion / piPath 由与 agent 启动同一条探测链路产出，避免「验证通过但启动失败」。
+ */
+export type WslConnectionValidation = {
+	ok: boolean;
+	whoami: string;
+	piVersion: string;
+	piPath: string;
+	error: string;
 };
 
 /** 安装命令执行结果 */

--- a/tests/piLocator.test.mjs
+++ b/tests/piLocator.test.mjs
@@ -1,17 +1,58 @@
 import assert from "node:assert/strict";
 import { mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import ts from "typescript";
 import vm from "node:vm";
 
+/** vm 沙箱与宿主不同 realm，strict deepEqual 会比原型；统一转成宿主纯值再比。 */
+function eqDeep(actual, expected) {
+	assert.deepEqual(JSON.parse(JSON.stringify(actual)), JSON.parse(JSON.stringify(expected)));
+}
+
 const require = createRequire(import.meta.url);
 
-function loadPiLocatorModule(platform = process.platform, envOverrides = {}, homePath = tmpdir(), moduleOverrides = {}) {
-	const source = readFileSync("src/main/pi/PiLocator.ts", "utf8");
-	const { outputText } = ts.transpileModule(source, {
+const PI_LOCATOR_DIR = "src/main/pi";
+
+/**
+ * 在沙箱里加载一个项目内 TS 模块。
+ * PiLocator 现在依赖 ../wsl/wslPiProbe 与 ../wsl/wslExe，相对导入必须一并解析，
+ * 否则测试里 require 直接抛 MODULE_NOT_FOUND。
+ */
+function loadTsFile(filePath, sandboxExtra = {}) {
+	const { outputText } = ts.transpileModule(readFileSync(filePath, "utf8"), {
+		compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+	});
+	const sandbox = {
+		exports: {},
+		require: (id) => {
+			if (id.startsWith(".")) {
+				return loadTsFile(join(dirname(filePath), id + ".ts"), sandboxExtra);
+			}
+			return require(id);
+		},
+		Buffer,
+		TextDecoder,
+		process,
+		console,
+		...sandboxExtra,
+	};
+	sandbox.global = sandbox;
+	vm.runInNewContext(outputText, sandbox, { filename: filePath });
+	return sandbox.exports;
+}
+
+function loadPiLocatorModule(
+	platform = process.platform,
+	envOverrides = {},
+	homePath = tmpdir(),
+	moduleOverrides = {},
+	sandboxExtra = {},
+) {
+	const filePath = join(PI_LOCATOR_DIR, "PiLocator.ts");
+	const { outputText } = ts.transpileModule(readFileSync(filePath, "utf8"), {
 		compilerOptions: {
 			module: ts.ModuleKind.CommonJS,
 			target: ts.ScriptTarget.ES2022,
@@ -31,8 +72,16 @@ function loadPiLocatorModule(platform = process.platform, envOverrides = {}, hom
 			if (id === "electron") {
 				return { app: { getPath: () => homePath } };
 			}
+			// 相对依赖（../wsl/wslPiProbe、../wsl/wslExe）用同一套沙箱环境加载
+			if (id.startsWith(".")) {
+				return loadTsFile(join(PI_LOCATOR_DIR, id + ".ts"), {
+					process: sandbox.process,
+					require: (nested) => (nested in moduleOverrides ? moduleOverrides[nested] : require(nested)),
+				});
+			}
 			return require(id);
 		},
+		...sandboxExtra,
 	};
 	sandbox.global = sandbox;
 	// 宿主开发机可能已设置 MISE_DATA_DIR 等变量（如 D:\mise-data），
@@ -268,6 +317,47 @@ test("createProcessEnv prepends search dirs to PATH/Path without pathPrefix (npm
 	}
 });
 
+// ── WSL 探测（nvm/fnm 等非登录 shell 场景）──────────────────────
+
+const FNM_PI = "/home/dev/.local/share/fnm/node-versions/v24.20.0/installation/bin/pi";
+const FNM_NODE_BIN = FNM_PI.slice(0, FNM_PI.lastIndexOf("/"));
+const FNM_PROBE_OUTPUT = `PIDECK_PI=${FNM_PI}\nPIDECK_NODE_BIN=${FNM_NODE_BIN}\n`;
+
+/** 探测调用的特征：-e <shell> -lic <script>，脚本里带 PIDECK_PI= 输出键。 */
+function isWslProbeArgs(args) {
+	return (
+		Array.isArray(args) &&
+		args.includes("-lic") &&
+		typeof args[args.length - 1] === "string" &&
+		args[args.length - 1].includes("PIDECK_PI=")
+	);
+}
+
+/** 统计探测次数的 mock：TTL 用例要区分「命中缓存」与「真的又打了一次」。 */
+function countingProbe(onProbe, probeOutput, version = "0.85.1") {
+	const base = mockWslProbe({ probeOutput, version });
+	return {
+		execFile: (command, args, options, callback) => {
+			if (isWslProbeArgs(args)) onProbe();
+			base.execFile(command, args, options, callback);
+		},
+		execFileSync: () => "",
+	};
+}
+
+function mockWslProbe({ probeOutput, version = "0.85.1" }) {
+	return {
+		execFile: (_command, args, _options, callback) => {
+			if (isWslProbeArgs(args)) {
+				callback(null, probeOutput, "");
+				return;
+			}
+			callback(null, `${version}\n`, "");
+		},
+		execFileSync: () => "",
+	};
+}
+
 test("places an explicit WSL cwd before the pi command", () => {
 	const { PiLocator } = loadPiLocatorModule("win32");
 	const invocation = new PiLocator().createInvocation(
@@ -400,13 +490,13 @@ test("resolveCommand never calls execFileSync to probe WSL which pi", () => {
 	resetWslCommandCache();
 	const resolved = new PiLocator().resolveCommand(undefined, true, "Ubuntu-24.04", "dev");
 	assert.equal(syncCalls, 0);
-	// 缓存未预热时不得同步 which；也不得再走 wsl.exe。本地扫描结果随 PATH 变化，不能是 wsl://。
-	assert.equal(resolved.startsWith("wsl://"), false);
+	// 缓存未预热时不得同步 which，但仍必须保持 WSL 边界，不能回退到宿主机 pi。
+	assert.equal(resolved, "wsl://Ubuntu-24.04/dev/pi");
 });
 
-test("warmWslCommand caches wsl:// so later resolveCommand stays off the sync path", async () => {
+test("warmWslCommand caches the absolute linux pi path reported by the probe", async () => {
 	let syncCalls = 0;
-	let whichCalls = 0;
+	let probeCalls = 0;
 	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
 		"win32",
 		{},
@@ -414,9 +504,9 @@ test("warmWslCommand caches wsl:// so later resolveCommand stays off the sync pa
 		{
 			"node:child_process": {
 				execFile: (_command, args, _options, callback) => {
-					if (Array.isArray(args) && args.includes("which")) {
-						whichCalls += 1;
-						callback(null, "/usr/bin/pi\n", "");
+					if (isWslProbeArgs(args)) {
+						probeCalls += 1;
+						callback(null, FNM_PROBE_OUTPUT, "");
 						return;
 					}
 					callback(null, "0.80.0\n", "");
@@ -431,12 +521,206 @@ test("warmWslCommand caches wsl:// so later resolveCommand stays off the sync pa
 	resetWslCommandCache();
 	const locator = new PiLocator();
 	const warmed = await locator.warmWslCommand("Ubuntu-24.04", "dev");
-	assert.equal(warmed, "wsl://Ubuntu-24.04/dev/pi");
-	assert.equal(
-		locator.resolveCommand(undefined, true, "Ubuntu-24.04", "dev"),
-		"wsl://Ubuntu-24.04/dev/pi",
-	);
+	// 缓存的必须是探测到的绝对路径，而不是裸 `pi`：启动时同样不依赖 PATH
+	assert.equal(warmed, `wsl://Ubuntu-24.04/dev/${FNM_PI}`);
+	assert.equal(locator.resolveCommand(undefined, true, "Ubuntu-24.04", "dev"), warmed);
 	await locator.warmWslCommand("Ubuntu-24.04", "dev");
-	assert.equal(whichCalls, 1);
-	assert.equal(syncCalls, 0);
+	assert.equal(probeCalls, 1, "第二次 warm 应命中缓存");
+	assert.equal(syncCalls, 0, "探测不得走同步子进程");
+});
+
+test("wsl invocation execs the absolute pi path with node bin injected into PATH", async () => {
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{ "node:child_process": mockWslProbe({ probeOutput: FNM_PROBE_OUTPUT }) },
+	);
+	resetWslCommandCache();
+	const locator = new PiLocator();
+	const command = await locator.warmWslCommand("Ubuntu-24.04", "dev");
+	const invocation = locator.createInvocation(command, ["--mode", "rpc"], { wslCwd: "/home/dev/my project" });
+
+	// wsl.exe 由 resolveWslExe 定位（System32 / Sysnative / PATH 回退），这里只断言落在 wsl.exe 上
+	assert.match(invocation.command, /wsl(\.exe)?$/i);
+	// -e：不让 wsl.exe 把参数拼成命令行交给默认 shell 二次解析（空格/引号安全）
+	const execIndex = invocation.args.indexOf("-e");
+	assert.ok(execIndex > 0, "缺少 -e exec 分隔符");
+	eqDeep(invocation.args.slice(execIndex, execIndex + 2), ["-e", "/usr/bin/env"]);
+	assert.ok(
+		invocation.args[execIndex + 2].startsWith(`PATH=${FNM_NODE_BIN}:`),
+		`PATH 注入缺失：${invocation.args[execIndex + 2]}`,
+	);
+	eqDeep(invocation.args.slice(-3), [FNM_PI, "--mode", "rpc"]);
+	eqDeep(invocation.args.slice(0, 7), [
+		"-d",
+		"Ubuntu-24.04",
+		"-u",
+		"dev",
+		"--cd",
+		"/home/dev/my project",
+		"-e",
+	]);
+});
+
+test("wsl pi check uses exactly the same exec args as the launch path", async () => {
+	const captured = [];
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{
+			"node:child_process": {
+				execFile: (command, args, _options, callback) => {
+					captured.push(args);
+					if (isWslProbeArgs(args)) {
+						callback(null, FNM_PROBE_OUTPUT, "");
+						return;
+					}
+					callback(null, "0.85.1\n", "");
+				},
+				execFileSync: () => "",
+			},
+		},
+	);
+	resetWslCommandCache();
+	const locator = new PiLocator();
+	const status = await locator.check(undefined, true, "Ubuntu-24.04", "dev");
+
+	assert.equal(status.installed, true);
+	assert.equal(status.version, "0.85.1");
+	// 探测后紧跟的那次 --version 校验，参数结构必须与 createInvocation 一致
+	const checkArgs = captured[captured.length - 1];
+	eqDeep(checkArgs, [
+		"-d",
+		"Ubuntu-24.04",
+		"-u",
+		"dev",
+		"-e",
+		"/usr/bin/env",
+		`PATH=${FNM_NODE_BIN}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
+		FNM_PI,
+		"--version",
+	]);
+	// 同一份参数也能由 createInvocation 产出：探测通过 == 可启动
+	eqDeep(locator.createInvocation(`wsl://Ubuntu-24.04/dev/${FNM_PI}`, ["--version"]).args, checkArgs);
+	// 诊断展示用 command 带上绝对路径，用户能直接复制到 WSL 终端验证
+	assert.equal(status.command, `wsl -d Ubuntu-24.04 -u dev ${FNM_PI}`);
+});
+
+test("a windows interop probe hit is not treated as a wsl installation", async () => {
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{ "node:child_process": mockWslProbe({ probeOutput: "PIDECK_PI=/mnt/c/Users/dev/AppData/Roaming/npm/pi\n" }) },
+	);
+	resetWslCommandCache();
+	const locator = new PiLocator();
+	const warmed = await locator.warmWslCommand("Ubuntu-24.04", "dev");
+	// /mnt/* 是 appendWindowsPath 带进来的宿主机 shim，不能当 WSL pi 用
+	assert.equal(warmed, undefined);
+	assert.equal(locator.resolveCommand(undefined, true, "Ubuntu-24.04", "dev"), "wsl://Ubuntu-24.04/dev/pi");
+});
+
+test("negative wsl probe is cached until the ttl expires", async () => {
+	let probeCalls = 0;
+	let now = 1_000;
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{ "node:child_process": countingProbe(() => (probeCalls += 1), "PIDECK_MISS=1\n") },
+		{ Date: { now: () => now } },
+	);
+	resetWslCommandCache();
+	const locator = new PiLocator();
+
+	assert.equal(await locator.warmWslCommand("Ubuntu-24.04", "dev"), undefined);
+	assert.equal(probeCalls, 1);
+	// TTL 内重复 warm：命中负缓存，不再打 wsl.exe
+	assert.equal(await locator.warmWslCommand("Ubuntu-24.04", "dev"), undefined);
+	assert.equal(probeCalls, 1, "负缓存 TTL 内不得重复探测");
+
+	// 超过负缓存 TTL：用户可能刚在 WSL 里装完 pi，必须能自动恢复
+	now += 61_000;
+	assert.equal(await locator.warmWslCommand("Ubuntu-24.04", "dev"), undefined);
+	assert.equal(probeCalls, 2, "负缓存过期后应重新探测");
+});
+
+test("force re-probes wsl even when a positive result is cached", async () => {
+	let probeCalls = 0;
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{
+			"node:child_process": {
+				execFile: (_command, args, _options, callback) => {
+					if (isWslProbeArgs(args)) {
+						probeCalls += 1;
+						callback(null, FNM_PROBE_OUTPUT, "");
+						return;
+					}
+					callback(null, "0.85.1\n", "");
+				},
+				execFileSync: () => "",
+			},
+		},
+	);
+	resetWslCommandCache();
+	const locator = new PiLocator();
+	await locator.warmWslCommand("Ubuntu-24.04", "dev");
+	await locator.warmWslCommand("Ubuntu-24.04", "dev");
+	assert.equal(probeCalls, 1);
+
+	// 设置页显式重检 / 切换 distro 后保存：忽略正缓存重新探测
+	await locator.warmWslCommand("Ubuntu-24.04", "dev", { force: true });
+	assert.equal(probeCalls, 2);
+});
+
+test("a custom wsl pi path derives its own node bin dir instead of inheriting the probe cache", async () => {
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{ "node:child_process": mockWslProbe({ probeOutput: FNM_PROBE_OUTPUT }) },
+	);
+	resetWslCommandCache();
+	const locator = new PiLocator();
+	await locator.warmWslCommand("Ubuntu-24.04", "dev");
+
+	// 用户手动指定了另一个 node 版本下的 pi：不得把探测缓存的 node 目录前置到 PATH
+	const invocation = locator.createInvocation("wsl://Ubuntu-24.04/dev//opt/other-node/bin/pi", [
+		"--version",
+	]);
+	const execIndex = invocation.args.indexOf("-e");
+	assert.ok(invocation.args[execIndex + 2].startsWith("PATH=/opt/other-node/bin:"), invocation.args[execIndex + 2]);
+});
+
+test("checkWslInstallation reports the resolved linux path for the settings page", async () => {
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{ "node:child_process": mockWslProbe({ probeOutput: FNM_PROBE_OUTPUT }) },
+	);
+	resetWslCommandCache();
+	const status = await new PiLocator().checkWslInstallation("Ubuntu-24.04", "dev", { force: true });
+	assert.equal(status.installed, true);
+	assert.equal(status.piPath, FNM_PI);
+	assert.equal(status.version, "0.85.1");
+});
+
+test("checkWslInstallation reports not-installed when the probe finds nothing", async () => {
+	const { PiLocator, resetWslCommandCache } = loadPiLocatorModule(
+		"win32",
+		{},
+		tmpdir(),
+		{ "node:child_process": mockWslProbe({ probeOutput: "PIDECK_MISS=1\n" }) },
+	);
+	resetWslCommandCache();
+	const status = await new PiLocator().checkWslInstallation("Ubuntu-24.04", "dev");
+	assert.equal(status.installed, false);
+	assert.equal(status.piPath, undefined);
 });

--- a/tests/wslPiProbe.test.mjs
+++ b/tests/wslPiProbe.test.mjs
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import test from "node:test";
+import ts from "typescript";
+import vm from "node:vm";
+
+const require = createRequire(import.meta.url);
+
+function loadModule(filePath, sandboxExtra = {}) {
+	const { outputText } = ts.transpileModule(readFileSync(filePath, "utf8"), {
+		compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+	});
+	const sandbox = { exports: {}, require, Buffer, TextDecoder, process, ...sandboxExtra };
+	vm.runInNewContext(outputText, sandbox, { filename: filePath });
+	return sandbox.exports;
+}
+
+// vm 沙箱与宿主不同 realm，strict deepEqual 会比较原型；统一转成宿主可比较的纯值
+function eqDeep(actual, expected) {
+	assert.deepEqual(JSON.parse(JSON.stringify(actual)), JSON.parse(JSON.stringify(expected)));
+}
+
+const probe = loadModule("src/main/wsl/wslPiProbe.ts");
+const wslExe = loadModule("src/main/wsl/wslExe.ts");
+
+// ── 探测脚本内容 ──────────────────────────────────────────────────────
+
+test("probe script resolves pi through PATH before falling back to known install dirs", () => {
+	const script = probe.buildWslPiProbeScript();
+	// nvm/fnm 的 PATH 注入只在交互 shell 生效，L1 必须走 command -v
+	assert.ok(script.includes("command -v pi"), "缺少 PATH 探测层");
+	assert.ok(script.includes("command -v node"), "缺少 node 目录探测层");
+});
+
+test("probe script covers version managers and package manager global bins", () => {
+	const script = probe.buildWslPiProbeScript();
+	for (const dir of [
+		".nvm/versions/node/*/bin",
+		".fnm/node-versions/*/installation/bin",
+		".local/share/fnm/node-versions/*/installation/bin",
+		".volta/bin",
+		".asdf/shims",
+		".local/share/mise/shims",
+		".local/share/mise/installs/node/*/bin",
+		".npm-global/bin",
+		".local/share/pnpm",
+		".yarn/bin",
+		".bun/bin",
+		".deno/bin",
+		".local/bin",
+		"/usr/local/bin/pi",
+		"/usr/bin/pi",
+		"/home/linuxbrew/.linuxbrew/bin/pi",
+	]) {
+		assert.ok(script.includes(dir), "探测目录缺少 " + dir);
+	}
+	// HOME/PNPM_HOME must be quoted without quoting the wildcard itself.
+	assert.ok(script.includes('"$HOME"/.nvm/versions/node/*/bin/pi'));
+	assert.ok(script.includes('"$PNPM_HOME"/pi'));
+});
+
+test("probe script asks package managers for their prefix as a last resort", () => {
+	const script = probe.buildWslPiProbeScript();
+	assert.ok(script.includes("npm config get prefix"));
+	assert.ok(script.includes("mise bin-paths"));
+	assert.ok(script.includes("volta which pi"));
+	assert.ok(script.includes("asdf which pi"));
+});
+
+test("probe script rejects windows interop hits so host pi is never mistaken for wsl pi", () => {
+	const script = probe.buildWslPiProbeScript();
+	// appendWindowsPath=true 时 PATH 带 /mnt/c/...，那里是 Windows 侧 shim
+	assert.ok(script.includes('case "$1" in /mnt/*) return 1 ;; esac'));
+	assert.ok(script.includes('case "$_d" in /mnt/*) continue ;; esac'));
+});
+
+test("probe script replaces the ephemeral fnm multishell path with the stable install bin", () => {
+	const script = probe.buildWslPiProbeScript();
+	// /run/user/<uid>/fnm_multishells/<pid>_<ts>/bin 每次 shell 都变，不能当缓存身份
+	assert.ok(script.includes("/run/user/*"));
+	assert.ok(script.includes('readlink -f "$_n"'));
+});
+
+test("probe script emits machine readable keys and always exits zero", () => {
+	const script = probe.buildWslPiProbeScript();
+	assert.ok(script.includes('printf \'PIDECK_PI=%s\\n\' "$1"'));
+	assert.ok(script.includes('printf \'PIDECK_NODE_BIN=%s\\n\''));
+	// node bin 缺省时由 pi 所在目录推导，不依赖调用方传第二参
+	assert.ok(script.includes('_bin=$(dirname "$1")'));
+	// 未命中也 exit 0：调用端要能区分「确实没装」与「bash 不存在 / spawn 失败」
+	assert.ok(script.includes("PIDECK_MISS=1"));
+	assert.ok(script.trimEnd().endsWith("exit 0"));
+});
+
+test("probe script appends caller supplied candidate dirs", () => {
+	assert.ok(probe.buildWslPiProbeScript(["/opt/custom-pi/bin"]).includes("/opt/custom-pi/bin/pi"));
+});
+
+// ── 探测输出解析 ──────────────────────────────────────────────────────
+
+test("parses pi path and node bin dir from probe output", () => {
+	const result = probe.parseWslPiProbeOutput(
+		"PIDECK_PI=/home/u/.local/share/fnm/node-versions/v24.20.0/installation/bin/pi\n" +
+			"PIDECK_NODE_BIN=/home/u/.local/share/fnm/node-versions/v24.20.0/installation/bin\n",
+	);
+	eqDeep(result, {
+		piPath: "/home/u/.local/share/fnm/node-versions/v24.20.0/installation/bin/pi",
+		nodeBinDir: "/home/u/.local/share/fnm/node-versions/v24.20.0/installation/bin",
+	});
+});
+
+test("ignores shell rc noise printed before the probe keys", () => {
+	const result = probe.parseWslPiProbeOutput(
+		[
+			"\x1b]0;/home/u\x07Welcome to Ubuntu",
+			"PIDECK_MISS=1",
+			"PIDECK_PI=/usr/local/bin/pi",
+			"PIDECK_NODE_BIN=/usr/local/bin",
+		].join("\n"),
+	);
+	assert.equal(result.piPath, "/usr/local/bin/pi");
+	assert.equal(result.nodeBinDir, "/usr/local/bin");
+});
+
+test("falls back to the pi directory when node bin dir is missing or unusable", () => {
+	assert.equal(
+		probe.parseWslPiProbeOutput("PIDECK_PI=/home/u/.nvm/versions/node/v22/bin/pi\nPIDECK_NODE_BIN=\n").nodeBinDir,
+		"/home/u/.nvm/versions/node/v22/bin",
+	);
+	assert.equal(
+		probe.parseWslPiProbeOutput("PIDECK_PI=/home/u/.volta/bin/pi\nPIDECK_NODE_BIN=relative/path\n").nodeBinDir,
+		"/home/u/.volta/bin",
+	);
+});
+
+test("treats a windows interop pi path as not installed", () => {
+	assert.equal(probe.parseWslPiProbeOutput("PIDECK_PI=/mnt/c/Users/dev/AppData/Roaming/npm/pi\n"), null);
+	// node bin 落在 /mnt 时同样不可信，回退到 pi 自身目录
+	assert.equal(
+		probe.parseWslPiProbeOutput(
+			"PIDECK_PI=/usr/local/bin/pi\nPIDECK_NODE_BIN=/mnt/c/Program Files/nodejs\n",
+		).nodeBinDir,
+		"/usr/local/bin",
+	);
+});
+
+test("returns null when nothing was found", () => {
+	assert.equal(probe.parseWslPiProbeOutput("PIDECK_MISS=1\n"), null);
+	assert.equal(probe.parseWslPiProbeOutput(""), null);
+	assert.equal(probe.parseWslPiProbeOutput("pi not found\n"), null);
+});
+
+test("tolerates utf-16 nul bytes leaking into wsl stdout", () => {
+	const spaced = "P\x00I\x00D\x00E\x00C\x00K\x00_\x00P\x00I\x00=\x00/\x00u\x00s\x00r\x00/\x00b\x00i\x00n\x00/\x00p\x00i\x00";
+	assert.equal(probe.parseWslPiProbeOutput(spaced + "\n").piPath, "/usr/bin/pi");
+});
+
+// ── 启动参数：探测与启动必须共用同一份结果 ─────────────────────────
+
+test("builds wsl exec args that exec the absolute pi path with node bin injected into PATH", () => {
+	const args = probe.buildWslPiExecArgs({
+		distro: "Ubuntu-24.04",
+		user: "dev",
+		piCommand: "/home/dev/.nvm/versions/node/v22.14.0/bin/pi",
+		nodeBinDir: "/home/dev/.nvm/versions/node/v22.14.0/bin",
+		args: ["--version"],
+	});
+	eqDeep(args, [
+		"-d",
+		"Ubuntu-24.04",
+		"-u",
+		"dev",
+		// -e：不让 wsl.exe 把参数交给默认 shell 二次解析
+		"-e",
+		"/usr/bin/env",
+		"PATH=/home/dev/.nvm/versions/node/v22.14.0/bin:" + probe.WSL_PI_BASE_PATH,
+		"/home/dev/.nvm/versions/node/v22.14.0/bin/pi",
+		"--version",
+	]);
+});
+
+test("places the linux cwd before the exec separator", () => {
+	const args = probe.buildWslPiExecArgs({
+		distro: "Ubuntu-24.04",
+		user: "root",
+		piCommand: "/root/.volta/bin/pi",
+		wslCwd: "/root/ba cli",
+		args: ["--mode", "rpc"],
+	});
+	eqDeep(args.slice(0, 7), ["-d", "Ubuntu-24.04", "-u", "root", "--cd", "/root/ba cli", "-e"]);
+	eqDeep(args.slice(-3), ["/root/.volta/bin/pi", "--mode", "rpc"]);
+});
+
+test("derives the node bin dir from the pi path when the probe did not report one", () => {
+	const args = probe.buildWslPiExecArgs({
+		distro: "Ubuntu",
+		user: "dev",
+		piCommand: "/usr/local/bin/pi",
+		args: [],
+	});
+	assert.equal(args[6], "PATH=/usr/local/bin:" + probe.WSL_PI_BASE_PATH);
+});
+
+test("keeps the inherited wsl path for a bare pi command name", () => {
+	const args = probe.buildWslPiExecArgs({
+		distro: "Ubuntu",
+		user: "dev",
+		piCommand: "pi",
+		nodeBinDir: "/home/dev/.nvm/versions/node/v22/bin",
+		args: ["--mode", "rpc"],
+	});
+	// 裸命令名说明 PATH 已经能解析，注入反而会丢掉用户环境
+	eqDeep(args, ["-d", "Ubuntu", "-u", "dev", "pi", "--mode", "rpc"]);
+});
+
+test("ignores a windows interop node bin dir when injecting PATH", () => {
+	const args = probe.buildWslPiExecArgs({
+		distro: "Ubuntu",
+		user: "dev",
+		piCommand: "/usr/bin/pi",
+		nodeBinDir: "/mnt/c/Program Files/nodejs",
+		args: [],
+	});
+	assert.equal(args[6], "PATH=/usr/bin:" + probe.WSL_PI_BASE_PATH);
+});
+
+// ── wsl:// 标记 ───────────────────────────────────────────────────────
+
+test("wsl marker round-trips an absolute linux pi path", () => {
+	const marker = probe.buildWslCommandMarker("Ubuntu-24.04", "dev", "/home/dev/.nvm/versions/node/v22/bin/pi");
+	assert.equal(marker, "wsl://Ubuntu-24.04/dev//home/dev/.nvm/versions/node/v22/bin/pi");
+	eqDeep(probe.parseWslCommandMarker(marker), {
+		distro: "Ubuntu-24.04",
+		user: "dev",
+		piCommand: "/home/dev/.nvm/versions/node/v22/bin/pi",
+	});
+});
+
+test("parseWslCommandMarker rejects malformed and host-interoperability markers", () => {
+	assert.equal(probe.parseWslCommandMarker("wsl://Ubuntu/dev"), null);
+	assert.equal(probe.parseWslCommandMarker("wsl://Ubuntu/dev/"), null);
+	assert.equal(probe.parseWslCommandMarker("wsl://Ubuntu/dev/-e"), null);
+	assert.equal(probe.parseWslCommandMarker("wsl://Ubuntu/dev//mnt/c/Users/dev/pi.cmd"), null);
+	assert.equal(probe.parseWslCommandMarker("pi"), null);
+});
+
+// ── wsl.exe 输出解码（UTF-16LE）──────────────────────────────────────
+
+test("decodes utf-16le wsl -l -q output into a distro list", () => {
+	const utf16 = Buffer.from("Ubuntu-26.04\r\n", "utf16le");
+	eqDeep(wslExe.parseWslDistroList(utf16), ["Ubuntu-26.04"]);
+});
+
+test("decodes utf-16le output with bom", () => {
+	const bom = Buffer.from([0xff, 0xfe]);
+	const body = Buffer.from("Debian\r\nUbuntu-24.04\r\n", "utf16le");
+	eqDeep(wslExe.parseWslDistroList(Buffer.concat([bom, body])), ["Debian", "Ubuntu-24.04"]);
+});
+
+test("decodes plain utf-8 output", () => {
+	eqDeep(wslExe.parseWslDistroList(Buffer.from("Ubuntu\r\n", "utf8")), ["Ubuntu"]);
+	eqDeep(wslExe.parseWslDistroList("Ubuntu-26.04\r\n"), ["Ubuntu-26.04"]);
+});
+
+test("drops empty and legacy default-distro marker lines", () => {
+	eqDeep(wslExe.parseWslDistroList("Ubuntu\r\n\r\nD:\\wsl\\base\r\n"), ["Ubuntu"]);
+});


### PR DESCRIPTION
## Summary

修复 #190：WSL 模式下用 nvm / fnm / volta 安装的 pi 检测不到，填 Linux 绝对路径也无效；附带修复设置页「发行版」下拉框恒为空。

根因：`wsl.exe -d D -u U <cmd>` 跑的是**非登录、非交互** shell，版本管理器的 PATH 注入写在 `~/.bashrc` 交互守卫之后，`which pi` 必然为空；即便拿到绝对路径，pi 的 `#!/usr/bin/env node` 在该 shell 里也找不到 node。

### 主要改动

- **新增 `src/main/wsl/wslPiProbe.ts`**（纯函数层，无 Electron / 子进程依赖，可单测）：三层探测脚本（交互登录 shell PATH → 已知安装目录 glob → 包管理器 prefix）、`wsl://` 标记构造与解析、`buildWslPiExecArgs` 启动参数组装。
- **`PiLocator`**：探测结果、CLI 校验与 agent 启动共用同一份参数组装；缓存改存「pi 绝对路径 + node bin 目录」，负缓存 60s TTL，显式重检走 `force`；热路径未预热时保留 WSL 边界，不再回退裸 `pi`（避免静默执行宿主机 pi）；`resolveWslExe` 的 PATH 回退关闭 shell。
- **`wslExe.ts` / `systemIpc.ts`**：`decodeWslOutput` + `parseWslDistroList` 处理 UTF-16LE 输出；`wslValidateConnection` 校验 distro/user 字符集与长度并返回解析到的 `piPath`；`piCheck` 接受 `force`（只认布尔 true）。
- **契约与 UI**：`WslConnectionValidation` 共享类型、preload `pi.check(force)`、previewApi 同步；WSL 配置变更与设置页显式重检强制重探；设置页展示解析路径；诊断报告对 `piPath` 脱敏；中英文文案提示可填写 WSL 内绝对路径。
- **测试**：新增 `tests/wslPiProbe.test.mjs`，扩充 `tests/piLocator.test.mjs`（含负缓存 TTL、force、interop 路径拒绝、启动参数与探测同源）。

## 验证

- `npm run typecheck` ✅
- `npm run build` ✅
- `node --test tests/piLocator.test.mjs tests/wslPiProbe.test.mjs tests/agentManagerWslPaths.test.mjs tests/piProcessWsl.test.mjs tests/wslPaths.test.mjs tests/environmentHealth.test.mjs tests/healthRedact.test.mjs` ✅（110 项）
- 真机端到端（Windows 11 + WSL2 Ubuntu-26.04 + fnm，症状见 #190）：探测脚本返回**稳定**安装路径而非随 shell 退出失效的 `/run/user/.../fnm_multishells`，按 `buildWslPiExecArgs` 组装的参数可直接跑通 `pi --version`：

```text
PIDECK_PI=/home/dev/.local/share/fnm/node-versions/v24.20.0/installation/lib/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js
PIDECK_NODE_BIN=/home/dev/.local/share/fnm/node-versions/v24.20.0/installation/bin
$ wsl -d Ubuntu-26.04 -u dev -e /usr/bin/env PATH="$NODE_BIN:/usr/local/sbin:...:/bin" "$PI" --version
0.85.1
```

## 仍存在优化空间（本次未做）

1. **正缓存无 TTL**：版本管理器切版本 / 卸载 pi 后，不触发 `force`（改设置、点「检测环境」）就仍会用旧的绝对路径去启动并失败。可在 agent 启动失败时自动 `force` 重探一次。
2. **探测最坏两轮串行**：`/bin/bash -lic` 失败才降级 `/bin/sh -c`，冷启动 WSL VM 时最长 2×20s；设置页只有「检测中」，没有进度与取消入口。
3. **超时不一致**：`wslListDistros` / `whoami` 仍是 10s，探测与 `--version` 是 20s，冷启动下可能出现「发行版列表先空、pi 后到」。
4. **失败原因未分类**：distro 不存在、用户不存在、未装 pi、探测超时目前都归为「未检测到 pi」，`execWslProbe` 的错误只进主进程日志，不回传 UI，用户无法自证是哪一环挂了。
5. **候选目录是内置清单**：`buildWslPiProbeScript(extraCandidateDirs)` 预留了扩展参数但无人传入，可接一个设置项让用户补自定义安装目录（Nix、自定义 XDG 等仍可能漏）。
6. **`wsl://` 仍是自研 URI**：畸形设置值靠正则与 `piCommand` 白名单兜住，但更彻底的做法是把 distro/user/piPath 作为结构化对象存进 settings。
7. **wsl.exe 路径解析有两份实现**：`PiLocator.resolveWslExe` 与 `wslExe.getWslExe` 各自维护 Sysnative/PATH 候选，可合并到一处。
8. **CI 无 WSL 集成用例**：单测靠 vm 沙箱加载 TS，真实 `wsl.exe`（UTF-16LE、interop 路径、fnm multishell）只在开发机手工验证；CI 虽有 windows-latest，但没有装 WSL distro + fnm 的 job。

## Checklist

- [x] I ran `npm run typecheck`.
- [x] I ran `npm run build`.
- [x] I added comments for non-obvious logic or state transitions.
- [x] I updated documentation if behavior changed.（中英文 i18n 文案已同步；CHANGELOG 待发版时统一补）

## Screenshots

设置页「验证并保存」成功后新增一行「解析路径：/home/dev/.local/share/fnm/.../bin/pi」，便于核对版本管理器的具体版本目录。

Closes ayuayue/PiDeck#190
