### PR TITLE
fix: nicobailon pi-subagents 异步派发误标完成，面板条目缺任务描述

### DIFF
--- a/src/main/pi/derivedSubagents.ts
+++ b/src/main/pi/derivedSubagents.ts
@@ -14,12 +14,17 @@
  *
  * 2. subagent 工具（nicobailon 的 pi-subagents 插件，npm 无 scope 包）：工具名为
  *    "subagent"（注意 @tintinweb 版的工具名是 "Agent"，其历史由 record/锚点覆盖）。
- *    单任务前台派发（args 有 agent+task、无 action/workflow 字段、async!==true）的
- *    toolResult 携带最终报告全文，可直接推导终态；后台派发（async===true）工具立即
- *    返回转后台确认，历史侧不推导（id 空间与 subagent-async widget 的 asyncId 不同，
- *    同时推导会出现双行），运行中状态由渲染层消费 subagent-async widget 实时呈现。
+ *    单任务派发（args 有 agent+task、无 action/workflow 字段）按配对 toolResult 分流：
+ *    前台结果携带最终报告全文，直接推导终态；异步回执（含 "The async run is
+ *    detached" 引导文，覆盖 asyncByDefault/forceTopLevelAsync 运行时强制后台、模型
+ *    args 不带 async:true 的场景）不足终态——把条目重键为回执中的 asyncId 并保持
+ *    running。asyncId 与 subagent-async widget 的 run.id 同源，渲染层按 id 合并去重
+ *    （旧设计因派发用 toolCallId、widget 用 asyncId 导致双行而放弃推导，重键后解决），
+ *    且派发 args.task 的描述文本可补充给无 task 文本的 widget 条目。
  *
- * 推导条目 source 为 "toolcall"（live 降级逻辑见 downgradeStaleRunning）；
+ * 推导条目 source 为 "toolcall"（live 降级逻辑见 downgradeStaleRunning；异步条目
+ * 的终态只能降到 stopped——完成通知是 custom_message/subagent-notify 且单任务不带
+ * runId，无法可靠关联回 asyncId，历史会话只能识别到「已不在运行」）。
  * acp 条目 id 固定用派发 toolCallId（acp_delegate_xxx），与桥接扩展落盘的
  * record/锚点 id 对齐；runId 只用于把终态通知/取消关联回派发条目。
  *
@@ -51,6 +56,25 @@ export function extractEntryText(content: unknown): string {
 		}
 	}
 	return out;
+}
+
+/**
+ * nicobailon pi-subagents 异步派发回执特征：派发立即返回、运行转后台。交互/非交互
+ * 两种引导文都以 "The async run is detached" 开头，作为回执判定标记。
+ */
+const ASYNC_RECEIPT_MARKER = "The async run is detached";
+
+/** 回执首段中携带 asyncId 的行："Async: worker [uuid]" / "Async workflow [id]" 等。 */
+const ASYNC_ID_LINE_RE = /^Async[^\n]*\s\[([^\]\s]+)\]$/m;
+
+/** 判断 subagent 工具结果是否为异步派发回执（非最终报告）。 */
+export function isAsyncDispatchReceipt(text: string): boolean {
+	return text.includes(ASYNC_RECEIPT_MARKER);
+}
+
+/** 从回执文本提取 asyncId（与 subagent-async widget 的 run.id 同源）；提取失败返回 undefined。 */
+export function extractAsyncRunId(text: string): string | undefined {
+	return ASYNC_ID_LINE_RE.exec(text)?.[1];
 }
 
 /** 派发确认 / 系统通知文本中的 runId（形如 runId `del_xxx`）。 */
@@ -150,15 +174,21 @@ export function deriveAcpDelegateEntries(
 /**
  * 从会话文件原始条目推导 subagent 工具（nicobailon pi-subagents）的子代理条目。
  *
- * 只推导单任务前台派发：args 有 agent、无 action/workflow 字段且 async !== true，
- * 其配对 toolResult 携带最终报告全文，可直接落终态。action 管理查询（list/status 等）、
- * 工作流脚本派发和后台派发（async === true）都不在此推导——后台/工作流运行由渲染层
- * 消费 subagent-async widget 实时呈现，历史侧重复推导会出现 id 空间不同的双行。
+ * 推导单任务派发：args 有 agent、无 action/workflow 字段。前台派发的 toolResult
+ * 携带最终报告全文，直接落终态；异步派发回执（含运行时强制后台的派发）把条目
+ * 重键为回执中的 asyncId 并保持 running——与 subagent-async widget 的 run.id
+ * 同源后，渲染层按 id 合并去重，且派发 args.task 的描述文本可供无 task 文本的
+ * widget 条目补充（widget 快照只有 agent 名）。action 管理查询（list/status 等）
+ * 与工作流脚本派发不是单次运行，不推导。
  */
 export function deriveSubagentToolEntries(
 	rawEntries: readonly unknown[],
 ): PiSubagentEntry[] {
 	const byId = new Map<string, PiSubagentEntry>();
+	// toolCallId → 条目：派发初始以 toolCallId 为键；异步回执到达后重键为 asyncId。
+	// 两张表共享同一 entry 对象，重键时同步增删 byId，byToolCallId 保留原键供后续
+	// 同 callId 结果幂等。
+	const byToolCallId = new Map<string, PiSubagentEntry>();
 
 	for (const raw of rawEntries) {
 		if (!isRecord(raw) || raw.type !== "message" || !isRecord(raw.message)) continue;
@@ -170,14 +200,13 @@ export function deriveSubagentToolEntries(
 			for (const item of message.content) {
 				if (!isRecord(item) || item.type !== "toolCall" || item.name !== SUBAGENT_TOOL) continue;
 				const toolCallId = typeof item.id === "string" ? item.id : "";
-				if (!toolCallId || byId.has(toolCallId)) continue;
+				if (!toolCallId || byToolCallId.has(toolCallId)) continue;
 				const args = isRecord(item.arguments) ? item.arguments : {};
 				// 派发形态：agent 必带；action（管理查询）与 workflowScript*（工作流）不是单次运行
 				if (typeof args.agent !== "string" || !args.agent) continue;
 				if (args.action != null || args.workflowScript != null || args.workflowScriptPath != null) continue;
-				// 后台派发交给 subagent-async widget，见函数头注释
-				if (args.async === true) continue;
-				byId.set(toolCallId, {
+				// async:true 显式后台派发也推导：回执到达后重键为 asyncId（见下方 toolResult 分支）
+				const entry: PiSubagentEntry = {
 					id: toolCallId,
 					type: args.agent,
 					description: typeof args.task === "string" ? args.task : "",
@@ -185,18 +214,33 @@ export function deriveSubagentToolEntries(
 					startedAt: Number.isFinite(timestampMs) ? timestampMs : undefined,
 					source: "toolcall",
 					via: "pi-subagents-tool",
-				});
+				};
+				byToolCallId.set(toolCallId, entry);
+				byId.set(toolCallId, entry);
 			}
 			continue;
 		}
 
 		if (role === "toolResult" && message.toolName === SUBAGENT_TOOL
 			&& typeof message.toolCallId === "string") {
-			// 前台派发的结果即最终报告（与 acp 的「派发确认」语义不同）
-			const entry = byId.get(message.toolCallId);
+			const entry = byToolCallId.get(message.toolCallId);
 			if (!entry || TERMINAL_STATUSES.has(entry.status)) continue;
-			entry.status = message.isError === true ? "error" : "completed";
 			const text = extractEntryText(message.content);
+			// 异步派发回执：运行转后台，非最终报告。重键为回执中的 asyncId（与
+			// subagent-async widget 的 run.id 同源，渲染层按 id 合并去重），保持
+			// running；提取不到 asyncId 的罕见回执（如 external-job follow-up）
+			// 保持 toolCallId 键，状态不变，由运行时 widget / 活性降级覆盖。
+			if (isAsyncDispatchReceipt(text)) {
+				const asyncId = extractAsyncRunId(text);
+				if (asyncId && asyncId !== entry.id) {
+					byId.delete(entry.id);
+					entry.id = asyncId;
+					byId.set(asyncId, entry);
+				}
+				continue;
+			}
+			// 前台派发的结果即最终报告（与异步回执的「派发确认」语义不同）
+			entry.status = message.isError === true ? "error" : "completed";
 			if (text) entry.result = text;
 			if (Number.isFinite(timestampMs)) entry.completedAt = timestampMs;
 		}

--- a/src/renderer/src/hooks/useSessionSubagents.ts
+++ b/src/renderer/src/hooks/useSessionSubagents.ts
@@ -148,8 +148,9 @@ const SNAPSHOT_STATE_TO_STATUS: Record<string, PiSubagentStatus> = {
 /**
  * 解析 subagent-async widget 行（首行 PI_SUBAGENT_ASYNC_JSON:{...}，rpc 模式由
  * nicobailon pi-subagents 插件推送）为子代理条目。快照无 task 文本（label 为
- * agent 名），description 留空；id 为插件 asyncId，与 record/推导条目 id 空间
- * 不相交。损坏载荷返回 []（fail-soft，不影响其他源）。
+ * agent 名），description 留空，由 applyAsyncSnapshotEntries 从同 id 的推导条目
+ * 补充；id 为插件 asyncId，与主进程派发回执推导的条目 id 同源。损坏载荷返回
+ * []（fail-soft，不影响其他源）。
  */
 export function parseSubagentAsyncSnapshot(
 	lines: readonly string[] | undefined,
@@ -186,6 +187,27 @@ export function parseSubagentAsyncSnapshot(
 	} catch {
 		return [];
 	}
+}
+
+/**
+ * 将 subagent-async widget 快照条目叠加进合并结果：快照是运行态唯一实时真源，
+ * 同 id 时以快照为准（状态更新）；快照条目无 task 文本（description 为空），
+ * 已存在同 id 条目时保留其 description（主进程从派发 args.task 推导）。
+ */
+export function applyAsyncSnapshotEntries(
+	existing: PiSubagentEntry[],
+	asyncEntries: PiSubagentEntry[],
+): PiSubagentEntry[] {
+	if (asyncEntries.length === 0) return existing;
+	const byId = new Map(existing.map((entry) => [entry.id, entry]));
+	for (const entry of asyncEntries) {
+		const prev = byId.get(entry.id);
+		byId.set(
+			entry.id,
+			!entry.description && prev?.description ? { ...entry, description: prev.description } : entry,
+		);
+	}
+	return [...byId.values()];
 }
 
 /* ------------------------------------------------------------------ */
@@ -241,16 +263,10 @@ export function useSessionSubagents(
 		() => mergeSubagentEntries(records, bridgeLines),
 		[records, bridgeLines],
 	);
-	const entries = useMemo(() => {
-		const asyncEntries = parseSubagentAsyncSnapshot(subagentAsyncLines);
-		if (asyncEntries.length === 0) return merged;
-		const byId = new Map(merged.map((entry) => [entry.id, entry]));
-		for (const entry of asyncEntries) {
-			// async 快照是运行态唯一实时真源；已存在同 id 时以快照为准（状态更新）
-			byId.set(entry.id, entry);
-		}
-		return [...byId.values()];
-	}, [merged, subagentAsyncLines]);
+	const entries = useMemo(
+		() => applyAsyncSnapshotEntries(merged, parseSubagentAsyncSnapshot(subagentAsyncLines)),
+		[merged, subagentAsyncLines],
+	);
 
 	return { entries, pluginActive, loading };
 }

--- a/src/shared/types/subagents.ts
+++ b/src/shared/types/subagents.ts
@@ -17,7 +17,7 @@ export type PiSubagentStatus =
 
 /** 子代理条目：从 subagents:record / 桥接事件 / 工具调用推导合成。 */
 export interface PiSubagentEntry {
-  /** 插件内部 agentId（record 或事件携带）；无桥接兜底时用工具调用 entryId 合成。 */
+  /** 插件内部 agentId（record 或事件携带）；异步派发为回执 asyncId（与 subagent-async widget 同源）；无桥接兜底时用工具调用 entryId 合成。 */
   id: string;
   /** 子代理类型（如 "Explore"），对应 AgentRecord.type。 */
   type: string;

--- a/tests/sessionSubagentMerge.test.mjs
+++ b/tests/sessionSubagentMerge.test.mjs
@@ -4,12 +4,13 @@
  * - 桥接 0 默认值不得覆盖 record 真实 toolUses/tokens
  * - record 终态不被桥接倒覆
  * - 桥接独有条目保留
+ * - applyAsyncSnapshotEntries：async widget 快照叠加，同 id 补充 description
  */
 import assert from "node:assert/strict";
 import test from "node:test";
 import { loadTsCommonJs } from "./helpers/loadTsCommonJs.mjs";
 
-const { mergeSubagentEntries } = loadTsCommonJs(
+const { mergeSubagentEntries, applyAsyncSnapshotEntries } = loadTsCommonJs(
   "src/renderer/src/hooks/useSessionSubagents.ts",
   {
     stubs: {
@@ -113,4 +114,84 @@ test("merge: active entries sort before terminal entries", () => {
   );
   assert.equal(merged[0].id, "live");
   assert.equal(merged[1].id, "done");
+});
+
+/* ------------------------------------------------------------------ */
+/* applyAsyncSnapshotEntries：nicobailon subagent-async widget 叠加      */
+/* ------------------------------------------------------------------ */
+
+/** 主进程派发回执推导的条目：id=asyncId，携带 args.task 描述 */
+function derivedAsync(overrides) {
+  return {
+    id: "fde17407-e9ba-4c52-b183-bec15a8a2ea6",
+    type: "worker",
+    description: "测试 shell 防线是否对子代理生效",
+    status: "running",
+    source: "toolcall",
+    via: "pi-subagents-tool",
+    startedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+/** widget 快照条目：无 task 文本（description 为空） */
+function widgetAsync(overrides) {
+  return {
+    id: "fde17407-e9ba-4c52-b183-bec15a8a2ea6",
+    type: "worker",
+    description: "",
+    status: "running",
+    source: "bridge",
+    via: "pi-subagents-tool",
+    startedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+test("applyAsyncSnapshot: 快照条目补充同 id 推导条目的 description", () => {
+  const merged = applyAsyncSnapshotEntries(
+    [derivedAsync()],
+    [widgetAsync()],
+  );
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].description, "测试 shell 防线是否对子代理生效");
+  // 状态以快照为准（运行态实时真源）
+  assert.equal(merged[0].status, "running");
+  assert.equal(merged[0].source, "bridge");
+});
+
+test("applyAsyncSnapshot: 快照状态更新覆盖推导条目，description 仍保留", () => {
+  const merged = applyAsyncSnapshotEntries(
+    [derivedAsync({ status: "running" })],
+    [widgetAsync({ status: "completed", completedAt: 1700000100000 })],
+  );
+  assert.equal(merged[0].status, "completed");
+  assert.equal(merged[0].completedAt, 1700000100000);
+  assert.equal(merged[0].description, "测试 shell 防线是否对子代理生效");
+});
+
+test("applyAsyncSnapshot: 快照自带 description 时不被推导条目覆盖", () => {
+  const merged = applyAsyncSnapshotEntries(
+    [derivedAsync({ description: "推导文本" })],
+    [widgetAsync({ description: "快照文本" })],
+  );
+  assert.equal(merged[0].description, "快照文本");
+});
+
+test("applyAsyncSnapshot: 空快照原样返回；纯快照条目保留；无描述补充时保持空", () => {
+  const existing = [derivedAsync()];
+  assert.equal(applyAsyncSnapshotEntries(existing, []), existing);
+
+  // 快照独有条目（推导侧还没拉到/无对应派发）：原样保留
+  const merged = applyAsyncSnapshotEntries([], [widgetAsync({ id: "run-only" })]);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].id, "run-only");
+  assert.equal(merged[0].description, "");
+
+  // 同 id 但推导条目也无描述：保持空，不造 undefined
+  const noDesc = applyAsyncSnapshotEntries(
+    [derivedAsync({ description: "" })],
+    [widgetAsync()],
+  );
+  assert.equal(noDesc[0].description, "");
 });

--- a/tests/sessionSubagentToolDerive.test.mjs
+++ b/tests/sessionSubagentToolDerive.test.mjs
@@ -2,8 +2,10 @@
  * subagent 工具链（nicobailon pi-subagents）兼容验证：
  * - 前台派发（agent+task、无 action/async）→ running，配对 toolResult → completed/error
  *   且 result 携带报告全文
- * - action 管理查询 / 工作流脚本派发 / 后台派发（async:true）不推导（后台由
- *   subagent-async widget 实时呈现，避免 id 空间不同的双行）
+ * - 异步派发回执（含 "The async run is detached"，覆盖 asyncByDefault/
+ *   forceTopLevelAsync 运行时强制后台、args 不带 async:true 的场景）→ 重键为回执
+ *   中的 asyncId 并保持 running（与 subagent-async widget 同 id 空间，渲染层去重）
+ * - action 管理查询 / 工作流脚本派发不推导
  * - parseSubagentAsyncSnapshot：PI_SUBAGENT_ASYNC_JSON 快照 → 条目（state 映射、
  *   非 acp/非快照载荷 fail-soft）
  */
@@ -105,7 +107,7 @@ test("derive: 未配对结果的派发保持 running（运行中/被杀由活性
   assert.equal(entries[0].status, "running");
 });
 
-test("derive: action 查询 / 工作流派发 / 后台派发均不推导", () => {
+test("derive: action 查询 / 工作流派发不推导；显式后台派发推导为 running", () => {
   const entries = deriveSubagentToolEntries([
     // action 管理查询（list/status 等）
     toolCallEntry({ toolCallId: "call_list", args: { action: "list" }, timestamp: T0 }),
@@ -113,11 +115,105 @@ test("derive: action 查询 / 工作流派发 / 后台派发均不推导", () =>
     toolCallEntry({ toolCallId: "call_act", args: { action: "stop", agent: "worker", runId: "r1" }, timestamp: T0 }),
     // 工作流脚本派发
     toolCallEntry({ toolCallId: "call_wf", args: { agent: "worker", task: "T", workflowScript: "return 1" }, timestamp: T0 }),
-    // 后台派发：运行态由 subagent-async widget 呈现
-    toolCallEntry({ toolCallId: "call_async", args: { agent: "worker", task: "T", async: true }, timestamp: T0 }),
   ]);
   // VM realm 数组原型不同，deepEqual 不可用
   assert.equal(entries.length, 0);
+
+  // 显式 async:true 派发也推导（回执到达后重键 asyncId，见下方回执测试）；
+  // 无回执时保持 toolCallId 键 running，历史侧由活性降级处理
+  const asyncDispatch = deriveSubagentToolEntries([
+    toolCallEntry({ toolCallId: "call_async", args: { agent: "worker", task: "后台任务", async: true }, timestamp: T0 }),
+  ]);
+  assert.equal(asyncDispatch.length, 1);
+  assert.equal(asyncDispatch[0].id, "call_async");
+  assert.equal(asyncDispatch[0].status, "running");
+  assert.equal(asyncDispatch[0].description, "后台任务");
+});
+
+/* ------------------------------------------------------------------ */
+/* 异步派发回执（真实样本格式，见 nicobailon pi-subagents formatAsyncStartedMessage） */
+/* ------------------------------------------------------------------ */
+
+const ASYNC_ID = "fde17407-e9ba-4c52-b183-bec15a8a2ea6";
+
+function asyncReceipt({ agent = "worker", id = ASYNC_ID, fanout = false, interactive = true } = {}) {
+  const head = (fanout ? "Run fan-out: 1/64 used, 63 remaining\n" : "") + `Async: ${agent} [${id}]\n\n`;
+  const guidance = interactive
+    ? "The async run is detached and running in the background.\nYou are in an interactive session. Return control to the user now."
+    : "The async run is detached. Do not run sleep timers or polling loops just to wait for it.";
+  return head + guidance;
+}
+
+test("derive: 强制后台派发（args 无 async）+ 回执 → 重键 asyncId 保持 running，不误标 completed", () => {
+  // forceTopLevelAsync/asyncByDefault 运行时强制后台：模型 args 不带 async:true，
+  // 回执到达前旧逻辑会把它误标 completed 并把回执文本当 result
+  const entries = deriveSubagentToolEntries([
+    toolCallEntry({
+      toolCallId: CALL_ID,
+      args: { agent: "worker", task: "测试 shell 防线是否对子代理生效" },
+      timestamp: T0,
+    }),
+    toolResultEntry({ toolCallId: CALL_ID, text: asyncReceipt({ fanout: true }), timestamp: T1 }),
+  ]);
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  assert.equal(entry.id, ASYNC_ID);
+  assert.equal(entry.type, "worker");
+  assert.equal(entry.description, "测试 shell 防线是否对子代理生效");
+  assert.equal(entry.status, "running");
+  assert.equal(entry.result, undefined);
+  assert.equal(entry.completedAt, undefined);
+});
+
+test("derive: 显式 async:true 派发 + 回执 → 同样重键 asyncId", () => {
+  const entries = deriveSubagentToolEntries([
+    toolCallEntry({ toolCallId: "call_async", args: { agent: "scout", task: "T", async: true }, timestamp: T0 }),
+    toolResultEntry({ toolCallId: "call_async", text: asyncReceipt({ agent: "scout", id: "run-2" }), timestamp: T1 }),
+  ]);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].id, "run-2");
+  assert.equal(entries[0].status, "running");
+  assert.equal(entries[0].description, "T");
+});
+
+test("derive: 非交互回执（The async run is detached.）同样识别", () => {
+  const entries = deriveSubagentToolEntries([
+    toolCallEntry({ toolCallId: CALL_ID, args: { agent: "worker", task: "T" }, timestamp: T0 }),
+    toolResultEntry({ toolCallId: CALL_ID, text: asyncReceipt({ interactive: false }), timestamp: T1 }),
+  ]);
+  assert.equal(entries[0].id, ASYNC_ID);
+  assert.equal(entries[0].status, "running");
+});
+
+test("derive: 无 asyncId 的回执（如 external-job follow-up）保持 toolCallId 键 running", () => {
+  const receipt = "Started external-job follow-up for run-1.\nFollow-up run: run-2\nAsync dir: /tmp/x\n\nThe async run is detached and running in the background.";
+  const entries = deriveSubagentToolEntries([
+    toolCallEntry({ toolCallId: CALL_ID, args: { agent: "worker", task: "T" }, timestamp: T0 }),
+    toolResultEntry({ toolCallId: CALL_ID, text: receipt, timestamp: T1 }),
+  ]);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].id, CALL_ID);
+  assert.equal(entries[0].status, "running");
+});
+
+test("derive: 工作流回执（Async workflow [id]）重键 asyncId；重复回执幂等", () => {
+  const wfReceipt = "Async workflow [wf-9]\n\nThe async run is detached and running in the background.";
+  // 工作流派发（workflowScript）不推导——回执无对应条目时被忽略，不产生孤立行
+  const orphan = deriveSubagentToolEntries([
+    toolResultEntry({ toolCallId: "call_wf_x", text: wfReceipt, timestamp: T1 }),
+  ]);
+  assert.equal(orphan.length, 0);
+
+  // 前台中途转后台（detach）的派发：同回执格式，重键生效
+  const detached = deriveSubagentToolEntries([
+    toolCallEntry({ toolCallId: CALL_ID, args: { agent: "worker", task: "T" }, timestamp: T0 }),
+    toolResultEntry({ toolCallId: CALL_ID, text: wfReceipt, timestamp: T1 }),
+    // 同一回执重放（fork 重放等）：幂等，不产生第二条
+    toolResultEntry({ toolCallId: CALL_ID, text: wfReceipt, timestamp: T1 }),
+  ]);
+  assert.equal(detached.length, 1);
+  assert.equal(detached[0].id, "wf-9");
+  assert.equal(detached[0].status, "running");
 });
 
 test("deriveToolSubagentEntries: acp 与 subagent 两条链并存拼接", () => {


### PR DESCRIPTION
Closes #205

## 问题原因

nicobailon 版 pi-subagents 在 `forceTopLevelAsync: true` / `asyncByDefault` 配置下由**运行时强制转后台**，模型派发参数里不带 `async: true`。此时主进程 `deriveSubagentToolEntries` 仍会推导出该派发条目，而异步派发的 toolResult 只是「转后台回执」（`Async: worker [asyncId]` + "The async run is detached..." 引导文），被当成最终报告**误标 `completed`**——实际子代理还在后台运行。同时 subagent-async widget 以 `asyncId` 为键展示同一次运行（running），与推导条目（`toolCallId` 键、completed）形成**双行 + 状态矛盾**。

另一个缺口：subagent-async widget 快照只携带 agent 名（label），无 task 文本，面板上看不到后台运行条目的任务描述。

## 修复摘要

- **`src/main/pi/derivedSubagents.ts`**：识别异步派发回执（交互/非交互引导文均以 "The async run is detached" 开头），不再误标 completed；把条目**重键为回执中的 asyncId**（与 subagent-async widget 的 `run.id` 同源，三方核验：回执 id、widget 快照 run.id、磁盘 async run 目录一致）并保持 running，渲染层按 id 合并去重。显式 `async: true` 派发同样纳入推导（旧设计因派发用 toolCallId、widget 用 asyncId 导致双行而放弃推导，重键后解决）；提取不到 asyncId 的罕见回执（external-job follow-up）保持 toolCallId 键 running，由运行时 widget / 活性降级覆盖。
- **`src/renderer/src/hooks/useSessionSubagents.ts`**：async widget 快照叠加抽为 `applyAsyncSnapshotEntries` 纯函数，同 id 条目保留推导侧 description（来自派发 `args.task`），快照状态仍为运行态实时真源。
- 历史会话残留 running 由现有 `downgradeStaleRunning` 降级 stopped（完成通知是 `custom_message`/`subagent-notify` 且单任务不带 runId，无法精确关联，只能识别「已不在运行」——已注释说明该上限）。

## 验证

```bash
node --test tests/sessionSubagentToolDerive.test.mjs tests/sessionSubagentMerge.test.mjs
# 23 pass / 0 fail（含真实回执样本格式的回归用例：强制后台派发、显式 async、
#   非交互回执、无 asyncId 回执、工作流回执幂等、description 补充/保留）
npm run typecheck
```

回执格式取自本机真实会话文件（`Run fan-out: ...\nAsync: worker [uuid]\n\nThe async run is detached and running in the background....`），非凭源码臆测。
