### PR TITLE
fix: WSL 模式 Linux 家目录全局技能并入白名单 (issue #203)

### DIFF
--- a/src/main/pi/AgentManager.ts
+++ b/src/main/pi/AgentManager.ts
@@ -540,7 +540,14 @@ export class AgentManager {
 			// 保证「选择器能看到扩展贡献的模型」与「运行时实际加载的扩展」同源。
 			// 技能/模板解析器同源：禁用的技能与提示词模板在 RPC 启动时以白名单剔除。
 			...createPiProcessExtensionResolvers(cwd, settings),
-			...createPiProcessSkillResolvers(cwd, settings),
+			// WSL 场景把 distro 家目录并入技能白名单扫描（issue #203）：WSL 里的 pi 以
+			// distro 内 HOME 运行，Linux 家目录的全局技能必须与 Windows 侧取并集注入；
+			// UNC 路径由 PiProcess 在 spawn 前转换为 distro 内 Linux 路径。
+			...createPiProcessSkillResolvers(
+				cwd,
+				settings,
+				this.wslEnvironment ? [this.wslEnvironment.windowsHome] : undefined,
+			),
 			...createPiProcessPromptResolvers(cwd, settings),
 			// 会话身份 = PiDeck 会话 key（SessionRecord.id，UUID 或旧版文件路径），扩展按它解析等级覆盖；
 			// 匿名会话（noSession）无 key，扩展仅用全局默认等级。

--- a/src/main/skills/piProcessSkillResolvers.ts
+++ b/src/main/skills/piProcessSkillResolvers.ts
@@ -5,6 +5,10 @@ import { resolveEnabledSkillPaths } from "./skillWhitelistResolver";
  * 为 PiProcess 构造技能白名单解析器。
  * 返回值可直接展开为 PiProcess 第 4 参 options 的 resolveEnabledSkillPaths。
  *
+ * additionalAgentHomeDirs：WSL 场景传入 distro 家目录（UNC 路径），Linux 家目录的
+ * 全局技能并入白名单（issue #203）；--skill 注入的 UNC 路径由 PiProcess 的 WSL
+ * 参数转换还原为 distro 内 Linux 路径。
+ *
  * 与 createPiProcessExtensionResolvers 同构：AgentManager（会话运行时 RPC）与
  * PiModelCapabilityCache（模型能力快照）必须走同一套「哪些技能加载」的判定。
  * 注意 PiModelCapabilityCache 固定 piRpcNoSkills: true（模型查询不需要技能），
@@ -13,6 +17,7 @@ import { resolveEnabledSkillPaths } from "./skillWhitelistResolver";
 export function createPiProcessSkillResolvers(
 	cwd: string,
 	settings: AppSettings,
+	additionalAgentHomeDirs?: string[],
 ): {
 	resolveEnabledSkillPaths: (
 		processSettings?: Partial<AppSettings>,
@@ -25,6 +30,7 @@ export function createPiProcessSkillResolvers(
 			resolveEnabledSkillPaths({
 				cwd,
 				includeProjectResources,
+				additionalAgentHomeDirs,
 				disabledNames:
 					processSettings?.disabledSkills ?? settings.disabledSkills ?? [],
 			}),

--- a/src/main/skills/skillWhitelistResolver.ts
+++ b/src/main/skills/skillWhitelistResolver.ts
@@ -56,7 +56,14 @@ export function resolveEnabledSkillPaths(
 	const projectBaseDir = join(cwd, ".pi");
 	const includeProjectResources = options.includeProjectResources !== false;
 
-	const userSettings = readSettingsObject(join(agentDir, "settings.json"));
+	// 附加 agent home（WSL 场景）：WSL 里的 pi 以 distro 内 HOME 运行，其 ~/.pi/agent/skills、
+	// ~/.agents/skills 及 settings.json 的全局技能必须与 Windows 侧 home 取并集，否则 --no-skills
+	// 会把 Linux 家目录技能全部关在白名单外（issue #203）。UNC（\\wsl.localhost\...）可在宿主侧
+	// 直接扫描，路径随后由 PiProcess 的 WSL 参数转换还原为 distro 内 Linux 路径。
+	const additionalHomes = (options.additionalAgentHomeDirs ?? [])
+		.map((dir) => dir.trim())
+		.filter((dir) => dir && resolve(dir) !== resolve(home));
+
 	const projectSettings = includeProjectResources
 		? readSettingsObject(join(projectBaseDir, "settings.json"))
 		: {};
@@ -101,40 +108,50 @@ export function resolveEnabledSkillPaths(
 		paths.push(path);
 	};
 
-	// settings.skills 数组的 plain 条目 = 显式路径；patterns 条目 = 该作用域自动发现过滤
-	const { plain: userPlain, patterns: userOverrides } = splitResourceEntries(
-		Array.isArray(userSettings.skills) ? userSettings.skills : [],
-	);
+	// 全局 home 的发现源（~/.pi/agent/skills、~/.agents/skills、settings.json 显式路径）。
+	// 主 home 与附加 home（WSL）共用同一套全局禁用判定；每个 home 的 settings.json 只约束
+	// 自己作用域内的发现（patterns 不跨 home 生效，与 pi 在对应环境内运行时一致）。
+	// 包资源（npm/git 安装）仍只解析主 home：UNC 逐包扫描成本高且 WSL 侧包安装罕见，
+	// 待有真实需求再扩展。
+	const globalAgentsSkillDirs = new Set<string>();
+	const collectGlobalHomeSkills = (homeDir: string): void => {
+		const homeAgentDir = join(homeDir, ".pi", "agent");
+		const homeSettings = readSettingsObject(join(homeAgentDir, "settings.json"));
+		const { plain, patterns } = splitResourceEntries(
+			Array.isArray(homeSettings.skills) ? homeSettings.skills : [],
+		);
+		collectSkillDir(join(homeAgentDir, "skills"), "pi", isGlobalPiEnabled, addPath, homeAgentDir, patterns);
+		const globalAgentsSkillsDir = join(homeDir, ".agents", "skills");
+		// 登记 resolved 路径供祖先目录去重：同一物理 ~/.agents/skills 是全局源，即使 cwd
+		//（如 WSL 内项目）沿祖先链再次碰到它，也不能按项目作用域重复枚举。
+		globalAgentsSkillDirs.add(resolve(globalAgentsSkillsDir));
+		collectSkillDir(
+			globalAgentsSkillsDir,
+			"agents",
+			isGlobalAgentsEnabled,
+			addPath,
+			dirname(globalAgentsSkillsDir),
+			patterns,
+		);
+		collectSettingsSkills(homeAgentDir, plain, patterns, isGlobalPiEnabled, addPath);
+	};
+	collectGlobalHomeSkills(home);
+	for (const extraHome of additionalHomes) {
+		collectGlobalHomeSkills(extraHome);
+	}
+
+	// 2) 项目资源只在 trust 放行后枚举；拒绝 trust 时白名单仅注入全局资源。
 	const { plain: projectPlain, patterns: projectOverrides } = splitResourceEntries(
 		Array.isArray(projectSettings.skills) ? projectSettings.skills : [],
 	);
-
-	// 1) 全局技能目录：~/.pi/agent/skills（pi 模式）+ ~/.agents/skills（agents 模式）
-	collectSkillDir(join(agentDir, "skills"), "pi", isGlobalPiEnabled, addPath, agentDir, userOverrides);
-	const globalAgentsSkillsDir = join(home, ".agents", "skills");
-	collectSkillDir(
-		globalAgentsSkillsDir,
-		"agents",
-		isGlobalAgentsEnabled,
-		addPath,
-		dirname(globalAgentsSkillsDir),
-		userOverrides,
-	);
-
-	// 2) 项目资源只在 trust 放行后枚举；拒绝 trust 时白名单仅注入全局资源。
 	if (includeProjectResources) {
 		collectSkillDir(join(projectBaseDir, "skills"), "pi", isProjectEnabled, addPath, projectBaseDir, projectOverrides);
-		const resolvedGlobalAgentsSkillsDir = resolve(globalAgentsSkillsDir);
 		for (const dir of collectAncestorAgentsSkillDirs(cwd)) {
-			// The same physical ~/.agents/skills root is global even when HOME is inside the repo.
-			if (resolve(dir) === resolvedGlobalAgentsSkillsDir) continue;
+			// 同一物理 ~/.agents/skills（任一 home 的全局源）即使出现在 cwd 祖先链上也保持全局语义。
+			if (globalAgentsSkillDirs.has(resolve(dir))) continue;
 			collectSkillDir(dir, "agents", isProjectEnabled, addPath, dirname(dir), projectOverrides);
 		}
-	}
-
-	// 3) settings.json skills 数组的显式路径（user + project；plain 条目经 patterns 过滤）
-	collectSettingsSkills(agentDir, userPlain, userOverrides, isGlobalPiEnabled, addPath);
-	if (includeProjectResources) {
+		// 项目 settings.json skills 数组的显式路径（plain 条目经 patterns 过滤）
 		collectSettingsSkills(projectBaseDir, projectPlain, projectOverrides, isProjectEnabled, addPath);
 	}
 
@@ -173,6 +190,12 @@ export function resolveEnabledSkillPaths(
 export type SkillWhitelistResolverOptions = {
 	/** WSL 场景传入 Windows 侧 home；缺省 homedir()（与 PiProcessOptions.agentHomeDir 语义一致）。 */
 	agentHomeDir?: string;
+	/**
+	 * 附加 agent home 根目录（WSL 场景为 distro 家目录的 UNC 路径 \\wsl.localhost\<distro>\...）。
+	 * 每个 home 的 ~/.pi/agent/skills、~/.agents/skills 与 settings.json skills 显式路径
+	 * 都并入全局白名单（与 Windows 侧 home 取并集，issue #203）；与主 home 相同的目录忽略。
+	 */
+	additionalAgentHomeDirs?: string[];
 	/** 会话项目根（pi 的 cwd），决定项目级 .pi/skills 与祖先 .agents/skills。 */
 	cwd: string;
 	/** False when the trust decision rejects project resources. */

--- a/tests/piProcessSecurityEnv.test.mjs
+++ b/tests/piProcessSecurityEnv.test.mjs
@@ -258,6 +258,34 @@ test("存在禁用技能时注入 --no-skills + 逐条 --skill 白名单", async
 	assert.equal(captured.args[idx + 4], "/mnt/c/Users/tester/skills/b/SKILL.md");
 });
 
+test("WSL 家目录的 --skill 白名单路径（UNC）转换为 distro 内 Linux 路径", async () => {
+	const { PiProcess, mockLocator, getCaptured } = loadPiProcess();
+	const proc = new PiProcess(
+		"C:\\proj",
+		{ wslEnabled: true, wslDistro: "Ubuntu-24.04", wslUser: "root" },
+		mockLocator,
+		{
+			// 模拟 WSL 场景：解析器经 \\wsl.localhost 扫到 Linux 家目录技能（issue #203）
+			resolveEnabledSkillPaths: () => [
+				"\\\\wsl.localhost\\Ubuntu-24.04\\root\\.agents\\skills\\wsl-skill\\SKILL.md",
+				"\\\\wsl.localhost\\Ubuntu-24.04\\root\\.pi\\agent\\skills\\wsl-pi-skill\\SKILL.md",
+			],
+			securitySnapshotPath: "C:\\Users\\tester\\AppData\\Roaming\\PiDeck-dev\\security-policy.json",
+		},
+	);
+	await proc.start(undefined, undefined, true);
+	const captured = getCaptured();
+	assert.ok(captured?.args, "spawn 应被调用");
+	const idx = captured.args.indexOf("--no-skills");
+	assert.ok(idx >= 0, "技能白名单模式应注入 --no-skills");
+	assert.equal(captured.args[idx + 1], "--skill");
+	// UNC（\\wsl.localhost\<distro>\...）必须转成 distro 内原生 Linux 路径，
+	// 否则 WSL 里的 pi 打不开 Windows UNC 形式的技能文件
+	assert.equal(captured.args[idx + 2], "/root/.agents/skills/wsl-skill/SKILL.md");
+	assert.equal(captured.args[idx + 3], "--skill");
+	assert.equal(captured.args[idx + 4], "/root/.pi/agent/skills/wsl-pi-skill/SKILL.md");
+});
+
 test("无禁用技能（resolver 返回 null）时不注入 --no-skills/--skill", async () => {
 	const { PiProcess, mockLocator, getCaptured } = loadPiProcess();
 	const proc = new PiProcess(

--- a/tests/skillWhitelistResolver.test.mjs
+++ b/tests/skillWhitelistResolver.test.mjs
@@ -512,3 +512,158 @@ test("project package replaces a same-identity user package", () => {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
+
+/* ------------------------------------------------------------------ */
+/* 附加 agent home（WSL 场景）：Linux 家目录技能并入白名单（issue #203） */
+/* ------------------------------------------------------------------ */
+
+/** 构造模拟 WSL 家目录：独立的 home 根，含 ~/.pi/agent 与 ~/.agents 骨架。 */
+function setupWslHome(root, name) {
+	const home = join(root, name);
+	const agentDir = join(home, ".pi", "agent");
+	mkdirSync(join(agentDir, "skills"), { recursive: true });
+	mkdirSync(join(home, ".agents", "skills"), { recursive: true });
+	return { home, agentDir };
+}
+
+test("additionalAgentHomeDirs：WSL 家目录的 ~/.pi/agent/skills 与 ~/.agents/skills 并入白名单", () => {
+	const { resolveEnabledSkillPaths } = loadResolverModule();
+	const { root, home, agentDir, cwd } = setupFixtures();
+	const wsl = setupWslHome(root, "wsl-home");
+	try {
+		// Windows 家目录（主 home）技能：保持原有行为
+		skillMd(join(agentDir, "skills", "win-skill"), "win-skill");
+		// WSL 家目录技能：pi 模式顶层 md 算、agents 模式嵌套算
+		skillMd(join(wsl.agentDir, "skills", "wsl-pi-skill"), "wsl-pi-skill");
+		writeFileSync(
+			join(wsl.agentDir, "skills", "wsl-root.md"),
+			"---\nname: wsl-root\ndescription: pi mode root\n---\n",
+			"utf8",
+		);
+		skillMd(join(wsl.home, ".agents", "skills", "wsl-agents-skill"), "wsl-agents-skill");
+		writeFileSync(
+			join(wsl.home, ".agents", "skills", "wsl-agents-root.md"),
+			"---\nname: wsl-agents-root\ndescription: agents mode root ignored\n---\n",
+			"utf8",
+		);
+
+		const result = resolveEnabledSkillPaths({
+			agentHomeDir: home,
+			cwd,
+			disabledNames: ["missing"],
+			additionalAgentHomeDirs: [wsl.home],
+		});
+		assert.ok(result, "存在禁用项时必须启用白名单");
+		same(result, [
+			join(agentDir, "skills", "win-skill", "SKILL.md"),
+			// WSL 侧：pi 模式目录技能 + 顶层 md；agents 模式只认嵌套目录
+			join(wsl.agentDir, "skills", "wsl-pi-skill", "SKILL.md"),
+			join(wsl.agentDir, "skills", "wsl-root.md"),
+			join(wsl.home, ".agents", "skills", "wsl-agents-skill", "SKILL.md"),
+		]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("additionalAgentHomeDirs：PiDeck 禁用名与 frontmatter 禁用对 WSL 家目录技能同样生效", () => {
+	const { resolveEnabledSkillPaths } = loadResolverModule();
+	const { root, home, cwd } = setupFixtures();
+	const wsl = setupWslHome(root, "wsl-home");
+	try {
+		skillMd(join(wsl.home, ".agents", "skills", "wsl-disabled"), "wsl-disabled");
+		skillMd(
+			join(wsl.home, ".agents", "skills", "wsl-frontmatter-off"),
+			"wsl-frontmatter-off",
+			"disable-model-invocation: true\n",
+		);
+		skillMd(join(wsl.home, ".agents", "skills", "wsl-kept"), "wsl-kept");
+
+		const result = resolveEnabledSkillPaths({
+			agentHomeDir: home,
+			cwd,
+			disabledNames: ["wsl-disabled"],
+			additionalAgentHomeDirs: [wsl.home],
+		});
+		assert.ok(result);
+		same(result, [join(wsl.home, ".agents", "skills", "wsl-kept", "SKILL.md")]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("additionalAgentHomeDirs：WSL 家目录 settings.json 的 skills 显式路径参与枚举", () => {
+	const { resolveEnabledSkillPaths } = loadResolverModule();
+	const { root, home, cwd } = setupFixtures();
+	const wsl = setupWslHome(root, "wsl-home");
+	try {
+		const explicitDir = join(wsl.home, "custom-skills");
+		skillMd(explicitDir, "wsl-explicit");
+		writeFileSync(
+			join(wsl.agentDir, "settings.json"),
+			JSON.stringify({ skills: [explicitDir] }),
+			"utf8",
+		);
+
+		const result = resolveEnabledSkillPaths({
+			agentHomeDir: home,
+			cwd,
+			disabledNames: ["missing"],
+			additionalAgentHomeDirs: [wsl.home],
+		});
+		assert.ok(result);
+		same(result, [join(explicitDir, "SKILL.md")]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("additionalAgentHomeDirs：拒绝项目 trust 时 WSL 家目录全局技能仍注入", () => {
+	const { resolveEnabledSkillPaths } = loadResolverModule();
+	const { root, home, agentDir, cwd } = setupFixtures();
+	const wsl = setupWslHome(root, "wsl-home");
+	try {
+		skillMd(join(agentDir, "skills", "win-global"), "win-global");
+		skillMd(join(wsl.agentDir, "skills", "wsl-global"), "wsl-global");
+		skillMd(join(cwd, ".pi", "skills", "project-skill"), "project-skill");
+
+		const result = resolveEnabledSkillPaths({
+			agentHomeDir: home,
+			cwd,
+			disabledNames: [],
+			additionalAgentHomeDirs: [wsl.home],
+			includeProjectResources: false,
+		});
+		assert.ok(result);
+		same(result, [
+			join(agentDir, "skills", "win-global", "SKILL.md"),
+			join(wsl.agentDir, "skills", "wsl-global", "SKILL.md"),
+		]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("additionalAgentHomeDirs：与主 home 相同的目录不重复枚举；不存在的目录跳过", () => {
+	const { resolveEnabledSkillPaths } = loadResolverModule();
+	const { root, home, agentDir, cwd } = setupFixtures();
+	try {
+		skillMd(join(agentDir, "skills", "win-skill"), "win-skill");
+
+		const withDup = resolveEnabledSkillPaths({
+			agentHomeDir: home,
+			cwd,
+			disabledNames: ["missing"],
+			additionalAgentHomeDirs: [home, join(root, "wsl-not-exist")],
+		});
+		const baseline = resolveEnabledSkillPaths({
+			agentHomeDir: home,
+			cwd,
+			disabledNames: ["missing"],
+		});
+		assert.ok(withDup && baseline);
+		same(withDup, baseline);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
Closes #203

## 问题原因

WSL 模式下 pi 进程在 distro 内以 Linux HOME（如 /root）运行，但技能白名单解析器 `resolveEnabledSkillPaths` 只在 Windows 宿主侧跑，扫描根恒为 Windows 家目录。`--no-skills` 又关掉了 distro 内 pi 的整条自动发现链，于是：

- Linux 家目录的 `~/.pi/agent/skills`、`~/.agents/skills` 全局技能被关在白名单外，命令候选中缺席；
- `--skill` 白名单 30 条全部指向 /mnt/c/...（Windows 家目录）；
- 按 pi 文档把 skill 装到 `~/.agents/skills`（Linux 侧）直接踩坑。

## 修复（issue 方案 1：WSL 家目录纳入 --skill 白名单）

- **`src/main/skills/skillWhitelistResolver.ts`**：新增 `additionalAgentHomeDirs` 选项。每个附加 home（WSL distro 家目录，经 `\\wsl.localhost\<distro>\...` UNC 可在宿主侧直接扫描）的 `~/.pi/agent/skills`（pi 模式）、`~/.agents/skills`（agents 模式）与 settings.json skills 显式路径并入全局白名单，与 Windows 侧 home 取**并集**。每个 home 的 settings.json 只约束自己作用域的发现（patterns 不跨 home，与 pi 在对应环境内运行时一致）。
- **祖先 `.agents/skills` 去重扩展到全部 home**：cwd（如 WSL 内项目）祖先链碰到任一 home 的全局 agents 目录时保持全局语义，不按项目作用域重复枚举。
- **`piProcessSkillResolvers.ts` / `AgentManager.ts`**：`createPiProcess` 注入 `wslEnvironment.windowsHome`（启动时 `resolveWslEnvironment` 已解析的 distro HOME，printenv 探测 + fallback）。
- **路径转换零改动**：PiProcess 既有的 WSL 参数转换本就把 `--skill` 后的 UNC 参数还原为 distro 内 Linux 路径（`\\wsl.localhost\<distro>\root\...` → `/root/...`），补了显式回归用例。

**范围取舍**：包资源（npm/git 安装）仍只解析主 home——UNC 逐包扫描成本高且 WSL 侧包安装罕见，待有真实需求再扩展。PiModelCapabilityCache 进程固定 `piRpcNoSkills`（模型查询不需要技能），无需同源注入。扩展/提示词模板白名单存在同构缺口（Linux 家目录扩展同样不在 `-e` 白名单内），本 PR 不动，可后续以同一模式跟进。

## 验证

```bash
node --test tests/skillWhitelistResolver.test.mjs   # 26/26，新增 5 例
node --test tests/piProcessSecurityEnv.test.mjs     # 含新增 UNC --skill 转换用例
npm run typecheck
```

新增用例：WSL home 并集（pi/agents 双模式根规则不变）、禁用名与 frontmatter 禁用覆盖 WSL home、WSL settings.json 显式路径、denied trust 时 WSL 全局技能仍注入、附加 home 与主 home 相同/不存在时忽略。